### PR TITLE
Fixed construction of vec for typecast operator of non alpaka vectors

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -40,7 +40,7 @@
 #include <cstdint>                          // std::uint32_t
 #include <ostream>                          // std::ostream
 #include <cassert>                          // assert
-#include <type_traits>                      // std::enable_if
+#include <type_traits>                      // std::enable_if, std::decay
 #include <algorithm>                        // std::min, std::max, std::min_element, std::max_element
 
 // The nvcc compiler does not support the out of class version.
@@ -169,11 +169,8 @@ namespace alpaka
             typename = typename std::enable_if<
                 // There have to be dim arguments.
                 (sizeof...(TArgs)+1 == TDim::value)
-                && (
-                    // And there is either more than one argument ...
-                    (sizeof...(TArgs) > 0u)
-                    // ... or the first argument is not applicable for the copy constructor.
-                    || (!std::is_base_of<Vec<TDim, TSize>, typename std::remove_reference<TArg0>::type>::value))
+                &&
+                (std::is_same<TSize, typename std::decay<TArg0>::type>::value)
                 >::type>
         ALPAKA_FN_HOST_ACC Vec(
             TArg0 && arg0,

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -35,3 +35,5 @@ ADD_SUBDIRECTORY("block/shared/")
 ADD_SUBDIRECTORY("kernel/")
 ADD_SUBDIRECTORY("mem/view/")
 ADD_SUBDIRECTORY("meta/")
+ADD_SUBDIRECTORY("vec/")
+

--- a/test/unit/vec/CMakeLists.txt
+++ b/test/unit/vec/CMakeLists.txt
@@ -1,0 +1,88 @@
+#
+# Copyright 2014-2015 Benjamin Worpitz
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required CMake version.
+################################################################################
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+
+SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+################################################################################
+
+SET(_SOURCE_DIR "src/")
+SET(_TARGET_NAME "vec")
+
+PROJECT(${_TARGET_NAME})
+
+#-------------------------------------------------------------------------------
+# Find alpaka test common.
+#-------------------------------------------------------------------------------
+
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../common/" CACHE STRING  "The location of the alpaka test common library")
+
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE("common" REQUIRED)
+
+#-------------------------------------------------------------------------------
+# Boost.Test.
+#-------------------------------------------------------------------------------
+FIND_PACKAGE(Boost QUIET COMPONENTS unit_test_framework)
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+
+ELSE()
+    LIST(APPEND _INCLUDE_DIRECTORIES_PRIVATE ${Boost_INCLUDE_DIRS})
+    LIST(APPEND _LINK_LIBRARIES_PRIVATE ${Boost_LIBRARIES})
+
+    IF(NOT Boost_USE_STATIC_LIBS)
+        LIST(APPEND _DEFINITIONS_PRIVATE "-DBOOST_TEST_DYN_LINK")
+    ENDIF()
+ENDIF()
+
+#-------------------------------------------------------------------------------
+# Add library.
+#-------------------------------------------------------------------------------
+
+# Add all the source files in all recursive subdirectories and group them accordingly.
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE)
+
+INCLUDE_DIRECTORIES(
+    ${_INCLUDE_DIRECTORIES_PRIVATE}
+    ${common_INCLUDE_DIRS})
+ADD_DEFINITIONS(
+    ${_DEFINITIONS_PRIVATE}
+    ${common_DEFINITIONS})
+# Always add all files to the target executable build call to add them to the build project.
+ALPAKA_ADD_EXECUTABLE(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+# Set the link libraries for this library (adds libs, include directories, defines and compile options).
+TARGET_LINK_LIBRARIES(
+    ${_TARGET_NAME}
+    PUBLIC "common" ${_LINK_LIBRARIES_PRIVATE})
+
+SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+ENABLE_TESTING()
+ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -1,0 +1,72 @@
+/**
+ * \file
+ * Copyright 2016 Erik Zenker
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(vec)
+
+template<
+    typename TDim,
+    typename TSize>
+struct NonAlpakaVec {
+
+    operator ::alpaka::Vec<
+        TDim,
+        TSize>() const
+    {
+        using AlpakaVector = ::alpaka::Vec<
+            TDim,
+            TSize
+        >;
+        AlpakaVector result( AlpakaVector::zeros() );
+
+        for(TSize d = 0; d < TDim::value; ++d)
+        {
+            result[TDim::value - 1 - d] = (*this)[d];
+        }    
+
+        return result;
+    }
+
+    auto operator [](TSize idx) const
+    -> TSize
+    {
+        return static_cast<TSize>(0);
+    }
+
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(
+    vec1DConstructionFromNonAlpakaVec)
+{
+    using Dim = alpaka::dim::DimInt<1u>;
+    using Size = std::size_t;
+
+    NonAlpakaVec<Dim, Size> nonAlpakaVec;
+    static_cast<alpaka::Vec<Dim, Size> >(nonAlpakaVec);
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/vec/src/main.cpp
+++ b/test/unit/vec/src/main.cpp
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE vec
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
When some non alpaka vector was casted to `alpaka::Vec` than the value constructor is used for the 1D case instead of the non alpaka vector typecast operator. 

I fixed that behaviour and added an unit test to prevent the error in the future. 