### PR TITLE
Use reference to device in ViewPlainPtr

### DIFF
--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -74,7 +74,7 @@ namespace alpaka
                     typename TPitch>
                 ALPAKA_FN_HOST_ACC ViewPlainPtr(
                     TElem * pMem,
-                    TDev const dev,
+                    TDev const & dev,
                     TExtent const & extent,
                     TPitch const & pitchBytes) :
                         m_pMem(pMem),
@@ -116,7 +116,7 @@ namespace alpaka
 
             public:
                 TElem * m_pMem;
-                TDev m_dev;
+                TDev const & m_dev;
                 Vec<TDim, TSize> m_extentElements;
                 Vec<TDim, TSize> m_pitchBytes;
             };


### PR DESCRIPTION
If no reference is used to provide the device to the ViewPlainPtr constructor, then
the device will destruct on ViewPlainPtr destruction. This error occured only
in CMake Release mode (CI was not able to find it, right?).
