### PR TITLE
remove all align(16)

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -152,13 +152,13 @@ namespace alpaka
         private:
             // getIdx
             typename idx::bt::IdxBtRefFiberIdMap<TDim, TSize>::FiberIdToIdxMap mutable m_fibersToIndices;  //!< The mapping of fibers id's to indices.
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;                    //!< The index of the currently executed block.
 
             // syncBlockThreads
-            TSize const m_blockThreadCount;                         //!< The number of threads per block the barrier has to wait for.
+            TSize const m_blockThreadCount;                             //!< The number of threads per block the barrier has to wait for.
             std::map<
                 boost::fibers::fiber::id,
-                TSize> mutable m_fibersToBarrier;                      //!< The mapping of fibers id's to their current barrier.
+                TSize> mutable m_fibersToBarrier;                       //!< The mapping of fibers id's to their current barrier.
             //!< We have to keep the current and the last barrier because one of the fibers can reach the next barrier before another fiber was wakeup from the last one and has checked if it can run.
 
             // allocBlockSharedArr

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -143,7 +143,7 @@ namespace alpaka
 
         private:
             // getIdx
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
 
             // getBlockSharedExternMem
             std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem;  //!< External block shared memory.

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -144,7 +144,7 @@ namespace alpaka
 
         private:
             // getIdx
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;   //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;   //!< The index of the currently executed block.
 
             // getBlockSharedExternMem
             std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem;  //!< External block shared memory.

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -144,7 +144,7 @@ namespace alpaka
 
         private:
             // getIdx
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
 
             // getBlockSharedExternMem
             std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem;  //!< External block shared memory.

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -141,7 +141,7 @@ namespace alpaka
 
         private:
             // getIdx
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;    //!< The index of the currently executed block.
 
             // getBlockSharedExternMem
             std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem;  //!< External block shared memory.

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -150,19 +150,19 @@ namespace alpaka
             // getIdx
             std::mutex mutable m_mtxMapInsert;                              //!< The mutex used to secure insertion into the ThreadIdToIdxMap.
             typename idx::bt::IdxBtRefThreadIdMap<TDim, TSize>::ThreadIdToIdxMap mutable m_threadToIndexMap;    //!< The mapping of thread id's to indices.
-            alignas(16u) Vec<TDim, TSize> mutable m_gridBlockIdx;           //!< The index of the currently executed block.
+            Vec<TDim, TSize> mutable m_gridBlockIdx;                        //!< The index of the currently executed block.
 
             // syncBlockThreads
-            TSize const m_blockThreadCount;                             //!< The number of threads per block the barrier has to wait for.
+            TSize const m_blockThreadCount;                                 //!< The number of threads per block the barrier has to wait for.
             std::map<
                 std::thread::id,
-                TSize> mutable m_threadToBarrierMap;                         //!< The mapping of thread id's to their current barrier.
+                TSize> mutable m_threadToBarrierMap;                        //!< The mapping of thread id's to their current barrier.
 
             // allocBlockSharedArr
             std::thread::id mutable m_idMasterThread;                       //!< The id of the master thread.
 
             // getBlockSharedExternMem
-            std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem;      //!< External block shared memory.
+            std::unique_ptr<uint8_t, boost::alignment::aligned_delete> mutable m_externalSharedMem; //!< External block shared memory.
         };
     }
 

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -73,7 +73,7 @@ namespace alpaka
                 ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~IdxGbRef() = default;
 
             public:
-                alignas(16u) Vec<TDim, TSize> const & m_gridBlockIdx;
+                Vec<TDim, TSize> const & m_gridBlockIdx;
             };
         }
     }

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -27,6 +27,7 @@
 #include <alpaka/offset/Traits.hpp>         // offset::getOffsetX, ...
 #include <alpaka/size/Traits.hpp>           // size::traits::SizeType
 
+#include <alpaka/core/Align.hpp>            // ALPAKA_OPTIMAL_ALIGNMENT_SIZE
 #include <alpaka/core/IntegerSequence.hpp>  // core::detail::make_integer_sequence
 #include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 #include <alpaka/core/Fold.hpp>             // core::foldr
@@ -138,7 +139,7 @@ namespace alpaka
     template<
         typename TDim,
         typename TSize>
-    class alignas(16u) Vec final
+    class Vec final
     {
     public:
         static_assert(TDim::value>0, "Dimensionality of the vector is required to be greater then zero!");
@@ -511,8 +512,7 @@ namespace alpaka
         }
 
     private:
-        // 16 Byte alignment for usage inside of CUDA kernels.
-        alignas(16u) TSize m_data[TDim::value];
+        TSize m_data[TDim::value];
     };
 
 

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -77,7 +77,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The WorkDivMembers grid block extent trait specialization for classes with WorkDivBase member type.
+            //! The work div grid block extent trait specialization for classes with WorkDivBase member type.
             //#############################################################################
             template<
                 typename TWorkDiv>
@@ -106,7 +106,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The WorkDivMembers block thread extent trait specialization for classes with WorkDivBase member type.
+            //! The work div block thread extent trait specialization for classes with WorkDivBase member type.
             //#############################################################################
             template<
                 typename TWorkDiv>
@@ -135,7 +135,7 @@ namespace alpaka
                 }
             };
             //#############################################################################
-            //! The WorkDivMembers block thread extent trait specialization for classes with WorkDivBase member type.
+            //! The work div block thread extent trait specialization for classes with WorkDivBase member type.
             //#############################################################################
             template<
                 typename TWorkDiv>

--- a/test/integ/mandelbrot/src/main.cpp
+++ b/test/integ/mandelbrot/src/main.cpp
@@ -258,7 +258,7 @@ public:
         return m_colors[iterationCount%16];
     }
 
-    alignas(16) std::uint32_t m_colors[16];
+    std::uint32_t m_colors[16];
 #endif
 };
 


### PR DESCRIPTION
Removes all the existing `align(16)` so that #91 can be closed.