### PR TITLE
Moved architecture switch to correct position

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -56,9 +56,9 @@ namespace alpaka
     {
         namespace cpu
         {
-#if BOOST_ARCH_X86
             namespace detail
             {
+#if BOOST_ARCH_X86
     #if BOOST_COMP_GNUC || BOOST_COMP_CLANG || (!BOOST_COMP_MSVC_EMULATED && __INTEL_COMPILER)
         #include <cpuid.h>
                 //-----------------------------------------------------------------------------


### PR DESCRIPTION
A architecture switch on the wrong position lead to compile errors on other platforms
than x86 e.g.: ppc.