### PR TITLE
fix invalid call of `vec::subVecEnd<>()`

### DIFF
--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -80,7 +80,12 @@ namespace alpaka
                         m_pMem(pMem),
                         m_dev(dev),
                         m_extentElements(extent::getExtentVecEnd<TDim>(extent)),
-                        m_pitchBytes(vec::subVecEnd<TDim>(pitchBytes))
+                        m_pitchBytes(
+                            vec::subVecEnd<TDim>(
+                               static_cast<
+                                    Vec<TDim, TSize> >(pitchBytes)
+                            )
+                        )
                 {}
 
                 //-----------------------------------------------------------------------------


### PR DESCRIPTION
`ViewPlainPtr` calls `vec::subVecEnd()` without explicit cast of the templated type to an alpaka vector

If a user defined vector for `pitchBytes` is used than no function signature for `vec::subVecEnd<TDim>` matches.
`ViewPlainPtr` allows any type for `pitchBytes` therefor a static cast is needed. After this pull request all user defined vector types with a well defined cast operator can be used.