### PR TITLE
provide blockThread and threadElem extents independently to getBlockSharedExternMemSizeBytes

### DIFF
--- a/include/alpaka/exec/ExecCpuFibers.hpp
+++ b/include/alpaka/exec/ExecCpuFibers.hpp
@@ -146,8 +146,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -158,7 +158,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuFibers<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -121,8 +121,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -133,7 +133,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuOmp2Blocks<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -120,8 +120,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -132,7 +132,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuOmp2Threads<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecCpuOmp4.hpp
+++ b/include/alpaka/exec/ExecCpuOmp4.hpp
@@ -120,8 +120,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -132,7 +132,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuOmp4<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecCpuSerial.hpp
+++ b/include/alpaka/exec/ExecCpuSerial.hpp
@@ -115,8 +115,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -127,7 +127,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuSerial<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecCpuThreads.hpp
+++ b/include/alpaka/exec/ExecCpuThreads.hpp
@@ -144,8 +144,8 @@ namespace alpaka
                     workdiv::getWorkDiv<Grid, Blocks>(*this));
                 auto const blockThreadExtent(
                     workdiv::getWorkDiv<Block, Threads>(*this));
-                auto const blockElemExtent(
-                    workdiv::getWorkDiv<Block, Elems>(*this));
+                auto const threadElemExtent(
+                    workdiv::getWorkDiv<Thread, Elems>(*this));
 
                 // Get the size of the block shared extern memory.
                 auto const blockSharedExternMemSizeBytes(
@@ -156,7 +156,8 @@ namespace alpaka
                                 kernel::getBlockSharedExternMemSizeBytes<
                                     TKernelFnObj,
                                     acc::AccCpuThreads<TDim, TSize>>(
-                                        blockElemExtent,
+                                        blockThreadExtent,
+                                        threadElemExtent,
                                         args...);
                         },
                         m_args));

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -360,7 +360,8 @@ namespace alpaka
                                     kernel::getBlockSharedExternMemSizeBytes<
                                         typename std::decay<TKernelFnObj>::type,
                                         acc::AccGpuCudaRt<TDim, TSize>>(
-                                            blockThreadExtent * threadElemExtent,
+                                            blockThreadExtent,
+                                            threadElemExtent,
                                             args...);
                             },
                             task.m_args));
@@ -500,7 +501,8 @@ namespace alpaka
                                     kernel::getBlockSharedExternMemSizeBytes<
                                         TKernelFnObj,
                                         acc::AccGpuCudaRt<TDim, TSize>>(
-                                            blockThreadExtent * threadElemExtent,
+                                            blockThreadExtent,
+                                            threadElemExtent,
                                             args...);
                             },
                             task.m_args));

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -67,33 +67,16 @@ namespace alpaka
                     typename TDim,
                     typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto getBlockSharedExternMemSizeBytes(
-                    Vec<TDim, size::Size<TAcc>> const & blockElemExtent,
+                    Vec<TDim, size::Size<TAcc>> const & blockThreadExtent,
+                    Vec<TDim, size::Size<TAcc>> const & threadElemExtent,
                     TArgs const & ... args)
                 -> size::Size<TAcc>
                 {
-                    boost::ignore_unused(blockElemExtent);
+                    boost::ignore_unused(blockThreadExtent);
+                    boost::ignore_unused(threadElemExtent);
                     boost::ignore_unused(args...);
 
                     return 0;
-                }
-            };
-
-            //#############################################################################
-            //! The trait for inquiring if the kernel supports vectorization.
-            //! The default implementation returns false.
-            //#############################################################################
-            template<
-                typename TKernelFnObj,
-                typename TSfinae = void>
-            struct SupportsVectorization
-            {
-                //-----------------------------------------------------------------------------
-                //!
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST_ACC static auto supportsVectorization()
-                -> bool
-                {
-                    return false;
                 }
             };
         }
@@ -112,7 +95,8 @@ namespace alpaka
             typename TDim,
             typename... TArgs>
         ALPAKA_FN_HOST_ACC auto getBlockSharedExternMemSizeBytes(
-            Vec<TDim, size::Size<TAcc>> const & blockElemExtent,
+            Vec<TDim, size::Size<TAcc>> const & blockThreadExtent,
+            Vec<TDim, size::Size<TAcc>> const & threadElemExtent,
             TArgs const & ... args)
         -> size::Size<TAcc>
         {
@@ -121,23 +105,9 @@ namespace alpaka
                     TKernelFnObj,
                     TAcc>
                 ::getBlockSharedExternMemSizeBytes(
-                    blockElemExtent,
+                    blockThreadExtent,
+                    threadElemExtent,
                     args...);
-        }
-        //-----------------------------------------------------------------------------
-        //! \return If the kernel supports vectorization.
-        //! The default implementation always returns false.
-        //-----------------------------------------------------------------------------
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<
-            typename TKernelFnObj>
-        ALPAKA_FN_HOST_ACC auto supportsVectorization()
-        -> bool
-        {
-            return
-                traits::SupportsVectorization<
-                    TKernelFnObj>
-                ::supportsVectorization();
         }
     }
 }

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -179,7 +179,8 @@ namespace alpaka
                     typename TIndex,
                     typename TElem>
                 ALPAKA_FN_HOST static auto getBlockSharedExternMemSizeBytes(
-                    TVec const & blockElemExtent,
+                    TVec const & blockThreadExtent,
+                    TVec const & threadElemExtent,
                     TIndex const & m,
                     TIndex const & n,
                     TIndex const & k,
@@ -206,7 +207,7 @@ namespace alpaka
                     boost::ignore_unused(ldc);
 
                     // Reserve the buffer for the two blocks of A and B.
-                    return 2u * blockElemExtent.prod() * sizeof(TElem);
+                    return 2u * blockThreadExtent.prod() * threadElemExtent.prod() * sizeof(TElem);
                 }
             };
         }

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -147,11 +147,12 @@ namespace alpaka
                     typename TVec,
                     typename... TArgs>
                 ALPAKA_FN_HOST static auto getBlockSharedExternMemSizeBytes(
-                    TVec const & blockElemExtent,
+                    TVec const & blockThreadExtent,
+                    TVec const & threadElemExtent,
                     TArgs && ...)
                 -> std::uint32_t
                 {
-                    return blockElemExtent.prod() * sizeof(std::uint32_t);
+                    return blockThreadExtent.prod() * threadElemExtent.prod() * sizeof(std::uint32_t);
                 }
             };
         }


### PR DESCRIPTION
This fixes #110 and additionally removes the never used `SupportsVectorization` trait that had been forgotten to remove.