### PR TITLE
convert vectorAdd integ test to axpy integ test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -491,10 +491,10 @@ script:
 
     #-------------------------------------------------------------------------------
     # Build and execute all integration tests.
+    - ./travis/compileExec.sh "test/integ/axpy/" ./axpy
     - ./travis/compileExec.sh "test/integ/mandelbrot/" ./mandelbrot
     - ./travis/compileExec.sh "test/integ/matMul/" ./matMul
     - ./travis/compileExec.sh "test/integ/sharedMem/" ./sharedMem
-    - ./travis/compileExec.sh "test/integ/vectorAdd/" ./vectorAdd
 
     #-------------------------------------------------------------------------------
 

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -30,11 +30,10 @@ SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 # Project.
 ################################################################################
 
-SET(_INCLUDE_DIR "include/")
-SET(_SUFFIXED_INCLUDE_DIR "${_INCLUDE_DIR}vectorAdd/")
 SET(_SOURCE_DIR "src/")
+SET(_PROJECT_NAME "vectorAdd")
 
-PROJECT("vectorAdd")
+PROJECT(${_PROJECT_NAME})
 
 #-------------------------------------------------------------------------------
 # Find alpaka.
@@ -57,11 +56,8 @@ SET(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
 # Add library.
 #-------------------------------------------------------------------------------
 
-# Add all the include files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SUFFIXED_INCLUDE_DIR}" "" "hpp" _FILES_HEADER)
-
 # Add all the source files in all recursive subdirectories and group them accordingly.
-append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_CXX)
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE)
 
 INCLUDE_DIRECTORIES(
     ${_INCLUDE_DIRECTORIES_PRIVATE}
@@ -70,9 +66,9 @@ ADD_DEFINITIONS(
     ${alpaka_DEFINITIONS} ${ALPAKA_DEV_COMPILE_OPTIONS})
 # Always add all files to the target executable build call to add them to the build project.
 ALPAKA_ADD_EXECUTABLE(
-    "vectorAdd"
-    ${_FILES_HEADER} ${_FILES_SOURCE_CXX})
+    ${_PROJECT_NAME}
+    ${_FILES_SOURCE})
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 TARGET_LINK_LIBRARIES(
-    "vectorAdd"
+    ${_PROJECT_NAME}
     PUBLIC "alpaka")

--- a/test/integ/CMakeLists.txt
+++ b/test/integ/CMakeLists.txt
@@ -24,15 +24,13 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
 
-SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
-
 PROJECT("alpakaIntegTest")
 
 ################################################################################
 # Add subdirectories.
 ################################################################################
 
+ADD_SUBDIRECTORY("axpy/")
 ADD_SUBDIRECTORY("mandelbrot/")
 ADD_SUBDIRECTORY("matMul/")
 ADD_SUBDIRECTORY("sharedMem/")
-ADD_SUBDIRECTORY("vectorAdd/")

--- a/test/integ/axpy/CMakeLists.txt
+++ b/test/integ/axpy/CMakeLists.txt
@@ -31,7 +31,7 @@ SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 
 SET(_SOURCE_DIR "src/")
-SET(_PROJECT_NAME "vectorAdd")
+SET(_PROJECT_NAME "axpy")
 
 PROJECT(${_PROJECT_NAME})
 


### PR DESCRIPTION
Currently there is a `vectorAdd` example and a `vectorAdd` integration test.
It is not possible to include both targets within a single project due to the name ambiguity. To solve this, I have converted the integration test to calculate `axpy` instead of a simple vector addition.