### PR TITLE
Add the missing helloWorld example to the CMake alpakaExamples project

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,12 +24,11 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
-
-PROJECT("alpaka_examples")
+PROJECT("alpakaExamples")
 
 ################################################################################
 # Add subdirectories.
 ################################################################################
 
+ADD_SUBDIRECTORY("helloWorld/")
 ADD_SUBDIRECTORY("vectorAdd/")


### PR DESCRIPTION
The helloWorld example was missing from the project that includes all examples.
By the way, the USE_FOLDERS property is useless in this CMakeLists.txt and the project name is not in the alpaka default camelCase.