### PR TITLE
Add tests for block shared memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -492,6 +492,7 @@ script:
     - ./travis/compileExec.sh "test/unit/meta/" ./meta
     - ./travis/compileExec.sh "test/unit/acc/" ./acc
     - ./travis/compileExec.sh "test/unit/kernel/" ./kernel
+    - ./travis/compileExec.sh "test/unit/block/shared/" ./blockShared
     - ./travis/compileExec.sh "test/unit/mem/view/" ./memView
 
     #-------------------------------------------------------------------------------

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ PROJECT("alpakaUnitTest")
 ################################################################################
 
 ADD_SUBDIRECTORY("acc/")
+ADD_SUBDIRECTORY("block/shared/")
 ADD_SUBDIRECTORY("kernel/")
 ADD_SUBDIRECTORY("mem/view/")
 ADD_SUBDIRECTORY("meta/")

--- a/test/unit/block/shared/CMakeLists.txt
+++ b/test/unit/block/shared/CMakeLists.txt
@@ -1,0 +1,83 @@
+#
+# Copyright 2014-2015 Benjamin Worpitz
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required CMake version.
+################################################################################
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+
+SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+################################################################################
+
+SET(_SOURCE_DIR "src/")
+SET(_TARGET_NAME "blockShared")
+
+PROJECT(${_TARGET_NAME})
+
+#-------------------------------------------------------------------------------
+# Find alpaka test common.
+#-------------------------------------------------------------------------------
+
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../common/" CACHE STRING  "The location of the alpaka test common library")
+
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE("common" REQUIRED)
+
+#-------------------------------------------------------------------------------
+# Boost.Test.
+#-------------------------------------------------------------------------------
+FIND_PACKAGE(Boost QUIET COMPONENTS unit_test_framework)
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+
+ELSE()
+    LIST(APPEND _INCLUDE_DIRECTORIES_PRIVATE ${Boost_INCLUDE_DIRS})
+    LIST(APPEND _LINK_LIBRARIES_PRIVATE ${Boost_LIBRARIES})
+ENDIF()
+
+#-------------------------------------------------------------------------------
+# Add library.
+#-------------------------------------------------------------------------------
+
+# Add all the source files in all recursive subdirectories and group them accordingly.
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE)
+
+INCLUDE_DIRECTORIES(
+    ${_INCLUDE_DIRECTORIES_PRIVATE}
+    ${common_INCLUDE_DIRS})
+ADD_DEFINITIONS(
+    ${common_DEFINITIONS})
+# Always add all files to the target executable build call to add them to the build project.
+ALPAKA_ADD_EXECUTABLE(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+# Set the link libraries for this library (adds libs, include directories, defines and compile options).
+TARGET_LINK_LIBRARIES(
+    ${_TARGET_NAME}
+    PUBLIC "common" ${_LINK_LIBRARIES_PRIVATE})
+
+SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+ENABLE_TESTING()
+ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -1,0 +1,123 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/stream/Stream.hpp>            // alpaka::test::stream::DefaultStream
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/test/unit_test.hpp>
+
+//#############################################################################
+//!
+//#############################################################################
+class BlockSharedMemDyn
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        // Assure that the pointer is non null.
+        auto && a = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), a);
+
+        // Each call should return the same pointer ...
+        auto && b = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
+        BOOST_REQUIRE_EQUAL(a, b);
+
+        // ... even for different types.
+        auto && c = alpaka::block::shared::dyn::getMem<float>(acc);
+        BOOST_REQUIRE_EQUAL(a, reinterpret_cast<std::uint32_t *>(c));
+    }
+};
+
+namespace alpaka
+{
+    namespace kernel
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The trait for getting the size of the block shared dynamic memory for a kernel.
+            //#############################################################################
+            template<
+                typename TAcc>
+            struct BlockSharedMemDynSizeBytes<
+                BlockSharedMemDyn,
+                TAcc>
+            {
+                //-----------------------------------------------------------------------------
+                //! \return The size of the shared memory allocated for a block.
+                //-----------------------------------------------------------------------------
+                template<
+                    typename TVec>
+                ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
+                    TVec const & blockThreadExtent,
+                    TVec const & threadElemExtent)
+                -> size::Size<TAcc>
+                {
+                    return sizeof(std::uint32_t) * blockThreadExtent.prod() * threadElemExtent.prod();
+                }
+            };
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE(blockSharedMemDyn)
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    sameNonNullAdress,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::Vec<Dim, Size>::ones());
+
+    BlockSharedMemDyn kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -1,0 +1,141 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/stream/Stream.hpp>            // alpaka::test::stream::DefaultStream
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(blockSharedMemSt)
+
+                                                                                                                                #include <iostream>
+//#############################################################################
+//!
+//#############################################################################
+class BlockSharedMemStNonNullTestKernel
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &a);
+
+        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &b);
+
+        auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<float *>(nullptr), &c);
+
+        auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<double *>(nullptr), &d);
+
+        auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint64_t *>(nullptr), &e);
+    }
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    nonNull,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::Vec<Dim, Size>::ones());
+
+    BlockSharedMemStNonNullTestKernel kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+
+//#############################################################################
+//!
+//#############################################################################
+class BlockSharedMemStSameTypeDifferentAdressTestKernel
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(&a, &b);
+        auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(&b,&c);
+    }
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    sameTypeDifferentAdress,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::Vec<Dim, Size>::ones());
+
+    BlockSharedMemStSameTypeDifferentAdressTestKernel kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/block/shared/src/main.cpp
+++ b/test/unit/block/shared/src/main.cpp
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE blockShared
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This test application can be used to test if #85 is supported by all compilers, platforms and runtimes.