### PR TITLE
fix shared memory allocation

### DIFF
--- a/include/alpaka/block/shared/BlockSharedAllocCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/BlockSharedAllocCudaBuiltIn.hpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2014-2015 Benjamin Worpitz
+ * Copyright 2014-2015 Benjamin Worpitz, Rene Widera
  *
  * This file is part of alpaka.
  *
@@ -73,9 +73,11 @@ namespace alpaka
                 //!
                 //#############################################################################
                 template<
-                    typename T>
+                    typename T,
+                    std::size_t TuniqueId>
                 struct AllocVar<
                     T,
+                    TuniqueId,
                     BlockSharedAllocCudaBuiltIn>
                 {
                     // NOTE: CUDA requires the constructor and destructor of shared objects to be empty.
@@ -103,10 +105,12 @@ namespace alpaka
                 //#############################################################################
                 template<
                     typename T,
-                    std::size_t TnumElements>
+                    std::size_t TnumElements,
+                    std::size_t TuniqueId>
                 struct AllocArr<
                     T,
                     TnumElements,
+                    TuniqueId,
                     BlockSharedAllocCudaBuiltIn>
                 {
                     // NOTE: CUDA requires the constructor and destructor of shared objects to be empty.

--- a/include/alpaka/block/shared/BlockSharedAllocMasterSync.hpp
+++ b/include/alpaka/block/shared/BlockSharedAllocMasterSync.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2015 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -94,9 +94,11 @@ namespace alpaka
                 //!
                 //#############################################################################
                 template<
-                    typename T>
+                    typename T,
+                    std::size_t TuniqueId>
                 struct AllocVar<
                     T,
+                    TuniqueId,
                     BlockSharedAllocMasterSync>
                 {
                     //-----------------------------------------------------------------------------
@@ -129,10 +131,12 @@ namespace alpaka
                 //#############################################################################
                 template<
                     typename T,
-                    std::size_t TnumElements>
+                    std::size_t TnumElements,
+                    std::size_t TuniqueId>
                 struct AllocArr<
                     T,
                     TnumElements,
+                    TuniqueId,
                     BlockSharedAllocMasterSync>
                 {
                     static_assert(

--- a/include/alpaka/block/shared/BlockSharedAllocNoSync.hpp
+++ b/include/alpaka/block/shared/BlockSharedAllocNoSync.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2015 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -85,9 +85,11 @@ namespace alpaka
                 //!
                 //#############################################################################
                 template<
-                    typename T>
+                    typename T,
+                    std::size_t TuniqueId>
                 struct AllocVar<
                     T,
+                    TuniqueId,
                     BlockSharedAllocNoSync>
                 {
                     //-----------------------------------------------------------------------------
@@ -111,10 +113,12 @@ namespace alpaka
                 //#############################################################################
                 template<
                     typename T,
-                    std::size_t TnumElements>
+                    std::size_t TnumElements,
+                    std::size_t TuniqueId>
                 struct AllocArr<
                     T,
                     TnumElements,
+                    TuniqueId,
                     BlockSharedAllocNoSync>
                 {
                     static_assert(

--- a/include/alpaka/block/shared/Traits.hpp
+++ b/include/alpaka/block/shared/Traits.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2015 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -47,6 +47,7 @@ namespace alpaka
                 //#############################################################################
                 template<
                     typename T,
+                    std::size_t TuniqueId,
                     typename TBlockSharedAlloc,
                     typename TSfinae = void>
                 struct AllocVar;
@@ -56,6 +57,7 @@ namespace alpaka
                 template<
                     typename T,
                     std::size_t TnumElements,
+                    std::size_t TuniqueId,
                     typename TBlockSharedAlloc,
                     typename TSfinae = void>
                 struct AllocArr;
@@ -72,12 +74,14 @@ namespace alpaka
             //! Allocates a variable in block shared memory.
             //!
             //! \tparam T The element type.
+            //! \tparam TuniqueId id those is unique inside a kernel
             //! \tparam TBlockSharedAlloc The block shared allocator implementation type.
             //! \param blockSharedAlloc The block shared allocator implementation.
             //-----------------------------------------------------------------------------
             ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename T,
+                std::size_t TuniqueId,
                 typename TBlockSharedAlloc>
             ALPAKA_FN_HOST_ACC auto allocVar(
                 TBlockSharedAlloc const & blockSharedAlloc)
@@ -86,6 +90,7 @@ namespace alpaka
                 return
                     traits::AllocVar<
                         T,
+                        TuniqueId,
                         TBlockSharedAlloc>
                     ::allocVar(
                         blockSharedAlloc);
@@ -96,6 +101,7 @@ namespace alpaka
             //!
             //! \tparam T The element type.
             //! \tparam TnumElements The Number of elements.
+            //! \tparam TuniqueId id those is unique inside a kernel
             //! \tparam TBlockSharedAlloc The block shared allocator implementation type.
             //! \param blockSharedAlloc The block shared allocator implementation.
             //-----------------------------------------------------------------------------
@@ -103,6 +109,7 @@ namespace alpaka
             template<
                 typename T,
                 std::size_t TnumElements,
+                std::size_t TuniqueId,
                 typename TBlockSharedAlloc>
             ALPAKA_FN_HOST_ACC auto allocArr(
                 TBlockSharedAlloc const & blockSharedAlloc)
@@ -116,6 +123,7 @@ namespace alpaka
                     traits::AllocArr<
                         T,
                         TnumElements,
+                        TuniqueId,
                         TBlockSharedAlloc>
                     ::allocArr(
                         blockSharedAlloc);
@@ -146,10 +154,12 @@ namespace alpaka
                 //! The AllocVar trait specialization for classes with BlockSharedAllocBase member type.
                 //#############################################################################
                 template<
-                    typename TBlockSharedAlloc,
-                    typename T>
+                    typename T,
+                    std::size_t TuniqueId,
+                    typename TBlockSharedAlloc>
                 struct AllocVar<
                     T,
+                    TuniqueId,
                     TBlockSharedAlloc,
                     typename std::enable_if<
                         std::is_base_of<typename TBlockSharedAlloc::BlockSharedAllocBase, typename std::decay<TBlockSharedAlloc>::type>::value
@@ -166,7 +176,8 @@ namespace alpaka
                         // Delegate the call to the base class.
                         return
                             block::shared::allocVar<
-                                T>(
+                                T,
+                                TuniqueId>(
                                     static_cast<typename TBlockSharedAlloc::BlockSharedAllocBase const &>(blockSharedAlloc));
                     }
                 };
@@ -174,12 +185,14 @@ namespace alpaka
                 //! The AllocArr trait specialization for classes with BlockSharedAllocBase member type.
                 //#############################################################################
                 template<
-                    typename TBlockSharedAlloc,
                     typename T,
-                    std::size_t TnumElements>
+                    std::size_t TnumElements,
+                    std::size_t TuniqueId,
+                    typename TBlockSharedAlloc>
                 struct AllocArr<
                     T,
                     TnumElements,
+                    TuniqueId,
                     TBlockSharedAlloc,
                     typename std::enable_if<
                         std::is_base_of<typename TBlockSharedAlloc::BlockSharedAllocBase, typename std::decay<TBlockSharedAlloc>::type>::value
@@ -197,7 +210,8 @@ namespace alpaka
                         return
                             block::shared::allocArr<
                                 T,
-                                TnumElements>(
+                                TnumElements,
+                                TuniqueId>(
                                     static_cast<typename TBlockSharedAlloc::BlockSharedAllocBase const &>(blockSharedAlloc));
                     }
                 };

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -68,8 +68,8 @@ public:
         std::uint32_t * const pBlockShared(acc.template getBlockSharedExternMem<std::uint32_t>());
 
         // Get some shared memory (allocate a second buffer directly afterwards to check for some synchronization bugs).
-        //std::uint32_t * const pBlockShared1(alpaka::block::shared::allocArr<std::uint32_t, TnumUselessWork::value>());
-        //std::uint32_t * const pBlockShared2(alpaka::block::shared::allocArr<std::uint32_t, TnumUselessWork::value>());
+        //std::uint32_t * const pBlockShared1(alpaka::block::shared::allocArr<std::uint32_t, TnumUselessWork::value,__COUNTER__>());
+        //std::uint32_t * const pBlockShared2(alpaka::block::shared::allocArr<std::uint32_t, TnumUselessWork::value,__COUNTER__>());
 
         // Calculate linearized index of the thread in the block.
         std::size_t const blockThreadIdx1d(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc)[0u]);


### PR DESCRIPTION
- change the interface of `allocVar` and `allocArr` (add unique id)
- add unique id to `allocArr` *example/sharedMem* code

If shared memory is allocated on `alpaka::acc::AccGpuCudaRt<...>` more than for one array or variable with the same type than all returned memory references points to the same memory address.
e.g.
```C++
...
auto& a = alpaka::block::shared::allocVar<std::uint32_t>(acc);
auto& b = alpaka::block::shared::allocVar<std::uint32_t>(acc);
assert( &a != &b ); // error both memory addresses are equal 
```

Shared memory allocations on CUDA inside a class are similar to static class variables. All classes with the same template signature has the same static variable.
```C++
template<typename T>
struct Foo {
static T mem;
};
```
`mem` is equal for all instances of Foo<T>  with the the same `T`.
The way to avoid this bug is to create a unique template signature for each in kernel shared memory allocation. Thus the problem that it is not possible in C++ to generate unique id's at compile time  the user must take care about this.

With this pull request the example looks like this:
```C++
...
auto& a = alpaka::block::shared::allocVar<std::uint32_t,0>(acc); //instead of manual counter __CONTER__ can used
auto& b = alpaka::block::shared::allocVar<std::uint32_t,1>(acc);
assert( &a != &b ); // OK!!
```