### PR TITLE
add CUDA 7.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ language:
 os:
     - linux
 
+sudo: required
+dist: trusty
+
 ################################################################################
 #
 ################################################################################
@@ -58,7 +61,7 @@ compiler:
 # ALPAKA_ACC_CPU_BT_OMP4_ENABLE                 : {ON, OFF}
 #   [ON] OMP_NUM_THREADS                        : {1, 2, 3, 4}
 # ALPAKA_ACC_GPU_CUDA_ENABLE                    : {ON, OFF}
-#   [ON] ALPAKA_CUDA_VERSION                    : {7.0}
+#   [ON] ALPAKA_CUDA_VERSION                    : {7.0, 7.5}
 # And one analysis build
 # ALPAKA_ANALYSIS                               : {ON, OFF}
 ################################################################################
@@ -73,14 +76,14 @@ env:
         - ALPAKA_CLANG_LIBSTDCPP_VERSION=4.9
 
     matrix:
-        - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=2 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=4 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.6 ALPAKA_BOOST_BRANCH=boost-1.56.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
+        - ALPAKA_CUDA_VERSION=7.5 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=2 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=4 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.6 ALPAKA_BOOST_BRANCH=boost-1.56.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=0 ALPAKA_CMAKE_VER=3.3.1 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=3 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.5 ALPAKA_BOOST_BRANCH=boost-1.57.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=2 ALPAKA_CMAKE_VER=3.3.0 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=2 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.6 ALPAKA_BOOST_BRANCH=boost-1.58.0 ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=ON  ALPAKA_DEBUG=1 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=4 ALPAKA_GCC_VER=5   ALPAKA_CLANG_VER=3.5 ALPAKA_BOOST_BRANCH=boost-1.59.0 ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=ON  ALPAKA_DEBUG=1 ALPAKA_CMAKE_VER=3.3.1 CMAKE_BUILD_TYPE=Debug   OMP_NUM_THREADS=4 ALPAKA_GCC_VER=5   ALPAKA_CLANG_VER=3.7 ALPAKA_BOOST_BRANCH=develop      ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
 
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=2 ALPAKA_CMAKE_VER=3.3.0 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=4 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.6 ALPAKA_BOOST_BRANCH=boost-1.58.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
-        - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=0 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=3 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.5 ALPAKA_BOOST_BRANCH=boost-1.59.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
+        - ALPAKA_CUDA_VERSION=7.5 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=0 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=3 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.5 ALPAKA_BOOST_BRANCH=boost-1.59.0 ALPAKA_ACC_GPU_CUDA_ENABLE=ON
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=2 ALPAKA_CMAKE_VER=3.3.1 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=2 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.6 ALPAKA_BOOST_BRANCH=boost-1.56.0 ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=0 ALPAKA_CMAKE_VER=3.3.0 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=1 ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.5 ALPAKA_BOOST_BRANCH=boost-1.57.0 ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
         - ALPAKA_CUDA_VERSION=7.0 ALPAKA_ANALYSIS=OFF ALPAKA_DEBUG=1 ALPAKA_CMAKE_VER=3.3.2 CMAKE_BUILD_TYPE=Release OMP_NUM_THREADS=4 ALPAKA_GCC_VER=5   ALPAKA_CLANG_VER=3.7 ALPAKA_BOOST_BRANCH=develop      ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
@@ -124,9 +127,9 @@ before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 
     # clang
-    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main' ;fi
-    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.6 main' ;fi
-    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise main' ;fi
+    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.5 main' ;fi
+    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main' ;fi
+    - if [ "${CXX}" == "clang++" ] ;then sudo add-apt-repository -y 'deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty main' ;fi
     - if [ "${CXX}" == "clang++" ] ;then wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add - ;fi
 
     # git
@@ -153,14 +156,14 @@ install:
     #-------------------------------------------------------------------------------
     # Get the current gcc version.
     - git --version
-    - sudo apt-get install git
+    - sudo apt-get -y install git
     - git --version
 
     #-------------------------------------------------------------------------------
     # gcc 4.6 is too old...
     - if [ "${CXX}" == "g++" ]
       ;then
-          sudo apt-get install g++-${ALPAKA_GCC_VER}
+          sudo apt-get -y install g++-${ALPAKA_GCC_VER}
           && sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${ALPAKA_GCC_VER} 50
           && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${ALPAKA_GCC_VER} 50
       ;fi
@@ -187,8 +190,8 @@ install:
     # We have to prepend /usr/bin to the path because else the preinstalled clang from usr/bin/local/ is used.
     - if [ "${CXX}" == "clang++" ]
       ;then
-          sudo apt-get install libstdc++-${ALPAKA_CLANG_LIBSTDCPP_VERSION}-dev
-          && sudo apt-get install clang-${ALPAKA_CLANG_VER}
+          sudo apt-get -y install libstdc++-${ALPAKA_CLANG_LIBSTDCPP_VERSION}-dev
+          && sudo apt-get -y install clang-${ALPAKA_CLANG_VER}
           && sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${ALPAKA_CLANG_VER} 50
           && sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${ALPAKA_CLANG_VER} 50
           && sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 50
@@ -238,14 +241,14 @@ install:
           && echo ${ALPAKA_CUDA_VER_MAJOR}
           && echo ${ALPAKA_CUDA_VER_MINOR}
       ;fi
-    # CUDA 7.0 does not support gcc > 4.9.2
+    # CUDA 7.x does not support gcc > 4.9.2
     - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
       ;then
           if [ "${CXX}" == "g++" ]
           ;then
               if (( (( ${ALPAKA_GCC_VER_MAJOR} > 4 )) || ( (( ${ALPAKA_GCC_VER_MAJOR} == 4 )) && (( ${ALPAKA_GCC_VER_MINOR} > 9 )) ) ))
               ;then
-                  if (( (( ${ALPAKA_CUDA_VER_MAJOR} == 7 )) && (( ${ALPAKA_CUDA_VER_MINOR} == 0 )) ))
+                  if (( ${ALPAKA_CUDA_VER_MAJOR} > 6 ))
                   ;then
                       export ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
                       && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because CUDA 7.0 does not support the gcc version!
@@ -254,7 +257,8 @@ install:
           ;fi
       ;fi
     # CUDA 7.0 does not support clang on linux.
-    # CUDA 7.5 does not support clang > 4.6 on linux.
+    # CUDA 7.5 does not support clang > 3.6 on linux.
+    # CUDA 7.5 for clang is buggy and does not compile alpaka correctly.
     - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
       ;then
           if [ "${CXX}" == "clang++" ]
@@ -265,10 +269,11 @@ install:
                   ;then
                       export ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
                       && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because clang is not a supported compiler for CUDA 7.0 on linux!
-                  ;fi
-                  && if (( (( ${ALPAKA_CUDA_VER_MAJOR} == 7 )) && (( ${ALPAKA_CUDA_VER_MINOR} == 5 )) ))
+                  ;elif (( (( ${ALPAKA_CUDA_VER_MAJOR} == 7 )) && (( ${ALPAKA_CUDA_VER_MINOR} == 5 )) ))
                   ;then
-                      if (( (( ${ALPAKA_CLANG_VER_MAJOR} > 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} > 6 )) ) ))
+                      export ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
+                      && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because the CUDA 7.5 clang support is buggy!
+                      && if (( (( ${ALPAKA_CLANG_VER_MAJOR} > 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} > 6 )) ) ))
                       ;then
                           export ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
                           && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because clang versions higher then 3.6 are not a supported compiler for CUDA 7.5 on linux!
@@ -292,8 +297,26 @@ install:
     # Install nvcc
     - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
       ;then
-          ALPAKA_CUDA_PKG_FILE_NAME=cuda-repo-ubuntu1204-${ALPAKA_CUDA_VER_MAJOR}-${ALPAKA_CUDA_VER_MINOR}-local_${ALPAKA_CUDA_VERSION}-28_amd64.deb
-          && wget http://developer.download.nvidia.com/compute/cuda/${ALPAKA_CUDA_VER_MAJOR}_${ALPAKA_CUDA_VER_MINOR}/Prod/local_installers/rpmdeb/${ALPAKA_CUDA_PKG_FILE_NAME}
+          if [ ${ALPAKA_CUDA_VER_MAJOR} == 7 ]
+          ;then
+              if [ ${ALPAKA_CUDA_VER_MINOR} == 0 ]
+              ;then
+                  ALPAKA_CUDA_PKG_FILE_NAME=cuda-repo-ubuntu1404-${ALPAKA_CUDA_VER_MAJOR}-${ALPAKA_CUDA_VER_MINOR}-local_${ALPAKA_CUDA_VERSION}-28_amd64.deb
+                  && ALPAKA_CUDA_PKG_FILE_PATH=http://developer.download.nvidia.com/compute/cuda/${ALPAKA_CUDA_VER_MAJOR}_${ALPAKA_CUDA_VER_MINOR}/Prod/local_installers/rpmdeb/${ALPAKA_CUDA_PKG_FILE_NAME}
+              ;elif [ ${ALPAKA_CUDA_VER_MINOR} == 5 ]
+              ;then
+                  ALPAKA_CUDA_PKG_FILE_NAME=cuda-repo-ubuntu1404-${ALPAKA_CUDA_VER_MAJOR}-${ALPAKA_CUDA_VER_MINOR}-local_${ALPAKA_CUDA_VERSION}-18_amd64.deb
+                  && ALPAKA_CUDA_PKG_FILE_PATH=http://developer.download.nvidia.com/compute/cuda/${ALPAKA_CUDA_VERSION}/Prod/local_installers/${ALPAKA_CUDA_PKG_FILE_NAME}
+              ;else
+                  echo CUDA versions other then 7.0 and 7.5 are not currently supported!
+              ;fi
+          ;else
+              echo CUDA versions other then 7.0 and 7.5 are not currently supported!
+          ;fi
+      ;fi
+    - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
+      ;then
+          wget ${ALPAKA_CUDA_PKG_FILE_PATH}
           && sudo dpkg -i ${ALPAKA_CUDA_PKG_FILE_NAME}
           && sudo apt-get -y update
           && sudo apt-get -y install cuda-core-${ALPAKA_CUDA_VERSION} cuda-cudart-${ALPAKA_CUDA_VERSION} cuda-cudart-dev-${ALPAKA_CUDA_VERSION} cuda-curand-${ALPAKA_CUDA_VERSION} cuda-curand-dev-${ALPAKA_CUDA_VERSION}
@@ -308,7 +331,7 @@ install:
     #-------------------------------------------------------------------------------
     # CMake 2.8.7 is too old...
     # Remove the old version.
-    - sudo apt-get remove cmake
+    - sudo apt-get -y remove cmake
     # Extract the version numbers.
     - ALPAKA_CMAKE_VER_MAJOR=${ALPAKA_CMAKE_VER:0:1}
     - echo ${ALPAKA_CMAKE_VER_MAJOR}

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Accelerator Back-ends
 |Accelerator Back-end|Lib/API|Devices|Execution strategy grid-blocks|Execution strategy block-threads|
 |---|---|---|---|---|
 |Serial|n/a|Host CPU (single core)|sequential|sequential (only 1 thread per block)|
-|OpenMP 2.0 blocks|OpenMP 2.0|Host CPU (multi core)|parallel (preemptive multitasking)|sequential (only 1 thread per block)|
-|OpenMP 2.0 threads|OpenMP 2.0|Host CPU (multi core)|sequential|parallel (preemptive multitasking)|
-|OpenMP 4.0 (CPU)|OpenMP 4.0|Host CPU (multi core)|parallel (undefined)|parallel (preemptive multitasking)|
+|OpenMP 2.0+ blocks|OpenMP 2.0+|Host CPU (multi core)|parallel (preemptive multitasking)|sequential (only 1 thread per block)|
+|OpenMP 2.0+ threads|OpenMP 2.0+|Host CPU (multi core)|sequential|parallel (preemptive multitasking)|
+|OpenMP 4.0+ (CPU)|OpenMP 4.0+|Host CPU (multi core)|parallel (undefined)|parallel (preemptive multitasking)|
 | std::thread | std::thread |Host CPU (multi core)|sequential|parallel (preemptive multitasking)|
 | Boost.Fiber | boost::fibers::fiber |Host CPU (single core)|sequential|parallel (cooperative multitasking)|
-|CUDA 7.0|CUDA 7.0|NVIDIA GPUs SM 2.0+|parallel (undefined)|parallel (lock-step within warps)|
+|CUDA 7.0+|CUDA 7.0+|NVIDIA GPUs SM 2.0+|parallel (undefined)|parallel (lock-step within warps)|
 
 
 Supported Compilers
@@ -58,14 +58,12 @@ This library uses C++11 (or newer when available).
 |Accelerator Back-end|gcc 4.9.2|gcc 5.2|clang 3.5/3.6|clang 3.7|MSVC 2015|
 |---|---|---|---|---|---|
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 2.0 blocks|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|
-|OpenMP 2.0 threads|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|
-|OpenMP 4.0 (CPU)|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|
+|OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|
+|OpenMP 2.0+ threads|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|
+|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|
 | std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Boost.Fiber |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|CUDA 7.0|:white_check_mark:|:x:|:x:|:x:|:x:|
-
-**NOTE**: :bangbang: Currently the *CUDA accelerator back-end* can not be enabled together with the *std::thread accelerator back-end* or the *Boost.Fiber accelerator back-end* due to bugs in the NVIDIA nvcc compiler :bangbang:
+|CUDA 7.0+|:white_check_mark:|:x:|:x:|:x:|:x:|
 
 Build status master branch: [![Build Status](https://travis-ci.org/ComputationalRadiationPhysics/alpaka.svg?branch=master)](https://travis-ci.org/ComputationalRadiationPhysics/alpaka)
 
@@ -83,8 +81,9 @@ When an accelerator back-end using *Boost.Fiber* is enabled, the develop branch 
 `boost-fibers`, `boost-context` and all of its dependencies are required to be build in C++14 mode `./b2 cxxflags="-std=c++14"`.
 
 When an accelerator back-end using *CUDA* is enabled, version *7.0* of the *CUDA SDK* is the minimum requirement.
+*NOTE*: When using *CUDA* 7.0, the *CUDA accelerator back-end* can not be enabled together with the *std::thread accelerator back-end* or the *Boost.Fiber accelerator back-end* due to bugs in the nvcc compiler.
 
-When an accelerator back-end using *OpenMP 2.0/4.0* is enabled, the compiler and the platform have to support the corresponding *OpenMP* version.
+When an accelerator back-end using *OpenMP* is enabled, the compiler and the platform have to support the corresponding minimum *OpenMP* version.
 
 
 Usage
@@ -92,12 +91,12 @@ Usage
 
 The library is header only so nothing has to be build.
 CMake 3.3.0+ is required to provide the correct defines and include paths.
-Just call `ALPAKA_ADD_EXECUTABLE` instead of `CUDA_ADD_EXECUTABLE` or `ADD_EXECUTABLE` and the difficulties of the CUDA nvcc compier in handling `.cu` and `.cpp` files is automatically taken care of.
-Examples how to utilize alpaka within CMake can be found in the `examples` folder.
-
+Just call `ALPAKA_ADD_EXECUTABLE` instead of `CUDA_ADD_EXECUTABLE` or `ADD_EXECUTABLE` and the difficulties of the CUDA nvcc compiler in handling `.cu` and `.cpp` files are automatically taken care of.
 Source files do not need any special file ending.
+Examples of how to utilize alpaka within CMake can be found in the `examples` folder.
+
 The whole alpaka library can be included with: `#include <alpaka/alpaka.hpp>`
-Code not intended to be utilized by users is hidden in the `detail` namespace.
+Code that is not intended to be utilized by the user is hidden in the `detail` namespace.
 
 
 Authors


### PR DESCRIPTION
CUDA 7.5 requires at least Ubuntu 14.04. Travis now allows to use a beta 14.04 image that we can use to test.