### PR TITLE
fix some icc incompatibilities

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -59,7 +59,7 @@ namespace alpaka
 #if BOOST_ARCH_X86
             namespace detail
             {
-    #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || __INTEL_COMPILER
+    #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && __INTEL_COMPILER)
         #include <cpuid.h>
                 //-----------------------------------------------------------------------------
                 //!
@@ -70,7 +70,7 @@ namespace alpaka
                     __cpuid_count(level, subfunction, ex[0], ex[1], ex[2], ex[3]);
                 }
 
-    #elif BOOST_COMP_MSVC
+    #elif BOOST_COMP_MSVC || __INTEL_COMPILER
         #include <intrin.h>
                 //-----------------------------------------------------------------------------
                 //!

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -35,6 +35,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <type_traits>                          // std::is_same
+#include <numeric>                              // std::iota
 
 BOOST_AUTO_TEST_SUITE(acc)
 


### PR DESCRIPTION
While using icc 16.0.1 on Windows I have found some incompatibilities:
* the `ViewSubViewTest.cpp` is missing an include
* ICC emulates GCC on linux and MSVC on Windows and always provides the same `cpuid` function as the emulated compiler.