### PR TITLE
fix boost fibers file renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -407,7 +407,7 @@ install:
     - ALPAKA_BOOST_B2+=" --with-program_options --with-test"
     - if [ "${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE}" == "ON" ]
       ;then
-          ALPAKA_BOOST_B2_CXXFLAGS+=" -std=c++14"
+          ALPAKA_BOOST_B2_CXXFLAGS+=" -std=c++11"
           && ALPAKA_BOOST_B2+=" --with-fiber --with-context --with-thread --with-system --with-atomic --with-chrono --with-date_time"
       ;fi
     - if [ "${ALPAKA_BOOST_B2_CXXFLAGS}" != "" ]

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The **alpaka** library itself just requires header-only libraries.
 However some of the accelerator back-end implementations require different boost libraries to be built.
 
 When an accelerator back-end using *Boost.Fiber* is enabled, the develop branch of boost and the proposed boost library [`boost-fiber`](https://github.com/olk/boost-fiber) (develop branch) are required.
-`boost-fiber`, `boost-context` and all of its dependencies are required to be build in C++14 mode `./b2 cxxflags="-std=c++14"`.
+`boost-fiber`, `boost-context` and all of its dependencies are required to be build in C++11 mode `./b2 cxxflags="-std=c++11"`.
 
 When an accelerator back-end using *CUDA* is enabled, version *7.0* of the *CUDA SDK* is the minimum requirement.
 *NOTE*: When using *CUDA* 7.0, the *CUDA accelerator back-end* can not be enabled together with the *std::thread accelerator back-end* or the *Boost.Fiber accelerator back-end* due to bugs in the nvcc compiler.

--- a/include/alpaka/core/Fibers.hpp
+++ b/include/alpaka/core/Fibers.hpp
@@ -38,12 +38,12 @@
 // Boost fiber:
 // http://olk.github.io/libs/fiber/doc/html/index.html
 // https://github.com/olk/boost-fiber
-#include <boost/fiber/fiber.hpp>        // boost::fibers::fiber
-#include <boost/fiber/operations.hpp>   // boost::this_fiber
-#include <boost/fiber/condition.hpp>    // boost::fibers::condition_variable
-#include <boost/fiber/mutex.hpp>        // boost::fibers::mutex
-#include <boost/fiber/future.hpp>       // boost::fibers::future
-//#include <boost/fiber/barrier.hpp>    // boost::fibers::barrier
+#include <boost/fiber/fiber.hpp>                // boost::fibers::fiber
+#include <boost/fiber/operations.hpp>           // boost::this_fiber
+#include <boost/fiber/condition_variable.hpp>   // boost::fibers::condition_variable
+#include <boost/fiber/mutex.hpp>                // boost::fibers::mutex
+#include <boost/fiber/future.hpp>               // boost::fibers::future
+//#include <boost/fiber/barrier.hpp>            // boost::fibers::barrier
 
 #if BOOST_COMP_MSVC
     #undef NOMINMAX


### PR DESCRIPTION
Within the Boost.Fiber repository the `condition.hpp` header has been renamed to `condition_variable.hpp`.
Furthermore the library requirements have been relaxed to C++11 instead of C++14.