### PR TITLE
use `OptimalAlignment<>` with GCC

### DIFF
--- a/include/alpaka/core/Align.hpp
+++ b/include/alpaka/core/Align.hpp
@@ -101,19 +101,15 @@ namespace alpaka
                         ? 128
                         :
 #endif
-                            // Align at a minimum of 16 Bytes.
-                            (/*(TsizeBytes <= 16)
-                            ? 16
-                            :*/ RoundUpToPowerOfTwo<TsizeBytes>::value)>
+                            (RoundUpToPowerOfTwo<TsizeBytes>::value)>
             {};
         }
     }
 }
 
-// GCC does not support constant expressions as parameters to alignas: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58109
+// ICC does not support constant expressions as parameters to alignas
 // The optimal alignment for a type is the next higher or equal power of two.
-// TODO: Is a alignment < 16 really optimal on a GPU?
-#if BOOST_COMP_GNUC || BOOST_COMP_INTEL
+#if BOOST_COMP_INTEL
     #define ALPAKA_OPTIMAL_ALIGNMENT_SIZE(...)\
             ((__VA_ARGS__)==1?1:\
             ((__VA_ARGS__)<=2?2:\


### PR DESCRIPTION
- remove precompiler `if` for GCC to calculate optimal alignment size
- remove TODO if GPUs can optimal use alignment < 16 byte (answere is yes)
- remove code in a comment

My tests shows that GCC 4.9.2 compiles well with the template version for `ALPAKA_OPTIMAL_ALIGNMENT_SIZE`.