### PR TITLE
change alpaka namespace scope in macro function

### DIFF
--- a/include/alpaka/core/Align.hpp
+++ b/include/alpaka/core/Align.hpp
@@ -123,5 +123,5 @@ namespace alpaka
             ALPAKA_OPTIMAL_ALIGNMENT_SIZE(sizeof(typename std::remove_cv<__VA_ARGS__>::type))
 #else
     #define ALPAKA_OPTIMAL_ALIGNMENT(...)\
-            alpaka::core::align::OptimalAlignment<sizeof(typename std::remove_cv<__VA_ARGS__>::type)>::value
+            ::alpaka::core::align::OptimalAlignment<sizeof(typename std::remove_cv<__VA_ARGS__>::type)>::value
 #endif


### PR DESCRIPTION
change `alapka::...` to `::alpaka::...` in macro `ALPAKA_OPTIMAL_ALIGNMENT()`