### PR TITLE
fix endless ViewSubView recursions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -249,7 +249,7 @@ install:
                   if (( ${ALPAKA_CUDA_VER_MAJOR} > 6 ))
                   ;then
                       export ALPAKA_ACC_GPU_CUDA_ENABLE=OFF
-                      && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because CUDA 7.0 does not support the gcc version!
+                      && echo ALPAKA_ACC_GPU_CUDA_ENABLE=${ALPAKA_ACC_GPU_CUDA_ENABLE} because CUDA 7.x does not support the gcc version!
                   ;fi
               ;fi
           ;fi
@@ -355,7 +355,7 @@ install:
     - git clone -b ${ALPAKA_BOOST_BRANCH} --recursive --single-branch --depth 1 https://github.com/boostorg/boost.git boost
     - cd boost/
     - export ALPAKA_BOOST_ROOT_DIR=`pwd`
-    - echo "${ALPAKA_BOOST_ROOT_DIR}"
+    - echo "ALPAKA_BOOST_ROOT_DIR=${ALPAKA_BOOST_ROOT_DIR}"
 
     - cd libs/
 
@@ -377,7 +377,7 @@ install:
     - cd boost_libs/
     - mkdir x64
     - export ALPAKA_BOOST_LIB_DIR=`pwd`/x64/lib
-    - echo "${ALPAKA_BOOST_LIB_DIR}"
+    - echo "ALPAKA_BOOST_LIB_DIR=${ALPAKA_BOOST_LIB_DIR}"
     - cd ../
     - cd boost/
 
@@ -391,7 +391,7 @@ install:
     - if [ "${CXX}" == "clang++" ]
       ;then
           export ALPAKA_BOOST_COMPILER=-clang${ALPAKA_CLANG_VER_MAJOR}${ALPAKA_CLANG_VER_MINOR}
-          && echo "${ALPAKA_BOOST_COMPILER}"
+          && echo "ALPAKA_BOOST_COMPILER=${ALPAKA_BOOST_COMPILER}"
           && ALPAKA_BOOST_B2_CXXFLAGS+="-Wno-unused-local-typedef -Wno-c99-extensions -Wno-variadic-macros -Wunknown-warning-option"
       ;fi
     # Select the libraries required.
@@ -409,7 +409,7 @@ install:
       ;fi
     - ALPAKA_BOOST_B2+=" --stagedir=../boost_libs/x64 stage"
     # Build boost.
-    - echo "${ALPAKA_BOOST_B2}"
+    - echo "ALPAKA_BOOST_B2=${ALPAKA_BOOST_B2}"
     - eval "${ALPAKA_BOOST_B2}"
 
     # Clean the intermediate build files.
@@ -487,10 +487,8 @@ script:
     #-------------------------------------------------------------------------------
     # Build and execute all unit tests (beginning with most general libraries).
     - ./travis/compileExec.sh "test/unit/meta/" ./meta
-    # Currently this test spams the nvcc output with
-    # warning: calling a __host__ function from a __host__ __device__ function is not allowed
-    # This renders the CI compile times unusable.
-    - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/acc/" ./acc ;fi
+    - ./travis/compileExec.sh "test/unit/acc/" ./acc
+    - ./travis/compileExec.sh "test/unit/mem/view/" ./memView
 
     #-------------------------------------------------------------------------------
     # Build and execute all integration tests.

--- a/example/bufferCopy/CMakeLists.txt
+++ b/example/bufferCopy/CMakeLists.txt
@@ -26,7 +26,7 @@ cmake_minimum_required(VERSION 3.0.1)
 ################################################################################
 # Find alpaka
 ################################################################################
-set(ALPAKA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" CACHE STRING  "The location of the alpaka library")
+set(ALPAKA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" CACHE STRING "The location of the alpaka library")
 list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 
 find_package("alpaka" REQUIRED)

--- a/example/helloWorld/CMakeLists.txt
+++ b/example/helloWorld/CMakeLists.txt
@@ -26,7 +26,7 @@ cmake_minimum_required(VERSION 3.0.1)
 ################################################################################
 # Find alpaka
 ################################################################################
-set(ALPAKA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" CACHE STRING  "The location of the alpaka library")
+set(ALPAKA_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../" CACHE STRING "The location of the alpaka library")
 list(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 
 find_package("alpaka" REQUIRED)

--- a/example/vectorAdd/CMakeLists.txt
+++ b/example/vectorAdd/CMakeLists.txt
@@ -39,7 +39,7 @@ PROJECT(${_TARGET_NAME})
 # Find alpaka.
 #-------------------------------------------------------------------------------
 
-SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING  "The location of the alpaka library")
+SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of the alpaka library")
 
 LIST(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 FIND_PACKAGE("alpaka" REQUIRED)

--- a/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
@@ -29,7 +29,7 @@
 
 #include <alpaka/idx/Traits.hpp>            // idx::getIdx
 
-#include <alpaka/vec/Vec.hpp>               // Vec, offset::getOffsetsVecEnd
+#include <alpaka/vec/Vec.hpp>               // Vec, offset::getOffsetVecEnd
 #include <alpaka/core/Cuda.hpp>             // getOffset(dim3)
 
 //#include <boost/core/ignore_unused.hpp>   // boost::ignore_unused
@@ -122,7 +122,7 @@ namespace alpaka
                 -> Vec<TDim, TSize>
                 {
                     //boost::ignore_unused(idx);
-                    return vec::cast<TSize>(offset::getOffsetsVecEnd<TDim>(threadIdx));
+                    return vec::cast<TSize>(offset::getOffsetVecEnd<TDim>(threadIdx));
                 }
             };
         }

--- a/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
@@ -29,7 +29,7 @@
 
 #include <alpaka/idx/Traits.hpp>            // idx::getIdx
 
-#include <alpaka/vec/Vec.hpp>               // Vec, offset::getOffsetsVecEnd
+#include <alpaka/vec/Vec.hpp>               // Vec, offset::getOffsetVecEnd
 #include <alpaka/core/Cuda.hpp>             // getOffset(dim3)
 
 //#include <boost/core/ignore_unused.hpp>   // boost::ignore_unused
@@ -122,7 +122,7 @@ namespace alpaka
                 -> Vec<TDim, TSize>
                 {
                     //boost::ignore_unused(idx);
-                    return vec::cast<TSize>(offset::getOffsetsVecEnd<TDim>(blockIdx));
+                    return vec::cast<TSize>(offset::getOffsetVecEnd<TDim>(blockIdx));
                 }
             };
         }

--- a/include/alpaka/meta/IntegerSequence.hpp
+++ b/include/alpaka/meta/IntegerSequence.hpp
@@ -85,6 +85,46 @@ namespace alpaka
             typename TIntegerSequence>
         using ConvertIntegerSequence = typename detail::ConvertIntegerSequence<TDstType, TIntegerSequence>::type;
 
+        namespace detail
+        {
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<
+                template<typename...> class TList,
+                typename T,
+                template<T> class TOp,
+                typename TIntegerSequence>
+            struct TransformIntegerSequence;
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<
+                template<typename...> class TList,
+                typename T,
+                template<T> class TOp,
+                T... Tvals>
+            struct TransformIntegerSequence<
+                TList,
+                T,
+                TOp,
+                IntegerSequence<T, Tvals...>>
+            {
+                using type =
+                    TList<
+                        TOp<Tvals>...>;
+            };
+        }
+        //#############################################################################
+        //!
+        //#############################################################################
+        template<
+            template<typename...> class TList,
+            typename T,
+            template<T> class TOp,
+            typename TIntegerSequence>
+        using TransformIntegerSequence = typename detail::TransformIntegerSequence<TList, T, TOp, TIntegerSequence>::type;
+
 
         template<bool TisSizeNegative, bool TbIsBegin, typename T, T Tbegin, typename TIntCon, typename TIntSeq>
         struct MakeIntegerSequenceHelper

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -444,7 +444,11 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto prod() const
         -> TSize
         {
-            return foldrAll(std::multiplies<TSize>());
+            return foldrAll(
+                [](TSize a, TSize b)
+                {
+                    return a * b;
+                });
         }
         //-----------------------------------------------------------------------------
         //! \return The sum of all values.
@@ -453,7 +457,11 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto sum() const
         -> TSize
         {
-            return foldrAll(std::plus<TSize>());
+            return foldrAll(
+                [](TSize a, TSize b)
+                {
+                    return a + b;
+                });
         }
         //-----------------------------------------------------------------------------
         //! \return The min of all values.
@@ -465,7 +473,7 @@ namespace alpaka
             return foldrAll(
                 [](TSize a, TSize b)
                 {
-                    return std::min(a,b);
+                    return (b < a) ? b : a;
                 });
         }
         //-----------------------------------------------------------------------------
@@ -478,14 +486,13 @@ namespace alpaka
             return foldrAll(
                 [](TSize a, TSize b)
                 {
-                    return std::max(a,b);
+                    return (b > a) ? b : a;
                 });
         }
         //-----------------------------------------------------------------------------
         //! \return The index of the minimal element.
         //-----------------------------------------------------------------------------
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto minElem() const
+        ALPAKA_FN_HOST auto minElem() const
         -> typename TDim::value_type
         {
             return
@@ -499,8 +506,7 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         //! \return The index of the maximal element.
         //-----------------------------------------------------------------------------
-        ALPAKA_NO_HOST_ACC_WARNING
-        ALPAKA_FN_HOST_ACC auto maxElem() const
+        ALPAKA_FN_HOST auto maxElem() const
         -> typename TDim::value_type
         {
             return
@@ -873,7 +879,7 @@ namespace alpaka
             };
         }
         //-----------------------------------------------------------------------------
-        //! \return The extent.
+        //! \return The extent vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<
@@ -945,12 +951,12 @@ namespace alpaka
             };
         }
         //-----------------------------------------------------------------------------
-        //! \return The offsets.
+        //! \return The offset vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename TOffsets>
-        ALPAKA_FN_HOST_ACC auto getOffsetsVec(
+        ALPAKA_FN_HOST_ACC auto getOffsetVec(
             TOffsets const & offsets = TOffsets())
         -> Vec<dim::Dim<TOffsets>, size::Size<TOffsets>>
         {
@@ -966,13 +972,13 @@ namespace alpaka
                         offsets);
         }
         //-----------------------------------------------------------------------------
-        //! \return The offsets vector but only the last N elements.
+        //! \return The offset vector but only the last N elements.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename TDim,
             typename TOffsets>
-        ALPAKA_FN_HOST_ACC auto getOffsetsVecEnd(
+        ALPAKA_FN_HOST_ACC auto getOffsetVecEnd(
             TOffsets const & offsets = TOffsets())
         -> Vec<TDim, size::Size<TOffsets>>
         {

--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -39,7 +39,7 @@ PROJECT(${_TARGET_NAME})
 # Find alpaka.
 #-------------------------------------------------------------------------------
 
-SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../" CACHE STRING  "The location of the alpaka library")
+SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../" CACHE STRING "The location of the alpaka library")
 
 LIST(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 FIND_PACKAGE("alpaka" REQUIRED)
@@ -61,6 +61,10 @@ IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
 ELSE()
     LIST(APPEND _INCLUDE_DIRECTORIES_PRIVATE ${Boost_INCLUDE_DIRS})
     LIST(APPEND _LINK_LIBRARIES_PRIVATE ${Boost_LIBRARIES})
+
+    IF(NOT Boost_USE_STATIC_LIBS)
+        LIST(APPEND _DEFINITIONS_PRIVATE "-DBOOST_TEST_DYN_LINK")
+    ENDIF()
 ENDIF()
 
 #-------------------------------------------------------------------------------
@@ -99,6 +103,7 @@ INCLUDE_DIRECTORIES(
     ${_INCLUDE_DIRECTORIES_PRIVATE}
     ${alpaka_INCLUDE_DIRS})
 ADD_DEFINITIONS(
+    ${_DEFINITIONS_PRIVATE}
     ${alpaka_DEFINITIONS} ${ALPAKA_DEV_COMPILE_OPTIONS})
 # Always add all files to the target executable build call to add them to the build project.
 ALPAKA_ADD_EXECUTABLE(

--- a/test/common/commonConfig.cmake
+++ b/test/common/commonConfig.cmake
@@ -39,7 +39,7 @@ UNSET(common_LIBRARIES)
 UNSET(_COMMON_FOUND)
 UNSET(_COMMON_INCLUDE_DIRECTORY)
 UNSET(_COMMON_SOURCE_DIRECTORY)
-UNSET(_COMMON_PROJECT_NAME)
+UNSET(_COMMON_TARGET_NAME)
 UNSET(_COMMON_FILES_HEADER)
 UNSET(_COMMON_FILES_SOURCE)
 UNSET(_COMMON_FILES_CMAKE)
@@ -52,15 +52,15 @@ GET_FILENAME_COMPONENT(_COMMON_ROOT_DIR "${_COMMON_ROOT_DIR}" ABSOLUTE)
 # Set found to true initially and set it to false if a required dependency is missing.
 SET(_COMMON_FOUND TRUE)
 
-SET(_COMMON_PROJECT_NAME "common")
+SET(_COMMON_TARGET_NAME "common")
 
-PROJECT(${_COMMON_PROJECT_NAME})
+PROJECT(${_COMMON_TARGET_NAME})
 
 #-------------------------------------------------------------------------------
 # Find alpaka.
 #-------------------------------------------------------------------------------
 
-SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING  "The location of the alpaka library")
+SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../" CACHE STRING "The location of the alpaka library")
 
 LIST(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
 FIND_PACKAGE("alpaka" REQUIRED)
@@ -95,22 +95,22 @@ LIST(APPEND _COMMON_FILES_CMAKE "${_COMMON_ROOT_DIR}/commonConfig.cmake" "${_COM
 #-------------------------------------------------------------------------------
 # Target.
 #-------------------------------------------------------------------------------
-IF(NOT TARGET ${_COMMON_PROJECT_NAME})
+IF(NOT TARGET ${_COMMON_TARGET_NAME})
     INCLUDE_DIRECTORIES(
         ${common_INCLUDE_DIRS})
     ADD_DEFINITIONS(
         ${common_DEFINITIONS})
     # Always add all files to the target executable build call to add them to the build project.
     ADD_LIBRARY(
-        ${_COMMON_PROJECT_NAME}
+        ${_COMMON_TARGET_NAME}
         STATIC
         ${_COMMON_FILES_HEADER} ${_COMMON_FILES_SOURCE} ${_COMMON_FILES_CMAKE})
     # Set the link libraries for this library (adds libs, include directories, defines and compile options).
     TARGET_LINK_LIBRARIES(
-        ${_COMMON_PROJECT_NAME}
+        ${_COMMON_TARGET_NAME}
         PUBLIC "alpaka" ${common_LIBRARIES})
     SET_TARGET_PROPERTIES(
-        ${_COMMON_PROJECT_NAME}
+        ${_COMMON_TARGET_NAME}
         PROPERTIES FOLDER "test")
 ENDIF()
 
@@ -125,7 +125,7 @@ IF(NOT _COMMON_FOUND)
     UNSET(_COMMON_FOUND)
     UNSET(_COMMON_INCLUDE_DIRECTORY)
     UNSET(_COMMON_SOURCE_DIRECTORY)
-    UNSET(_COMMON_PROJECT_NAME)
+    UNSET(_COMMON_TARGET_NAME)
     UNSET(_COMMON_FILES_HEADER)
     UNSET(_COMMON_FILES_SOURCE)
     UNSET(_COMMON_FILES_CMAKE)
@@ -142,6 +142,6 @@ ENDIF()
 # Handles the REQUIRED, QUIET and version-related arguments for FIND_PACKAGE.
 INCLUDE(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-    ${_COMMON_PROJECT_NAME}
+    ${_COMMON_TARGET_NAME}
     FOUND_VAR common_FOUND
     REQUIRED_VARS common_INCLUDE_DIR)

--- a/test/common/include/alpaka/test/acc/Acc.hpp
+++ b/test/common/include/alpaka/test/acc/Acc.hpp
@@ -27,6 +27,13 @@
 #include <type_traits>                      // std::is_class
 #include <iosfwd>                           // std::ostream
 
+
+// When compiling the tests with nvcc on th CI infrastructure we have to dramatically reduce the number of tested combinations.
+// Else the log length would be exceeded.
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDACC__) && ALPAKA_INTEGRATION_TEST
+    #define ALPAKA_CUDA_INTEGRATION_TEST
+#endif
+
 namespace alpaka
 {
     //-----------------------------------------------------------------------------
@@ -44,7 +51,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             namespace detail
             {
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED)
                 template<
                     typename TDim,
                     typename TSize>
@@ -55,7 +62,7 @@ namespace alpaka
                     typename TSize>
                 using AccCpuSerialIfAvailableElseVoid = int;
 #endif
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED) && !defined(ALPAKA_CUDA_INTEGRATION_TEST)
                 template<
                     typename TDim,
                     typename TSize>
@@ -66,7 +73,7 @@ namespace alpaka
                     typename TSize>
                 using AccCpuThreadsIfAvailableElseVoid = int;
 #endif
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLED)
                 template<
                     typename TDim,
                     typename TSize>
@@ -77,7 +84,7 @@ namespace alpaka
                     typename TSize>
                 using AccCpuFibersIfAvailableElseVoid = int;
 #endif
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#if defined(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED)
                 template<
                     typename TDim,
                     typename TSize>
@@ -88,7 +95,7 @@ namespace alpaka
                     typename TSize>
                 using AccCpuOmp2BlocksIfAvailableElseVoid = int;
 #endif
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#if defined(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED) && !defined(ALPAKA_CUDA_INTEGRATION_TEST)
                 template<
                     typename TDim,
                     typename TSize>
@@ -99,7 +106,7 @@ namespace alpaka
                     typename TSize>
                 using AccCpuOmp2ThreadsIfAvailableElseVoid = int;
 #endif
-#ifdef ALPAKA_ACC_CPU_BT_OMP4_ENABLED
+#if defined(ALPAKA_ACC_CPU_BT_OMP4_ENABLED) && !defined(ALPAKA_CUDA_INTEGRATION_TEST)
                 template<
                     typename TDim,
                     typename TSize>
@@ -194,6 +201,33 @@ namespace alpaka
 
             namespace detail
             {
+#if defined(ALPAKA_CUDA_INTEGRATION_TEST)
+                //#############################################################################
+                //! A std::tuple holding dimensions.
+                //#############################################################################
+                using TestDims =
+                    std::tuple<
+                        alpaka::dim::DimInt<1u>,
+                        //alpaka::dim::DimInt<2u>,
+                        alpaka::dim::DimInt<3u>/*,
+                        alpaka::dim::DimInt<4u>*/>;
+
+                //#############################################################################
+                //! A std::tuple holding size types.
+                //#############################################################################
+                using TestSizes =
+                    std::tuple<
+                        std::size_t,
+                        //std::int64_t,
+                        std::uint64_t,
+                        std::int32_t,
+                        //std::uint32_t,
+                        //std::int16_t,
+                        std::uint16_t/*,
+                        std::int8_t,
+                        std::uint8_t*/>;
+#else
+
                 //#############################################################################
                 //! A std::tuple holding dimensions.
                 //#############################################################################
@@ -202,7 +236,11 @@ namespace alpaka
                         alpaka::dim::DimInt<1u>,
                         alpaka::dim::DimInt<2u>,
                         alpaka::dim::DimInt<3u>,
-                        alpaka::dim::DimInt<4u>>;
+                // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
+#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDACC__))
+                        alpaka::dim::DimInt<4u>
+#endif
+                    >;
 
                 //#############################################################################
                 //! A std::tuple holding size types.
@@ -215,9 +253,10 @@ namespace alpaka
                         std::int32_t,
                         std::uint32_t,
                         std::int16_t,
-                        std::uint16_t,
+                        std::uint16_t/*,
                         std::int8_t,
-                        std::uint8_t>;
+                        std::uint8_t*/>;
+#endif
 
                 //#############################################################################
                 //! A std::tuple holding multiple std::tuple consisting of a dimension and a size type.

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -31,4 +31,5 @@ PROJECT("alpakaUnitTest")
 ################################################################################
 
 ADD_SUBDIRECTORY("acc/")
+ADD_SUBDIRECTORY("mem/view/")
 ADD_SUBDIRECTORY("meta/")

--- a/test/unit/acc/CMakeLists.txt
+++ b/test/unit/acc/CMakeLists.txt
@@ -54,6 +54,10 @@ IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
 ELSE()
     LIST(APPEND _INCLUDE_DIRECTORIES_PRIVATE ${Boost_INCLUDE_DIRS})
     LIST(APPEND _LINK_LIBRARIES_PRIVATE ${Boost_LIBRARIES})
+
+    IF(NOT Boost_USE_STATIC_LIBS)
+        LIST(APPEND _DEFINITIONS_PRIVATE "-DBOOST_TEST_DYN_LINK")
+    ENDIF()
 ENDIF()
 
 #-------------------------------------------------------------------------------
@@ -67,6 +71,7 @@ INCLUDE_DIRECTORIES(
     ${_INCLUDE_DIRECTORIES_PRIVATE}
     ${common_INCLUDE_DIRS})
 ADD_DEFINITIONS(
+    ${_DEFINITIONS_PRIVATE}
     ${common_DEFINITIONS})
 # Always add all files to the target executable build call to add them to the build project.
 ALPAKA_ADD_EXECUTABLE(

--- a/test/unit/mem/view/CMakeLists.txt
+++ b/test/unit/mem/view/CMakeLists.txt
@@ -31,25 +31,18 @@ SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 ################################################################################
 
 SET(_SOURCE_DIR "src/")
-SET(_TARGET_NAME "meta")
+SET(_TARGET_NAME "memView")
 
 PROJECT(${_TARGET_NAME})
 
 #-------------------------------------------------------------------------------
-# Find alpaka.
+# Find alpaka test common.
 #-------------------------------------------------------------------------------
 
-SET(ALPAKA_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../" CACHE STRING "The location of the alpaka library")
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../../common/" CACHE STRING  "The location of the alpaka test common library")
 
-LIST(APPEND CMAKE_MODULE_PATH "${ALPAKA_ROOT}")
-FIND_PACKAGE("alpaka" REQUIRED)
-
-#-------------------------------------------------------------------------------
-# Common.
-#-------------------------------------------------------------------------------
-
-INCLUDE("${ALPAKA_ROOT}cmake/common.cmake")
-INCLUDE("${ALPAKA_ROOT}cmake/dev.cmake")
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE("common" REQUIRED)
 
 #-------------------------------------------------------------------------------
 # Boost.Test.
@@ -76,10 +69,10 @@ append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE)
 
 INCLUDE_DIRECTORIES(
     ${_INCLUDE_DIRECTORIES_PRIVATE}
-    ${alpaka_INCLUDE_DIRS})
+    ${common_INCLUDE_DIRS})
 ADD_DEFINITIONS(
     ${_DEFINITIONS_PRIVATE}
-    ${alpaka_DEFINITIONS})
+    ${common_DEFINITIONS})
 # Always add all files to the target executable build call to add them to the build project.
 ALPAKA_ADD_EXECUTABLE(
     ${_TARGET_NAME}
@@ -87,7 +80,7 @@ ALPAKA_ADD_EXECUTABLE(
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 TARGET_LINK_LIBRARIES(
     ${_TARGET_NAME}
-    PUBLIC "alpaka" ${_LINK_LIBRARIES_PRIVATE})
+    PUBLIC "common" ${_LINK_LIBRARIES_PRIVATE})
 
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -1,0 +1,269 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>      // alpaka::test::acc::TestAccs
+
+#include <boost/test/unit_test.hpp>
+
+#include <type_traits>                  // std::is_same
+
+BOOST_AUTO_TEST_SUITE(acc)
+
+
+//#############################################################################
+//!
+//#############################################################################
+struct CheckPitchBytesIdentical
+{
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    CheckPitchBytesIdentical()
+    {};
+
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    template<
+        typename TIdx,
+        typename TView1,
+        typename TView2>
+    auto operator()(
+        TView1 const & view1,
+        TView2 const & view2) const
+    -> void
+    {
+        BOOST_REQUIRE_EQUAL(
+            alpaka::mem::view::getPitchBytes<TIdx::value>(view1),
+            alpaka::mem::view::getPitchBytes<TIdx::value>(view2));
+    }
+};
+
+//#############################################################################
+//!
+//#############################################################################
+struct CheckPitchBytesIdentical2
+{
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    CheckPitchBytesIdentical2()
+    {};
+
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    template<
+        typename TIdx,
+        typename TDim,
+        typename TSize,
+        typename TView2>
+    auto operator()(
+        alpaka::Vec<TDim, TSize> const & vec,
+        TView2 const & view2) const
+    -> void
+    {
+        BOOST_REQUIRE_EQUAL(
+            vec[TIdx::value],
+            alpaka::mem::view::getPitchBytes<TIdx::value>(view2));
+    }
+};
+
+//#############################################################################
+//! 1D: sizeof(TSize) * (5)
+//! 2D: sizeof(TSize) * (5, 4)
+//! 3D: sizeof(TSize) * (5, 4, 3)
+//! 4D: sizeof(TSize) * (5, 4, 3, 2)
+//#############################################################################
+template<
+    std::size_t Tidx>
+struct CreateExtentBufVal
+{
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    template<
+        typename TSize>
+    static auto create(
+        TSize)
+    -> TSize
+    {
+        return sizeof(TSize) * (5u - Tidx);
+    }
+};
+
+//#############################################################################
+//! 1D: sizeof(TSize) * (4)
+//! 2D: sizeof(TSize) * (4, 3)
+//! 3D: sizeof(TSize) * (4, 3, 2)
+//! 4D: sizeof(TSize) * (4, 3, 2, 1)
+//#############################################################################
+template<
+    std::size_t Tidx>
+struct CreateExtentViewVal
+{
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    template<
+        typename TSize>
+    static auto create(
+        TSize)
+    -> TSize
+    {
+        return sizeof(TSize) * (4u - Tidx);
+    }
+};
+
+//-----------------------------------------------------------------------------
+//!
+//-----------------------------------------------------------------------------
+template<
+    typename TDim,
+    typename TSize,
+    template<std::size_t> class TCreate>
+static auto createVecFromIndexedFn()
+-> alpaka::Vec<TDim, TSize>
+{
+    return
+#ifdef ALPAKA_CREATE_VEC_IN_CLASS
+        alpaka::Vec<TDim, TSize>::template
+#else
+        alpaka::
+#endif
+        createVecFromIndexedFn<
+#ifndef ALPAKA_CREATE_VEC_IN_CLASS
+            TDim,
+#endif
+            TCreate>(
+                TSize());
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    basicViewSubViewOperations,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dev = alpaka::dev::Dev<TAcc>;
+    using Elem = float;
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    using View = alpaka::mem::view::ViewSubView<Dev, Elem, Dim, Size>;
+
+    Dev dev(alpaka::dev::DevMan<TAcc>::getDevByIdx(0u));
+
+    // We have to be careful with the extents used.
+    // When Size is a 8 bit signed integer and Dim is 4, the extent is extremely limited.
+    auto const extentBuf(createVecFromIndexedFn<Dim, Size, CreateExtentBufVal>());
+    auto buf(alpaka::mem::buf::alloc<Elem, Size>(dev, extentBuf));
+
+    // TODO: Test failing cases of view extents larger then the underlying buffer extents.
+    auto const extentView(createVecFromIndexedFn<Dim, Size, CreateExtentViewVal>());
+    auto const offsetView(alpaka::Vec<Dim, Size>::all(sizeof(Size)));
+    View view(buf, extentView, offsetView);
+
+    //-----------------------------------------------------------------------------
+    // alpaka::dev::traits::DevType
+    static_assert(
+        std::is_same<alpaka::dev::Dev<View>, Dev>::value,
+        "The device type of the view has to be equal to the specified one.");
+    //-----------------------------------------------------------------------------
+    // alpaka::dev::traits::GetDev
+    BOOST_REQUIRE(
+        dev == alpaka::dev::getDev(view));
+
+    //-----------------------------------------------------------------------------
+    // alpaka::dim::traits::DimType
+    static_assert(
+        alpaka::dim::Dim<View>::value == Dim::value,
+        "The dimensionality of the view has to be equal to the specified one.");
+
+    //-----------------------------------------------------------------------------
+    // alpaka::elem::traits::ElemType
+    static_assert(
+        std::is_same<alpaka::elem::Elem<View>, Elem>::value,
+        "The element type of the view has to be equal to the specified one.");
+
+    //-----------------------------------------------------------------------------
+    // alpaka::extent::traits::GetExtent
+    BOOST_REQUIRE_EQUAL(
+        extentView,
+        alpaka::extent::getExtentVec(view));
+
+    //-----------------------------------------------------------------------------
+    // alpaka::mem::view::traits::GetPitchBytes
+    // The pitch of the view has to be identical to the pitch of the underlying buffer in all dimensions.
+    using IdxSequence1 = alpaka::meta::MakeIndexSequence<Dim::value + 1u>;
+    using DimSequence1 = alpaka::meta::TransformIntegerSequence<std::tuple, std::size_t, alpaka::dim::DimInt, IdxSequence1>;
+    CheckPitchBytesIdentical const checkPitchBytesIdentical;
+    alpaka::meta::forEachType<
+        DimSequence1>(
+            checkPitchBytesIdentical,
+            buf,
+            view);
+
+    // The pitches have to be exactly the values we calculate here.
+    auto pitches(alpaka::Vec<alpaka::dim::DimInt<Dim::value + 1u>, Size>::ones());
+    // Initialize the pitch between two elements of the X dimension ...
+    pitches[Dim::value] = sizeof(Elem);
+    // ... and fill all the other dimensions.
+    for(Size i = Dim::value; i > static_cast<Size>(0u); --i)
+    {
+        pitches[i-1] = extentBuf[i-1] * pitches[i];
+    }
+    CheckPitchBytesIdentical2 const checkPitchBytesIdentical2;
+    alpaka::meta::forEachType<
+        DimSequence1>(
+            checkPitchBytesIdentical2,
+            pitches,
+            view);
+
+    //-----------------------------------------------------------------------------
+    // alpaka::mem::view::traits::GetPtrNative
+    // The native pointer has to be exactly the value we calculate here.
+    auto viewPtrNative(reinterpret_cast<std::uint8_t *>(alpaka::mem::view::getPtrNative(buf)));
+    for(Size i = Dim::value; i > static_cast<Size>(0u); --i)
+    {
+        viewPtrNative += offsetView[i - 1u] * pitches[i];
+    }
+    BOOST_REQUIRE_EQUAL(
+        reinterpret_cast<Elem *>(viewPtrNative),
+        alpaka::mem::view::getPtrNative(view));
+
+    //-----------------------------------------------------------------------------
+    // alpaka::offset::traits::GetOffset
+    BOOST_REQUIRE_EQUAL(
+        offsetView,
+        alpaka::offset::getOffsetVec(view));
+
+    //-----------------------------------------------------------------------------
+    // alpaka::size::traits::SizeType
+    static_assert(
+        std::is_same<alpaka::size::Size<View>, Size>::value,
+        "The size type of the view has to be equal to the specified one.");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mem/view/src/main.cpp
+++ b/test/unit/mem/view/src/main.cpp
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE memView
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
* `GetPitchBytes`, `GetPtrNative` as well as `GetDev` were endless recursive (fixes #136 and #141 )
* `pitchedOffsetBytes` was called with one argument too much
* The default implementation of `GetPitchBytes` ignored user specialized dimensions and just took the extent (fixes #137)
* `Buf` renamed to `ViewBaseView` to reflect the usage