### PR TITLE
Remove exception handling from vectorAdd example

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -347,5 +347,5 @@ int main() {
     /**
      * No copy failure, so lets return :)
      */
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/example/helloWorld/src/helloworld.cpp
+++ b/example/helloWorld/src/helloworld.cpp
@@ -201,5 +201,5 @@ int main() {
     /**
      * Everything is fine, so lets return :)
      */
-    return 0;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I have removed the exception handling and the initial console printing from the vectorAdd example for simplification.