### PR TITLE
fix wrong guards

### DIFF
--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
 
 #if _OPENMP < 200203
-    #error If ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+    #error If ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
 #endif
 
 // Base classes.

--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
 
 #if _OPENMP < 200203
-    #error If ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
+    #error If ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED is set, the compiler has to support OpenMP 2.0 or higher!
 #endif
 
 // Specialized traits.


### PR DESCRIPTION
rename guard `ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED` to
`ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED` for `AccCpuOmp2Blocks`

This bug was introduced with the issue #100