### PR TITLE
add accelerator clock method

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -33,6 +33,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
 #include <alpaka/block/sync/BlockSyncFiberIdMapBarrier.hpp>                 // BlockSyncFiberIdMapBarrier
 #include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/time/TimeStl.hpp>              // TimeStl
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                // acc::traits::AccType
@@ -85,7 +86,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncFiberIdMapBarrier<TSize>,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeStl
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -118,6 +120,7 @@ namespace alpaka
                         m_blockThreadCount,
                         m_fibersToBarrier),
                     rand::RandStl(),
+                    time::TimeStl(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros()),
                     m_blockThreadCount(workdiv::getWorkDiv<Block, Threads>(workDiv).prod())
             {}

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -37,6 +37,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>                // BlockSharedMemStNoSync
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>  // BlockSyncNoOp
 #include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/time/TimeOmp.hpp>              // TimeOmp
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                // acc::traits::AccType
@@ -86,7 +87,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStNoSync,
             public block::sync::BlockSyncNoOp,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeOmp
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -115,6 +117,7 @@ namespace alpaka
                     block::shared::st::BlockSharedMemStNoSync(),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStl(),
+                    time::TimeOmp(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros())
             {}
 

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -37,6 +37,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
 #include <alpaka/block/sync/BlockSyncOmpBarrier.hpp>                        // BlockSyncOmpBarrier
 #include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/time/TimeOmp.hpp>              // TimeOmp
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                // acc::traits::AccType
@@ -85,7 +86,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncOmpBarrier,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeOmp
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -116,6 +118,7 @@ namespace alpaka
                         [](){return (::omp_get_thread_num() == 0);}),
                     block::sync::BlockSyncOmpBarrier(),
                     rand::RandStl(),
+                    time::TimeOmp(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros())
             {}
 

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -37,6 +37,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
 #include <alpaka/block/sync/BlockSyncOmpBarrier.hpp>                        // BlockSyncOmpBarrier
 #include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/time/TimeOmp.hpp>              // TimeOmp
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                // acc::traits::AccType
@@ -85,7 +86,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncOmpBarrier,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeOmp
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -116,6 +118,7 @@ namespace alpaka
                         [](){return (::omp_get_thread_num() == 0);}),
                     block::sync::BlockSyncOmpBarrier(),
                     rand::RandStl(),
+                    time::TimeOmp(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros())
             {}
 

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -33,6 +33,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>                // BlockSharedMemStNoSync
 #include <alpaka/block/sync/BlockSyncNoOp.hpp>  // BlockSyncNoOp
 #include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/time/TimeStl.hpp>              // TimeStl
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                // acc::traits::AccType
@@ -79,7 +80,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStNoSync,
             public block::sync::BlockSyncNoOp,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeStl
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -108,6 +110,7 @@ namespace alpaka
                     block::shared::st::BlockSharedMemStNoSync(),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStl(),
+                    time::TimeStl(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros())
             {}
 

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -32,7 +32,8 @@
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
 #include <alpaka/block/sync/BlockSyncThreadIdMapBarrier.hpp>                // BlockSyncThreadIdMapBarrier
-#include <alpaka/rand/RandStl.hpp>              // RandStl
+#include <alpaka/rand/RandStl.hpp>                  // RandStl
+#include <alpaka/time/TimeStl.hpp>                  // TimeStl
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                    // acc::traits::AccType
@@ -82,7 +83,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
             public block::sync::BlockSyncThreadIdMapBarrier<TSize>,
-            public rand::RandStl
+            public rand::RandStl,
+            public time::TimeStl
         {
         public:
             // Partial specialization with the correct TDim and TSize is not allowed.
@@ -115,6 +117,7 @@ namespace alpaka
                         m_blockThreadCount,
                         m_threadToBarrierMap),
                     rand::RandStl(),
+                    time::TimeStl(),
                     m_gridBlockIdx(Vec<TDim, TSize>::zeros()),
                     m_blockThreadCount(workdiv::getWorkDiv<Block, Threads>(workDiv).prod())
             {}

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -37,6 +37,7 @@
 #include <alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp>   // BlockSharedMemStCudaBuiltIn
 #include <alpaka/block/sync/BlockSyncCudaBuiltIn.hpp>                   // BlockSyncCudaBuiltIn
 #include <alpaka/rand/RandCuRand.hpp>               // RandCuRand
+#include <alpaka/time/TimeCudaBuiltIn.hpp>          // TimeCudaBuiltIn
 
 // Specialized traits.
 #include <alpaka/acc/Traits.hpp>                    // acc::traits::AccType
@@ -83,7 +84,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynCudaBuiltIn,
             public block::shared::st::BlockSharedMemStCudaBuiltIn,
             public block::sync::BlockSyncCudaBuiltIn,
-            public rand::RandCuRand
+            public rand::RandCuRand,
+            public time::TimeCudaBuiltIn
         {
         public:
             //-----------------------------------------------------------------------------
@@ -99,7 +101,8 @@ namespace alpaka
                     block::shared::dyn::BlockSharedMemDynCudaBuiltIn(),
                     block::shared::st::BlockSharedMemStCudaBuiltIn(),
                     block::sync::BlockSyncCudaBuiltIn(),
-                    rand::RandCuRand()
+                    rand::RandCuRand(),
+                    time::TimeCudaBuiltIn()
             {}
 
         public:

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz
 *
 * This file is part of alpaka.
 *
@@ -216,6 +216,11 @@
 #include <alpaka/stream/StreamCpuAsync.hpp>
 #include <alpaka/stream/StreamCpuSync.hpp>
 #include <alpaka/stream/Traits.hpp>
+
+//-----------------------------------------------------------------------------
+// time
+//-----------------------------------------------------------------------------
+#include <alpaka/time/Traits.hpp>
 
 //-----------------------------------------------------------------------------
 // wait

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -266,10 +266,6 @@ namespace alpaka
         };
     }
 
-    namespace event
-    {
-        class EventCpu;
-    }
     namespace dev
     {
         namespace traits

--- a/include/alpaka/time/TimeCudaBuiltIn.hpp
+++ b/include/alpaka/time/TimeCudaBuiltIn.hpp
@@ -1,0 +1,99 @@
+/**
+ * \file
+ * Copyright 2016 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+
+#ifndef __CUDACC__
+    #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
+#endif
+
+#include <alpaka/time/Traits.hpp>       // time::Clock
+
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY
+
+namespace alpaka
+{
+    namespace time
+    {
+        //#############################################################################
+        //! The GPU CUDA accelerator time implementation.
+        //#############################################################################
+        class TimeCudaBuiltIn
+        {
+        public:
+            using TimeBase = TimeCudaBuiltIn;
+
+            //-----------------------------------------------------------------------------
+            //! Default constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY TimeCudaBuiltIn() = default;
+            //-----------------------------------------------------------------------------
+            //! Copy constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY TimeCudaBuiltIn(TimeCudaBuiltIn const &) = delete;
+            //-----------------------------------------------------------------------------
+            //! Move constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY TimeCudaBuiltIn(TimeCudaBuiltIn &&) = delete;
+            //-----------------------------------------------------------------------------
+            //! Copy assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(TimeCudaBuiltIn const &) -> TimeCudaBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            //! Move assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(TimeCudaBuiltIn &&) -> TimeCudaBuiltIn & = delete;
+            //-----------------------------------------------------------------------------
+            //! Destructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_CUDA_ONLY /*virtual*/ ~TimeCudaBuiltIn() = default;
+        };
+
+        namespace traits
+        {
+            //#############################################################################
+            //! The CUDA built-in clock operation.
+            //#############################################################################
+            template<>
+            struct Clock<
+                time::TimeCudaBuiltIn>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_CUDA_ONLY static auto clock(
+                    time::TimeCudaBuiltIn const &)
+                -> std::uint64_t
+                {
+                    // This can be converted to a wall-clock time in seconds by dividing through the shader clock rate given by cudaDeviceProp::clockRate.
+                    // This clock rate is double the main clock rate on Fermi and older cards. 
+                    return
+                        static_cast<std::uint64_t>(
+                            clock64());
+                }
+            };
+        }
+    }
+}
+
+#endif

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -1,0 +1,101 @@
+/**
+* \file
+* Copyright 2016 Benjamin Worpitz
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifdef _OPENMP
+
+#include <alpaka/time/Traits.hpp>       // time::Clock
+
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY
+
+#include <boost/core/ignore_unused.hpp> // boost::ignore_unused
+
+#include <omp.h>                        // omp_get_wtime
+
+namespace alpaka
+{
+    namespace time
+    {
+        //#############################################################################
+        //! The OpenMP accelerator time implementation.
+        //#############################################################################
+        class TimeOmp
+        {
+        public:
+            using TimeBase = TimeOmp;
+
+            //-----------------------------------------------------------------------------
+            //! Default constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeOmp() = default;
+            //-----------------------------------------------------------------------------
+            //! Copy constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeOmp(TimeOmp const &) = delete;
+            //-----------------------------------------------------------------------------
+            //! Move constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeOmp(TimeOmp &&) = delete;
+            //-----------------------------------------------------------------------------
+            //! Copy assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeOmp const &) -> TimeOmp & = delete;
+            //-----------------------------------------------------------------------------
+            //! Move assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeOmp &&) -> TimeOmp & = delete;
+            //-----------------------------------------------------------------------------
+            //! Destructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~TimeOmp() = default;
+        };
+
+        namespace traits
+        {
+            //#############################################################################
+            //! The OpenMP accelerator clock operation.
+            //#############################################################################
+            template<>
+            struct Clock<
+                time::TimeOmp>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_NO_CUDA static auto clock(
+                    time::TimeOmp const & time)
+                -> std::uint64_t
+                {
+                    boost::ignore_unused(time);
+                    // NOTE: We compute the number of clock ticks by dividing the following durations:
+                    // - omp_get_wtime returns the elapsed wall clock time in seconds.
+                    // - omp_get_wtick gets the timer precision, i.e., the number of seconds between two successive clock ticks. 
+                    return
+                        static_cast<std::uint64_t>(
+                            omp_get_wtime() / omp_get_wtick());
+                }
+            };
+        }
+    }
+}
+
+#endif

--- a/include/alpaka/time/TimeStl.hpp
+++ b/include/alpaka/time/TimeStl.hpp
@@ -1,0 +1,100 @@
+/**
+* \file
+* Copyright 2016 Benjamin Worpitz
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/time/Traits.hpp>       // time::Clock
+
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY
+
+#include <boost/core/ignore_unused.hpp> // boost::ignore_unused
+
+//#include <ctime>                        // std::clock
+#include <chrono>                       // std::chrono::high_resolution_clock
+
+namespace alpaka
+{
+    namespace time
+    {
+        //#############################################################################
+        //! The CPU fibers accelerator time implementation.
+        //#############################################################################
+        class TimeStl
+        {
+        public:
+            using TimeBase = TimeStl;
+
+            //-----------------------------------------------------------------------------
+            //! Default constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeStl() = default;
+            //-----------------------------------------------------------------------------
+            //! Copy constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeStl(TimeStl const &) = delete;
+            //-----------------------------------------------------------------------------
+            //! Move constructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA TimeStl(TimeStl &&) = delete;
+            //-----------------------------------------------------------------------------
+            //! Copy assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeStl const &) -> TimeStl & = delete;
+            //-----------------------------------------------------------------------------
+            //! Move assignment operator.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeStl &&) -> TimeStl & = delete;
+            //-----------------------------------------------------------------------------
+            //! Destructor.
+            //-----------------------------------------------------------------------------
+            ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~TimeStl() = default;
+        };
+
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU fibers accelerator clock operation.
+            //#############################################################################
+            template<>
+            struct Clock<
+                TimeStl>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_NO_CUDA static auto clock(
+                    time::TimeStl const & time)
+                -> std::uint64_t
+                {
+                    boost::ignore_unused(time);
+
+                    // NOTE: high_resolution_clock returns a non-steady wall-clock time!
+                    // This means that it is not ensured that the values will always increase monotonically.
+                    return
+                        static_cast<std::uint64_t>(
+                            std::chrono::high_resolution_clock::now()
+                                .time_since_epoch()
+                                    .count());
+                }
+            };
+        }
+    }
+}

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -1,0 +1,98 @@
+/**
+* \file
+* Copyright 2016 Benjamin Worpitz
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+
+#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+
+namespace alpaka
+{
+    //-----------------------------------------------------------------------------
+    //! The time traits specifics.
+    //-----------------------------------------------------------------------------
+    namespace time
+    {
+        //-----------------------------------------------------------------------------
+        //! The time traits.
+        //-----------------------------------------------------------------------------
+        namespace traits
+        {
+            //#############################################################################
+            //! The clock trait.
+            //#############################################################################
+            template<
+                typename TTime,
+                typename TSfinae = void>
+            struct Clock;
+        }
+
+        //-----------------------------------------------------------------------------
+        //! \return A counter that is increasing every clock cycle.
+        //!
+        //! \tparam TTime The time implementation type.
+        //! \param time The time implementation.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TTime>
+        ALPAKA_FN_HOST_ACC auto clock(
+            TTime const & time)
+        -> std::uint64_t
+        {
+            return
+                traits::Clock<
+                    TTime>
+                ::clock(
+                    time);
+        }
+
+        namespace traits
+        {
+            //#############################################################################
+            //! The Clock trait specialization for classes with TimeBase member type.
+            //#############################################################################
+            template<
+                typename TTime>
+            struct Clock<
+                TTime,
+                typename std::enable_if<
+                    std::is_base_of<typename TTime::TimeBase, typename std::decay<TTime>::type>::value
+                    && (!std::is_same<typename TTime::TimeBase, typename std::decay<TTime>::type>::value)>::type>
+            {
+                //-----------------------------------------------------------------------------
+                //!
+                //-----------------------------------------------------------------------------
+                ALPAKA_NO_HOST_ACC_WARNING
+                ALPAKA_FN_HOST_ACC static auto clock(
+                    TTime const & time)
+                -> std::uint64_t
+                {
+                    // Delegate the call to the base class.
+                    return
+                        time::clock(
+                            static_cast<typename TTime::TimeBase const &>(time));
+                }
+            };
+        }
+    }
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -35,5 +35,5 @@ ADD_SUBDIRECTORY("block/shared/")
 ADD_SUBDIRECTORY("kernel/")
 ADD_SUBDIRECTORY("mem/view/")
 ADD_SUBDIRECTORY("meta/")
+ADD_SUBDIRECTORY("time/")
 ADD_SUBDIRECTORY("vec/")
-

--- a/test/unit/time/CMakeLists.txt
+++ b/test/unit/time/CMakeLists.txt
@@ -1,0 +1,83 @@
+#
+# Copyright 2016 Benjamin Worpitz
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required CMake version.
+################################################################################
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+
+SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+################################################################################
+
+SET(_SOURCE_DIR "src/")
+SET(_TARGET_NAME "time")
+
+PROJECT(${_TARGET_NAME})
+
+#-------------------------------------------------------------------------------
+# Find alpaka test common.
+#-------------------------------------------------------------------------------
+
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../common/" CACHE STRING  "The location of the alpaka test common library")
+
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE("common" REQUIRED)
+
+#-------------------------------------------------------------------------------
+# Boost.Test.
+#-------------------------------------------------------------------------------
+FIND_PACKAGE(Boost QUIET COMPONENTS unit_test_framework)
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+
+ELSE()
+    LIST(APPEND _INCLUDE_DIRECTORIES_PRIVATE ${Boost_INCLUDE_DIRS})
+    LIST(APPEND _LINK_LIBRARIES_PRIVATE ${Boost_LIBRARIES})
+ENDIF()
+
+#-------------------------------------------------------------------------------
+# Add library.
+#-------------------------------------------------------------------------------
+
+# Add all the source files in all recursive subdirectories and group them accordingly.
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE)
+
+INCLUDE_DIRECTORIES(
+    ${_INCLUDE_DIRECTORIES_PRIVATE}
+    ${common_INCLUDE_DIRS})
+ADD_DEFINITIONS(
+    ${common_DEFINITIONS})
+# Always add all files to the target executable build call to add them to the build project.
+ALPAKA_ADD_EXECUTABLE(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+# Set the link libraries for this library (adds libs, include directories, defines and compile options).
+TARGET_LINK_LIBRARIES(
+    ${_TARGET_NAME}
+    PUBLIC "common" ${_LINK_LIBRARIES_PRIVATE})
+
+SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+ENABLE_TESTING()
+ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -1,0 +1,89 @@
+/**
+ * \file
+ * Copyright 2016 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/test/unit_test.hpp>
+
+//#############################################################################
+//!
+//#############################################################################
+class ClockTestKernel
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        std::uint64_t const start(
+            alpaka::time::clock(acc));
+        BOOST_REQUIRE_NE(0u, start);
+
+        std::uint64_t const end(
+            alpaka::time::clock(acc));
+        BOOST_REQUIRE_NE(0u, end);
+
+        // 'end' has to be greater then 'start'.
+        BOOST_REQUIRE_GT(end, start);
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(timeClock)
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    clockIsWorking,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::Vec<Dim, Size>::ones());
+
+    ClockTestKernel kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/time/src/main.cpp
+++ b/test/unit/time/src/main.cpp
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * Copyright 2016 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE time
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
This adds the missing `clock64()` instruction returning a wall clock time in ticks which was noted in issue #18 as `alpaka::time::clock(acc)`.