### PR TITLE
allow object for `getBlockSharedMemDynSizeBytes`

### DIFF
--- a/include/alpaka/exec/ExecCpuFibers.hpp
+++ b/include/alpaka/exec/ExecCpuFibers.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -156,8 +156,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuFibers<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);

--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -131,8 +131,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuOmp2Blocks<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -130,8 +130,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuOmp2Threads<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);
@@ -184,10 +184,10 @@ namespace alpaka
                         {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                             // GCC 5.1 fails with:
-                            // error: redeclaration of ‘const int& iBlockThreadCount’
+                            // error: redeclaration of const int& iBlockThreadCount
                             // if(numThreads != iBlockThreadCount
                             //                ^
-                            // note: ‘const int& iBlockThreadCount’ previously declared here
+                            // note: const int& iBlockThreadCount previously declared here
                             // #pragma omp parallel num_threads(iBlockThreadCount)
                             //         ^
 #if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0))

--- a/include/alpaka/exec/ExecCpuOmp4.hpp
+++ b/include/alpaka/exec/ExecCpuOmp4.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -130,8 +130,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuOmp4<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);
@@ -188,7 +188,7 @@ namespace alpaka
                         {
                             Vec<dim::DimInt<1u>, TSize> const gridBlockIdx(b);
                             // When this is not repeated here:
-                            // error: ‘gridBlockExtent’ referenced in target region does not have a mappable type
+                            // error: gridBlockExtent referenced in target region does not have a mappable type
                             auto const gridBlockExtent2(
                                 workdiv::getWorkDiv<Grid, Blocks>(*static_cast<workdiv::WorkDivMembers<TDim, TSize> const *>(this)));
                             acc.m_gridBlockIdx = core::mapIdx<TDim::value>(

--- a/include/alpaka/exec/ExecCpuSerial.hpp
+++ b/include/alpaka/exec/ExecCpuSerial.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -125,8 +125,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuSerial<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);

--- a/include/alpaka/exec/ExecCpuThreads.hpp
+++ b/include/alpaka/exec/ExecCpuThreads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -154,8 +154,8 @@ namespace alpaka
                         {
                             return
                                 kernel::getBlockSharedMemDynSizeBytes<
-                                    TKernelFnObj,
                                     acc::AccCpuThreads<TDim, TSize>>(
+                                        m_kernelFnObj,
                                         blockThreadExtent,
                                         threadElemExtent,
                                         args...);

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -355,8 +355,8 @@ namespace alpaka
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
-                                        typename std::decay<TKernelFnObj>::type,
                                         acc::AccGpuCudaRt<TDim, TSize>>(
+                                            task.m_kernelFnObj,
                                             blockThreadExtent,
                                             threadElemExtent,
                                             args...);
@@ -496,8 +496,8 @@ namespace alpaka
                             {
                                 return
                                     kernel::getBlockSharedMemDynSizeBytes<
-                                        TKernelFnObj,
                                         acc::AccGpuCudaRt<TDim, TSize>>(
+                                            task.m_kernelFnObj,
                                             blockThreadExtent,
                                             threadElemExtent,
                                             args...);

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -56,6 +56,7 @@ namespace alpaka
             struct BlockSharedMemDynSizeBytes
             {
                 //-----------------------------------------------------------------------------
+                //! \param kernelFnObj The kernel object for which the block shared memory size should be calculated
                 //! \param blockElemExtent The block element extent for which the block shared memory size should be calculated.
                 //! \tparam TArgs The kernel invocation argument types pack.
                 //! \param args,... The kernel invocation arguments for which the block shared memory size should be calculated.
@@ -67,11 +68,13 @@ namespace alpaka
                     typename TDim,
                     typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
+                    TKernelFnObj const & kernelFnObj,
                     Vec<TDim, size::Size<TAcc>> const & blockThreadExtent,
                     Vec<TDim, size::Size<TAcc>> const & threadElemExtent,
                     TArgs const & ... args)
                 -> size::Size<TAcc>
                 {
+                    boost::ignore_unused(kernelFnObj);
                     boost::ignore_unused(blockThreadExtent);
                     boost::ignore_unused(threadElemExtent);
                     boost::ignore_unused(args...);
@@ -90,11 +93,12 @@ namespace alpaka
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
         template<
-            typename TKernelFnObj,
             typename TAcc,
+            typename TKernelFnObj,
             typename TDim,
             typename... TArgs>
         ALPAKA_FN_HOST_ACC auto getBlockSharedMemDynSizeBytes(
+            TKernelFnObj const & kernelFnObj,
             Vec<TDim, size::Size<TAcc>> const & blockThreadExtent,
             Vec<TDim, size::Size<TAcc>> const & threadElemExtent,
             TArgs const & ... args)
@@ -105,6 +109,7 @@ namespace alpaka
                     TKernelFnObj,
                     TAcc>
                 ::getBlockSharedMemDynSizeBytes(
+                    kernelFnObj,
                     blockThreadExtent,
                     threadElemExtent,
                     args...);

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -179,6 +179,7 @@ namespace alpaka
                     typename TIndex,
                     typename TElem>
                 ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
+                    MatMulKernel const & matMulKernel,
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent,
                     TIndex const & m,
@@ -194,6 +195,7 @@ namespace alpaka
                     TIndex const & ldc)
                 -> TIndex
                 {
+                    boost::ignore_unused(matMulKernel);
                     boost::ignore_unused(m);
                     boost::ignore_unused(n);
                     boost::ignore_unused(k);

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -143,11 +143,13 @@ namespace alpaka
                     typename TVec,
                     typename... TArgs>
                 ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
+                    SharedMemKernel<TnumUselessWork> const & sharedMemKernel,
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent,
                     TArgs && ...)
                 -> std::uint32_t
                 {
+                    boost::ignore_unused(sharedMemKernel);
                     return blockThreadExtent.prod() * threadElemExtent.prod() * sizeof(std::uint32_t);
                 }
             };

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -85,10 +85,12 @@ namespace alpaka
                 template<
                     typename TVec>
                 ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
+                    BlockSharedMemDyn const & blockSharedMemDyn,
                     TVec const & blockThreadExtent,
                     TVec const & threadElemExtent)
                 -> size::Size<TAcc>
                 {
+                    boost::ignore_unused(blockSharedMemDyn);
                     return sizeof(std::uint32_t) * blockThreadExtent.prod() * threadElemExtent.prod();
                 }
             };


### PR DESCRIPTION
Currently there is only the kernel type used to define external shared memory. 
If the user defined a kernel where the needed information for the external shared memory size is stored as member attribute than this can't mapped with the current interface.
The upper case can be done for example with a own `bind()` command where all functor parameters were stored as const members of a functor.
By passing the function kernel object to the shared memory trait this can be handled. 

Allow that external shared memory can be defined with the help of an function object instead only by a function type.

- change template signature for the trait `getBlockSharedMemDynSizeBytes()`
- add one  parameter to `traits::BlockSharedMemDynSizeBytes<>::getBlockSharedMemDynSizeBytes()`
- update examples and integration tests