### PR TITLE
Close #83 Comparison for 1D Vectors with Zero

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -631,7 +631,7 @@ namespace alpaka
         for(typename TDim::value_type i(0); i<TDim::value; ++i)
         {
             os << v[i];
-            if(i<TDim::value-1)
+            if(i != TDim::value-1)
             {
                 os << ", ";
             }


### PR DESCRIPTION
Close #83 For 1D vectors, unsigned var `i` is always smaller than zero leading to a "pointless comparison" warning.