### PR TITLE
fix wrong view namespace

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -203,7 +203,7 @@ int main() {
                                             static_cast<Size>(nElementsPerDim));
 
     std::array<Data, nElementsPerDim * nElementsPerDim * nElementsPerDim> plainBuffer;
-    alpaka::mem::buf::ViewPlainPtr<DevHost, Data, Dim, Size> hostBufferPlain(plainBuffer.data(), devHost, extents);
+    alpaka::mem::view::ViewPlainPtr<DevHost, Data, Dim, Size> hostBufferPlain(plainBuffer.data(), devHost, extents);
     alpaka::mem::buf::Buf<DevHost, Data, Dim, Size> hostBuffer  (alpaka::mem::buf::alloc<Data, Size>(devHost, extents));
     alpaka::mem::buf::Buf<DevAcc, Data, Dim, Size> deviceBuffer1(alpaka::mem::buf::alloc<Data, Size>(devAcc,  extents));
     alpaka::mem::buf::Buf<DevAcc, Data, Dim, Size> deviceBuffer2(alpaka::mem::buf::alloc<Data, Size>(devAcc,  extents));

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -304,35 +304,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The BufCpu buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TElem,
-                    typename TDim,
-                    typename TSize>
-                struct GetBuf<
-                    mem::buf::BufCpu<TElem, TDim, TSize>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::buf::BufCpu<TElem, TDim, TSize> const & buf)
-                    -> mem::buf::BufCpu<TElem, TDim, TSize> const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::buf::BufCpu<TElem, TDim, TSize> & buf)
-                    -> mem::buf::BufCpu<TElem, TDim, TSize> &
-                    {
-                        return buf;
-                    }
-                };
-                //#############################################################################
                 //! The BufCpu native pointer get trait specialization.
                 //#############################################################################
                 template<

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -242,35 +242,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The BufCudaRt buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TElem,
-                    typename TDim,
-                    typename TSize>
-                struct GetBuf<
-                    mem::buf::BufCudaRt<TElem, TDim, TSize>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::buf::BufCudaRt<TElem, TDim, TSize> const & buf)
-                    -> mem::buf::BufCudaRt<TElem, TDim, TSize> const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::buf::BufCudaRt<TElem, TDim, TSize> & buf)
-                    -> mem::buf::BufCudaRt<TElem, TDim, TSize> &
-                    {
-                        return buf;
-                    }
-                };
-                //#############################################################################
                 //! The BufCudaRt native pointer get trait specialization.
                 //#############################################################################
                 template<

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -83,14 +83,14 @@ namespace alpaka
                                 m_extentWidthBytes(static_cast<Size>(m_extentWidth * sizeof(elem::Elem<TViewDst>))),
                                 m_dstWidth(static_cast<Size>(extent::getWidth(viewDst))),
                                 m_srcWidth(static_cast<Size>(extent::getWidth(viewSrc))),
-                                m_dstBufWidth(static_cast<Size>(extent::getWidth(mem::view::getBuf(viewDst)))),
-                                m_srcBufWidth(static_cast<Size>(extent::getWidth(mem::view::getBuf(viewSrc)))),
+                                m_dstBufWidth(static_cast<Size>(extent::getWidth(viewDst))),
+                                m_srcBufWidth(static_cast<Size>(extent::getWidth(viewSrc))),
 
                                 m_extentHeight(extent::getHeight(extent)),
                                 m_dstHeight(static_cast<Size>(extent::getHeight(viewDst))),
                                 m_srcHeight(static_cast<Size>(extent::getHeight(viewSrc))),
-                                m_dstBufHeight(static_cast<Size>(extent::getHeight(mem::view::getBuf(viewDst)))),
-                                m_srcBufHeight(static_cast<Size>(extent::getHeight(mem::view::getBuf(viewSrc)))),
+                                m_dstBufHeight(static_cast<Size>(extent::getHeight(viewDst))),
+                                m_srcBufHeight(static_cast<Size>(extent::getHeight(viewSrc))),
 
                                 m_extentDepth(extent::getDepth(extent)),
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -98,9 +98,8 @@ namespace alpaka
                             auto const dstNativePtr(reinterpret_cast<std::uint8_t *>(mem::view::getPtrNative(m_view)));
                             auto const dstSliceSizeBytes(dstPitchBytes * dstHeight);
 
-                            auto const & dstBuf(mem::view::getBuf(m_view));
-                            auto const dstBufWidth(extent::getWidth(dstBuf));
-                            auto const dstBufHeight(extent::getHeight(dstBuf));
+                            auto const dstBufWidth(extent::getWidth(m_view));
+                            auto const dstBufHeight(extent::getHeight(m_view));
 
                             int iByte(static_cast<int>(m_byte));
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -129,14 +129,6 @@ namespace alpaka
                     typename TDevSrc,
                     typename TSfinae = void>
                 struct TaskCopy;
-
-                //#############################################################################
-                //! The buffer trait.
-                //#############################################################################
-                template<
-                    typename TView,
-                    typename TSfinae = void>
-                struct GetBuf;
             }
 
             //-----------------------------------------------------------------------------
@@ -377,51 +369,6 @@ namespace alpaka
                         viewDst,
                         viewSrc,
                         extent));
-            }
-
-            //-----------------------------------------------------------------------------
-            //! Gets the memory buffer.
-            //!
-            //! \param view The view the buffer is received from.
-            //! \return The memory buffer.
-            //-----------------------------------------------------------------------------
-            template<
-                typename TView>
-            ALPAKA_FN_HOST auto getBuf(
-                TView const & view)
-            -> decltype(
-                traits::GetBuf<
-                    TView>
-                ::getBuf(
-                    view))
-            {
-                return
-                    traits::GetBuf<
-                        TView>
-                    ::getBuf(
-                        view);
-            }
-            //-----------------------------------------------------------------------------
-            //! Gets the memory buffer.
-            //!
-            //! \param view The view the buffer is received from.
-            //! \return The memory buffer.
-            //-----------------------------------------------------------------------------
-            template<
-                typename TView>
-            ALPAKA_FN_HOST auto getBuf(
-                TView & view)
-            -> decltype(
-                traits::GetBuf<
-                    TView>
-                ::getBuf(
-                    view))
-            {
-                return
-                    traits::GetBuf<
-                        TView>
-                    ::getBuf(
-                        view);
             }
 
             namespace detail

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/mem/buf/Traits.hpp>    // dev::traits::DevType, DimType, GetExtent,Copy, GetOffset, ...
+#include <alpaka/mem/view/Traits.hpp>   // dev::traits::DevType, DimType, GetExtent,Copy, GetOffset, ...
 
 #include <alpaka/vec/Vec.hpp>           // Vec<N>
 
@@ -29,10 +29,10 @@ namespace alpaka
 {
     namespace mem
     {
-        namespace buf
+        namespace view
         {
             //#############################################################################
-            //! The memory buffer wrapper used to wrap plain pointers.
+            //! The memory view to wrap plain pointers.
             //#############################################################################
             template<
                 typename TDev,
@@ -131,7 +131,7 @@ namespace alpaka
                 typename TDim,
                 typename TSize>
             struct DevType<
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 using type = TDev;
             };
@@ -145,14 +145,14 @@ namespace alpaka
                 typename TDim,
                 typename TSize>
             struct GetDev<
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getDev(
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const & buf)
+                    mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const & view)
                     -> TDev
                 {
-                    return buf.m_dev;
+                    return view.m_dev;
                 }
             };
         }
@@ -170,7 +170,7 @@ namespace alpaka
                 typename TDim,
                 typename TSize>
             struct DimType<
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 using type = TDim;
             };
@@ -189,7 +189,7 @@ namespace alpaka
                 typename TDim,
                 typename TSize>
             struct ElemType<
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 using type = TElem;
             };
@@ -210,12 +210,12 @@ namespace alpaka
                 typename TSize>
             struct GetExtent<
                 TIdx,
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>,
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>,
                 typename std::enable_if<(TDim::value > TIdx::value)>::type>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getExtent(
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const & extent)
+                    mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const & extent)
                 -> TSize
                 {
                     return extent.m_extentElements[TIdx::value];
@@ -230,39 +230,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The ViewPlainPtr buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TDev,
-                    typename TElem,
-                    typename TDim,
-                    typename TSize>
-                struct GetBuf<
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getBuf(
-                        mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const & buf)
-                    -> mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getBuf(
-                        mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> & buf)
-                    -> mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> &
-                    {
-                        return buf;
-                    }
-                };
-
-                //#############################################################################
                 //! The ViewPlainPtr native pointer get trait specialization.
                 //#############################################################################
                 template<
@@ -271,21 +238,21 @@ namespace alpaka
                     typename TDim,
                     typename TSize>
                 struct GetPtrNative<
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                    mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
                 {
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto getPtrNative(
-                        mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const & buf)
+                        mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const & view)
                     -> TElem const *
                     {
-                        return buf.m_pMem;
+                        return view.m_pMem;
                     }
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto getPtrNative(
-                        mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> & buf)
+                        mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> & view)
                     -> TElem *
                     {
-                        return buf.m_pMem;
+                        return view.m_pMem;
                     }
                 };
 
@@ -299,14 +266,14 @@ namespace alpaka
                     typename TSize>
                 struct GetPitchBytes<
                     dim::DimInt<TDim::value - 1u>,
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                    mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
                 {
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto getPitchBytes(
-                        mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const & buf)
+                        mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const & view)
                     -> TSize
                     {
-                        return buf.m_pitchBytes;
+                        return view.m_pitchBytes;
                     }
                 };
             }
@@ -327,14 +294,14 @@ namespace alpaka
                 typename TSize>
             struct GetOffset<
                 TIdx,
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 //-----------------------------------------------------------------------------
                 //!
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getOffset(
-                    mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize> const &)
+                    mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const &)
                 -> TSize
                 {
                     return 0u;
@@ -355,7 +322,7 @@ namespace alpaka
                 typename TDim,
                 typename TSize>
             struct SizeType<
-                mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>>
+                mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>>
             {
                 using type = TSize;
             };

--- a/include/alpaka/mem/view/ViewStdContainers.hpp
+++ b/include/alpaka/mem/view/ViewStdContainers.hpp
@@ -152,36 +152,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The fixed size array buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TFixedSizeArray>
-                struct GetBuf<
-                    TFixedSizeArray,
-                    typename std::enable_if<
-                        std::is_array<TFixedSizeArray>::value>::type>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        TFixedSizeArray const & buf)
-                    -> TFixedSizeArray const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        TFixedSizeArray & buf)
-                    -> TFixedSizeArray &
-                    {
-                        return buf;
-                    }
-                };
-
-                //#############################################################################
                 //! The fixed size array native pointer get trait specialization.
                 //#############################################################################
                 template<
@@ -398,35 +368,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The std::array buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TElem,
-                    std::size_t Tsize>
-                struct GetBuf<
-                    std::array<TElem, Tsize>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        std::array<TElem, Tsize> const & buf)
-                    -> std::array<TElem, Tsize> const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        std::array<TElem, Tsize> & buf)
-                    -> std::array<TElem, Tsize> &
-                    {
-                        return buf;
-                    }
-                };
-
-                //#############################################################################
                 //! The std::array native pointer get trait specialization.
                 //#############################################################################
                 template<
@@ -629,35 +570,6 @@ namespace alpaka
         {
             namespace traits
             {
-                //#############################################################################
-                //! The std::vector buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TElem,
-                    typename TAllocator>
-                struct GetBuf<
-                    std::vector<TElem, TAllocator>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        std::vector<TElem, TAllocator> const & buf)
-                    -> std::vector<TElem, TAllocator> const &
-                    {
-                        return buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        std::vector<TElem, TAllocator> & buf)
-                    -> std::vector<TElem, TAllocator> &
-                    {
-                        return buf;
-                    }
-                };
-
                 //#############################################################################
                 //! The std::vector native pointer get trait specialization.
                 //#############################################################################

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -68,73 +68,73 @@ namespace alpaka
                 using Dev = TDev;
                 using Elem = TElem;
                 using Dim = TDim;
-                using Buf = mem::buf::ViewPlainPtr<TDev, TElem, TDim, TSize>;
+                using Buf = mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>;
                 // If the value type is const, we store a const buffer.
                 //using BufC = detail::MimicConst<TElem, Buf>;
 
             public:
                 //-----------------------------------------------------------------------------
                 //! Constructor.
-                //! \param buf This can be either a memory buffer or a memory view.
+                //! \param view This can be either a memory buffer or a memory view.
                 //-----------------------------------------------------------------------------
                 template<
-                    typename TBuf>
+                    typename TView>
                 ViewSubView(
-                    TBuf const & buf) :
+                    TView const & view) :
                         m_Buf(
-                            mem::view::getPtrNative(buf),
-                            dev::getDev(buf),
-                            extent::getExtentVecEnd<TDim>(buf),
-                            mem::view::getPitchBytes<TDim::value - 1u>(buf)),
-                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(buf)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(buf))
+                            mem::view::getPtrNative(view),
+                            dev::getDev(view),
+                            extent::getExtentVecEnd<TDim>(view),
+                            mem::view::getPitchBytes<TDim::value - 1u>(view)),
+                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(view)),
+                        m_extentElements(extent::getExtentVecEnd<TDim>(view))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
                 }
                 //-----------------------------------------------------------------------------
                 //! Constructor.
-                //! \param buf This can be either a memory buffer or a memory view.
+                //! \param view This can be either a memory buffer or a memory view.
                 //-----------------------------------------------------------------------------
                 template<
-                    typename TBuf>
+                    typename TView>
                 ViewSubView(
-                    TBuf & buf) :
+                    TView & view) :
                         m_Buf(
-                            mem::view::getPtrNative(buf),
-                            dev::getDev(buf),
-                            extent::getExtentVecEnd<TDim>(buf),
-                            mem::view::getPitchBytes<TDim::value - 1u>(buf)),
-                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(buf)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(buf))
+                            mem::view::getPtrNative(view),
+                            dev::getDev(view),
+                            extent::getExtentVecEnd<TDim>(view),
+                            mem::view::getPitchBytes<TDim::value - 1u>(view)),
+                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(view)),
+                        m_extentElements(extent::getExtentVecEnd<TDim>(view))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     static_assert(
-                        std::is_same<TSize, size::Size<TBuf>>::value,
-                        "The size type of TBuf and the TSize template parameter have to be identical!");
+                        std::is_same<TSize, size::Size<TView>>::value,
+                        "The size type of TView and the TSize template parameter have to be identical!");
                 }
 
                 //-----------------------------------------------------------------------------
                 //! Constructor.
-                //! \param buf This can be either a memory buffer or a memory view.
+                //! \param view This can be either a memory buffer or a memory view.
                 //! \param extentElements The extent in elements.
                 //! \param relativeOffsetsElements The offsets in elements.
                 //-----------------------------------------------------------------------------
                 template<
-                    typename TBuf,
+                    typename TView,
                     typename TOffsets,
                     typename TExtent>
                 ViewSubView(
-                    TBuf const & buf,
+                    TView const & view,
                     TExtent const & extentElements,
                     TOffsets const & relativeOffsetsElements = TOffsets()) :
                         m_Buf(
-                            mem::view::getPtrNative(buf),
-                            dev::getDev(buf),
-                            extent::getExtentVecEnd<TDim>(buf),
-                            mem::view::getPitchBytes<TDim::value - 1u>(buf)),
+                            mem::view::getPtrNative(view),
+                            dev::getDev(view),
+                            extent::getExtentVecEnd<TDim>(view),
+                            mem::view::getPitchBytes<TDim::value - 1u>(view)),
                         m_extentElements(extent::getExtentVecEnd<TDim>(extentElements)),
-                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(relativeOffsetsElements) + offset::getOffsetsVecEnd<TDim>(buf))
+                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(relativeOffsetsElements) + offset::getOffsetsVecEnd<TDim>(view))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -145,37 +145,37 @@ namespace alpaka
                         std::is_same<TSize, size::Size<TExtent>>::value,
                         "The size type of TExtent and the TSize template parameter have to be identical!");
                     static_assert(
-                        std::is_same<TSize, size::Size<TBuf>>::value,
-                        "The size type of TBuf and the TSize template parameter have to be identical!");
+                        std::is_same<TSize, size::Size<TView>>::value,
+                        "The size type of TView and the TSize template parameter have to be identical!");
 
-                    assert(extent::getWidth(relativeOffsetsElements) <= extent::getWidth(buf));
-                    assert(extent::getHeight(relativeOffsetsElements) <= extent::getHeight(buf));
-                    assert(extent::getDepth(relativeOffsetsElements) <= extent::getDepth(buf));
-                    assert((offset::getOffsetX(relativeOffsetsElements)+offset::getOffsetX(buf)+extent::getWidth(extentElements)) <= extent::getWidth(buf));
-                    assert((offset::getOffsetY(relativeOffsetsElements)+offset::getOffsetY(buf)+extent::getHeight(extentElements)) <= extent::getHeight(buf));
-                    assert((offset::getOffsetZ(relativeOffsetsElements)+offset::getOffsetZ(buf)+extent::getDepth(extentElements)) <= extent::getDepth(buf));
+                    assert(extent::getWidth(relativeOffsetsElements) <= extent::getWidth(view));
+                    assert(extent::getHeight(relativeOffsetsElements) <= extent::getHeight(view));
+                    assert(extent::getDepth(relativeOffsetsElements) <= extent::getDepth(view));
+                    assert((offset::getOffsetX(relativeOffsetsElements)+offset::getOffsetX(view)+extent::getWidth(extentElements)) <= extent::getWidth(view));
+                    assert((offset::getOffsetY(relativeOffsetsElements)+offset::getOffsetY(view)+extent::getHeight(extentElements)) <= extent::getHeight(view));
+                    assert((offset::getOffsetZ(relativeOffsetsElements)+offset::getOffsetZ(view)+extent::getDepth(extentElements)) <= extent::getDepth(view));
                 }
                 //-----------------------------------------------------------------------------
                 //! Constructor.
-                //! \param buf This can be either a memory buffer or a memory view.
+                //! \param view This can be either a memory buffer or a memory view.
                 //! \param extentElements The extent in elements.
                 //! \param relativeOffsetsElements The offsets in elements.
                 //-----------------------------------------------------------------------------
                 template<
-                    typename TBuf,
+                    typename TView,
                     typename TOffsets,
                     typename TExtent>
                 ViewSubView(
-                    TBuf & buf,
+                    TView & view,
                     TExtent const & extentElements,
                     TOffsets const & relativeOffsetsElements = TOffsets()) :
                         m_Buf(
-                            mem::view::getPtrNative(buf),
-                            dev::getDev(buf),
-                            extent::getExtentVecEnd<TDim>(buf),
-                            mem::view::getPitchBytes<TDim::value - 1u>(buf)),
+                            mem::view::getPtrNative(view),
+                            dev::getDev(view),
+                            extent::getExtentVecEnd<TDim>(view),
+                            mem::view::getPitchBytes<TDim::value - 1u>(view)),
                         m_extentElements(extent::getExtentVecEnd<TDim>(extentElements)),
-                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(relativeOffsetsElements) + offset::getOffsetsVecEnd<TDim>(buf))
+                        m_vOffsetsElements(offset::getOffsetsVecEnd<TDim>(relativeOffsetsElements) + offset::getOffsetsVecEnd<TDim>(view))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
@@ -186,15 +186,15 @@ namespace alpaka
                         std::is_same<TSize, size::Size<TExtent>>::value,
                         "The size type of TExtent and the TSize template parameter have to be identical!");
                     static_assert(
-                        std::is_same<TSize, size::Size<TBuf>>::value,
-                        "The size type of TBuf and the TSize template parameter have to be identical!");
+                        std::is_same<TSize, size::Size<TView>>::value,
+                        "The size type of TView and the TSize template parameter have to be identical!");
 
-                    assert(extent::getWidth(relativeOffsetsElements) <= extent::getWidth(buf));
-                    assert(extent::getHeight(relativeOffsetsElements) <= extent::getHeight(buf));
-                    assert(extent::getDepth(relativeOffsetsElements) <= extent::getDepth(buf));
-                    assert((offset::getOffsetX(relativeOffsetsElements)+offset::getOffsetX(buf)+extent::getWidth(extentElements)) <= extent::getWidth(buf));
-                    assert((offset::getOffsetY(relativeOffsetsElements)+offset::getOffsetY(buf)+extent::getHeight(extentElements)) <= extent::getHeight(buf));
-                    assert((offset::getOffsetZ(relativeOffsetsElements)+offset::getOffsetZ(buf)+extent::getDepth(extentElements)) <= extent::getDepth(buf));
+                    assert(extent::getWidth(relativeOffsetsElements) <= extent::getWidth(view));
+                    assert(extent::getHeight(relativeOffsetsElements) <= extent::getHeight(view));
+                    assert(extent::getDepth(relativeOffsetsElements) <= extent::getDepth(view));
+                    assert((offset::getOffsetX(relativeOffsetsElements)+offset::getOffsetX(view)+extent::getWidth(extentElements)) <= extent::getWidth(view));
+                    assert((offset::getOffsetY(relativeOffsetsElements)+offset::getOffsetY(view)+extent::getHeight(extentElements)) <= extent::getHeight(view));
+                    assert((offset::getOffsetZ(relativeOffsetsElements)+offset::getOffsetZ(view)+extent::getDepth(extentElements)) <= extent::getDepth(view));
                 }
 
             public:
@@ -246,7 +246,7 @@ namespace alpaka
                 {
                     return
                         dev::getDev(
-                            mem::view::getBuf(view));
+                            view);
                 }
             };
         }
@@ -326,37 +326,6 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The ViewSubView buf trait specialization.
-                //#############################################################################
-                template<
-                    typename TElem,
-                    typename TDim,
-                    typename TDev,
-                    typename TSize>
-                struct GetBuf<
-                    mem::view::ViewSubView<TDev, TElem, TDim, TSize>>
-                {
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::view::ViewSubView<TDev, TElem, TDim, TSize> const & view)
-                    -> typename mem::view::ViewSubView<TDev, TElem, TDim, TSize>::Buf const &
-                    {
-                        return view.m_Buf;
-                    }
-                    //-----------------------------------------------------------------------------
-                    //!
-                    //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST static auto getBuf(
-                        mem::view::ViewSubView<TDev, TElem, TDim, TSize> & view)
-                    -> typename mem::view::ViewSubView<TDev, TElem, TDim, TSize>::Buf &
-                    {
-                        return view.m_Buf;
-                    }
-                };
-
-                //#############################################################################
                 //! The ViewSubView native pointer get trait specialization.
                 //#############################################################################
                 template<
@@ -377,12 +346,11 @@ namespace alpaka
                         mem::view::ViewSubView<TDev, TElem, TDim, TSize> const & view)
                     -> TElem const *
                     {
-                        auto const & buf(mem::view::getBuf(view));
                         // \TODO: pre-calculate this pointer for faster execution.
                         return
                             reinterpret_cast<TElem const *>(
-                                reinterpret_cast<std::uint8_t const *>(mem::view::getPtrNative(buf))
-                                + pitchedOffsetBytes(view, buf, IdxSequence()));
+                                reinterpret_cast<std::uint8_t const *>(mem::view::getPtrNative(view))
+                                + pitchedOffsetBytes(view, view, IdxSequence()));
                     }
                     //-----------------------------------------------------------------------------
                     //!
@@ -391,12 +359,11 @@ namespace alpaka
                         mem::view::ViewSubView<TDev, TElem, TDim, TSize> & view)
                     -> TElem *
                     {
-                        auto & buf(mem::view::getBuf(view));
                         // \TODO: pre-calculate this pointer for faster execution.
                         return
                             reinterpret_cast<TElem *>(
-                                reinterpret_cast<std::uint8_t *>(mem::view::getPtrNative(buf))
-                                + pitchedOffsetBytes(view, buf, IdxSequence()));
+                                reinterpret_cast<std::uint8_t *>(mem::view::getPtrNative(view))
+                                + pitchedOffsetBytes(view, IdxSequence()));
                     }
 
                 private:
@@ -405,34 +372,30 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TView,
-                        typename TBuf,
                         std::size_t... TIndices>
                     ALPAKA_FN_HOST static auto pitchedOffsetBytes(
                         TView const & view,
-                        TBuf const & buf,
                         alpaka::core::detail::integer_sequence<std::size_t, TIndices...> const &)
                     -> TSize
                     {
                         return
                             core::foldr(
                                 std::plus<TSize>(),
-                                pitchedOffsetBytesDim<TIndices>(view, buf)...);
+                                pitchedOffsetBytesDim<TIndices>(view)...);
                     }
                     //-----------------------------------------------------------------------------
                     //!
                     //-----------------------------------------------------------------------------
                     template<
                         std::size_t Tidx,
-                        typename TView,
-                        typename TBuf>
+                        typename TView>
                     ALPAKA_FN_HOST static auto pitchedOffsetBytesDim(
-                        TView const & view,
-                        TBuf const & buf)
+                        TView const & view)
                     -> TSize
                     {
                         return
                             offset::getOffset<Tidx>(view)
-                            * mem::view::getPitchBytes<Tidx + 1u>(buf);
+                            * mem::view::getPitchBytes<Tidx + 1u>(view);
                     }
                 };
 
@@ -458,7 +421,7 @@ namespace alpaka
                     {
                         return
                             mem::view::getPitchBytes<TIdx::value>(
-                                mem::view::getBuf(view));
+                                view);
                     }
                 };
             }

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -288,7 +288,7 @@ struct MatMulTester
         // For 1D data this would not be required because alpaka::mem::view::copy is specialized for std::vector and std::array.
         // For multi dimensional data you could directly create them using alpaka::mem::buf::alloc<Type>(devHost, extent), which is not used here.
         // Instead we use ViewPlainPtr to wrap the data.
-        using BufWrapper = alpaka::mem::buf::ViewPlainPtr<
+        using BufWrapper = alpaka::mem::view::ViewPlainPtr<
             std::decay<decltype(devHost)>::type,
             Val,
             alpaka::dim::DimInt<2u>,


### PR DESCRIPTION
In the course of moving `ViewPlainPtr` in #109 it was missed to change the namespace.
Furthermore, views can not be required to provide an underlying buffer because only `ViewSubView` has one but all others do not. Therefore `mem::view::GetBuf` has been removed.