### PR TITLE
Use implicit id counter for shared memory allocation

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -188,6 +188,7 @@
 #include <alpaka/meta/ForEachType.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
 #include <alpaka/meta/NdLoop.hpp>
+#include <alpaka/meta/UniqueId.hpp>
 #include <alpaka/meta/StdTupleAsMplSequence.hpp>
 #include <alpaka/meta/Transform.hpp>
 

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <alpaka/meta/UniqueId.hpp> // meta::uniqueId
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -86,8 +88,8 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 template<
                     typename T,
-                    std::size_t TuniqueId,
-                    typename TBlockSharedMemSt>
+                    typename TBlockSharedMemSt,
+                    std::size_t TuniqueId = meta::uniqueId()>
                 ALPAKA_FN_HOST_ACC auto allocVar(
                     TBlockSharedMemSt const & blockSharedMemSt)
                 -> T &
@@ -114,8 +116,8 @@ namespace alpaka
                 template<
                     typename T,
                     std::size_t TnumElements,
-                    std::size_t TuniqueId,
-                    typename TBlockSharedMemSt>
+                    typename TBlockSharedMemSt,
+                    std::size_t TuniqueId = meta::uniqueId()>
                 ALPAKA_FN_HOST_ACC auto allocArr(
                     TBlockSharedMemSt const & blockSharedMemSt)
                 -> T *
@@ -182,6 +184,7 @@ namespace alpaka
                             return
                                 block::shared::st::allocVar<
                                     T,
+                                    typename TBlockSharedMemSt::BlockSharedMemStBase,
                                     TuniqueId>(
                                         static_cast<typename TBlockSharedMemSt::BlockSharedMemStBase const &>(blockSharedMemSt));
                         }
@@ -216,6 +219,7 @@ namespace alpaka
                                 block::shared::st::allocArr<
                                     T,
                                     TnumElements,
+                                    typename TBlockSharedMemSt::BlockSharedMemStBase,
                                     TuniqueId>(
                                         static_cast<typename TBlockSharedMemSt::BlockSharedMemStBase const &>(blockSharedMemSt));
                         }

--- a/include/alpaka/meta/UniqueId.hpp
+++ b/include/alpaka/meta/UniqueId.hpp
@@ -1,0 +1,176 @@
+/**
+* \file
+* Copyright 2015 Benjamin Worpitz, Rene Widera
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <boost/predef.h>           // workarounds
+
+#include <cstddef>                  // std::size_t
+
+namespace alpaka
+{
+    namespace meta
+    {
+        namespace detail
+        {
+            static std::size_t constexpr maxUniqueId = 128u;
+
+            //#############################################################################
+            // Based on the code from Filip Roseen at http://b.atch.se/posts/constexpr-counter/
+            //#############################################################################
+            template<
+                std::size_t N>
+            struct flag;
+
+            //-----------------------------------------------------------------------------
+            //
+            //-----------------------------------------------------------------------------
+            template<
+                std::size_t N>
+            std::size_t constexpr adl_flag(flag<N>);
+
+            //#############################################################################
+            //
+            //#############################################################################
+            template<
+                std::size_t N>
+            struct flag
+            {
+    // Declaring the non-template friend function is desired.
+    // Therefore, we can disable the warning
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    // warning: friend declaration ‘constexpr std::size_t alpaka::meta::detail::adl_flag(alpaka::meta::detail::flag<N>)’ declares a non-template function [-Wnon-template-friend]
+    #pragma GCC diagnostic ignored "-Wnon-template-friend"
+#elif BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wundefined-inline"
+#elif BOOST_COMP_MSVC
+    #pragma warning(push)
+    //#pragma warning(disable: 4244)
+#endif
+                friend std::size_t constexpr adl_flag(flag<N>);
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#elif BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#elif BOOST_COMP_MSVC
+    #pragma warning(pop)
+#endif
+            };
+
+            //#############################################################################
+            //
+            //#############################################################################
+            template<
+                std::size_t N>
+            struct writer
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                friend std::size_t constexpr adl_flag(flag<N>)
+                {
+                    return N;
+                }
+
+                static std::size_t constexpr value = N;
+            };
+
+#if (BOOST_COMP_MSVC || __CUDACC__)
+            //-----------------------------------------------------------------------------
+            //! The matcher.
+            //-----------------------------------------------------------------------------
+            template<
+                std::size_t N,
+                class = char[noexcept(adl_flag(flag<N>{})) ? +1 : -1]>
+            auto constexpr reader(std::size_t, flag<N>)
+            -> std::size_t
+            {
+              return N;
+            }
+#else
+            //-----------------------------------------------------------------------------
+            //! The matcher.
+            //-----------------------------------------------------------------------------
+            template<
+                std::size_t N,
+                std::size_t = adl_flag(flag<N>{})>
+            auto constexpr reader(
+                std::size_t,
+                flag<N>)
+            -> std::size_t
+            {
+                return N;
+            }
+#endif
+            //-----------------------------------------------------------------------------
+            //! The searcher.
+            //-----------------------------------------------------------------------------
+            template<
+                std::size_t N>
+            auto constexpr reader(
+                float,
+                flag<N>,
+                std::size_t R = reader(std::size_t{0u}, flag<N-1u>{}))
+            -> std::size_t
+            {
+                return R;
+            }
+            //-----------------------------------------------------------------------------
+            //! Reader base case.
+            //-----------------------------------------------------------------------------
+            std::size_t constexpr reader(float, flag<0u>)
+            {
+                return 0u;
+            }
+        }
+
+        // NOTE: We can not hide this uniqueId implementation inside the detail namespace and forward to it from outside.
+        // Compilers would not be forced to reevaluate the default template parameters in this case and will always generate the same ID.
+#if (BOOST_COMP_MSVC)
+        //-----------------------------------------------------------------------------
+        //! \return An unique compile time ID.
+        //-----------------------------------------------------------------------------
+        template<
+            std::size_t N = 1u,
+            std::size_t C = detail::reader(std::size_t{0u}, detail::flag<detail::maxUniqueId>{})>
+        auto constexpr uniqueId(
+            std::size_t R = detail::writer<C + N>::value)
+        -> std::size_t
+        {
+            return R;
+        }
+#else
+        //-----------------------------------------------------------------------------
+        //! \return An unique compile time ID.
+        //-----------------------------------------------------------------------------
+        template<
+            std::size_t N = 1u>
+        auto constexpr uniqueId(
+            std::size_t R = detail::writer<detail::reader(std::size_t{0u}, detail::flag<detail::maxUniqueId>{}) + N>::value)
+        -> std::size_t
+        {
+            return R;
+        }
+#endif
+    }
+}

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -52,29 +52,29 @@ public:
         TAcc const & acc) const
     -> void
     {
-        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t>(acc);
         BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &a);
 
-        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t>(acc);
         BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &b);
 
-        auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
+        auto && c = alpaka::block::shared::st::allocVar<float>(acc);
         BOOST_REQUIRE_NE(static_cast<float *>(nullptr), &c);
 
-        auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
+        auto && d = alpaka::block::shared::st::allocVar<double>(acc);
         BOOST_REQUIRE_NE(static_cast<double *>(nullptr), &d);
 
-        auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
+        auto && e = alpaka::block::shared::st::allocVar<std::uint64_t>(acc);
         BOOST_REQUIRE_NE(static_cast<std::uint64_t *>(nullptr), &e);
 
 
-        auto * f = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
+        auto * f = alpaka::block::shared::st::allocArr<std::uint32_t, 32u>(acc);
         BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), f);
 
-        auto * g = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
+        auto * g = alpaka::block::shared::st::allocArr<std::uint32_t, 32u>(acc);
         BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), g);
 
-        auto * h = alpaka::block::shared::st::allocArr<double, 16u, __COUNTER__>(acc);
+        auto * h = alpaka::block::shared::st::allocArr<double, 16u>(acc);
         BOOST_REQUIRE_NE(static_cast<double *>(nullptr), h);
     }
 };
@@ -117,19 +117,18 @@ public:
         TAcc const & acc) const
     -> void
     {
-        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t>(acc);
+        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t>(acc);
         BOOST_REQUIRE_NE(&a, &b);
-        auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&b,&c);
+        auto && c = alpaka::block::shared::st::allocVar<std::uint32_t>(acc);
         BOOST_REQUIRE_NE(&a, &c);
         BOOST_REQUIRE_NE(&b, &c);
 
-        auto * d = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
+        auto * d = alpaka::block::shared::st::allocArr<std::uint32_t, 32u>(acc);
         BOOST_REQUIRE_NE(&a, d);
         BOOST_REQUIRE_NE(&b, d);
         BOOST_REQUIRE_NE(&c, d);
-        auto * e = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
+        auto * e = alpaka::block::shared::st::allocArr<std::uint32_t, 32u>(acc);
         BOOST_REQUIRE_NE(&a, e);
         BOOST_REQUIRE_NE(&b, e);
         BOOST_REQUIRE_NE(&c, e);

--- a/test/unit/meta/src/UniqueIdTest.cpp
+++ b/test/unit/meta/src/UniqueIdTest.cpp
@@ -1,0 +1,68 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(meta)
+
+//#############################################################################
+//!
+//#############################################################################
+template<
+    std::size_t TuniqueId = alpaka::meta::uniqueId()>
+auto constexpr uniqueIdAsDefaultTemplateParam()
+-> std::size_t
+{
+    return TuniqueId;
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(uniqueId)
+{
+    using IsSetInput =
+        std::tuple<
+            int,
+            float,
+            long>;
+
+    auto constexpr a =
+        alpaka::meta::uniqueId();
+    auto constexpr b =
+        alpaka::meta::uniqueId();
+    static_assert(
+        a != b,
+        "alpaka::meta::uniqueId 'a != b' failed!");
+
+    auto constexpr c =
+        uniqueIdAsDefaultTemplateParam();
+    static_assert(
+        a != c,
+        "alpaka::meta::uniqueId 'a != c' failed!");
+    static_assert(
+        b != c,
+        "alpaka::meta::uniqueId 'b != c' failed!");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This branch implements a compile time counter for the shared memory allocation that is compiling on all platforms.
It is based on the code from [Filip Roséen](http://b.atch.se/posts/constexpr-counter/).
At least in C++11 and C++14 this code is valid. The C++ Standards Committee is currently debating on wheter this should be legal or not in C++17. See [here](https://groups.google.com/a/isocpp.org/forum/#!msg/std-discussion/M6aJMH_ewoM/-cV4Rq0ou5QJ).

- [ ] [Suppress](https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html) the high number of warnings. (-Wundefined-internal / -Wnon-template-friend)
- [ ] Increase the maximum counter value from 64 to something reasonable. However, this could exceed the maximum template instantiation depth.
- [ ] Add the solution to the [Stackoverflow thread](http://stackoverflow.com/questions/33345498/cuda-shared-memory-wrapped-in-class-points-to-same-memory).