### PR TITLE
work around MSVC 2015 Update 1&2 subVecEnd ICE

### DIFF
--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -26,6 +26,8 @@
 #include <alpaka/offset/Traits.hpp> // offset::GetOffset
 #include <alpaka/size/Traits.hpp>   // size::traits::SizeType
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 namespace alpaka
 {
     //-----------------------------------------------------------------------------
@@ -35,6 +37,180 @@ namespace alpaka
     {
         namespace traits
         {
+            //#############################################################################
+            //! Trait for selecting a sub-vector.
+            //#############################################################################
+            template<
+                typename TVec,
+                typename TIndexSequence,
+                typename TSfinae = void>
+            struct SubVecFromIndices;
+
+            //#############################################################################
+            //! Trait for casting a vector.
+            //#############################################################################
+            template<
+                typename TSize,
+                typename TVec,
+                typename TSfinae = void>
+            struct Cast;
+
+            //#############################################################################
+            //! Trait for reversing a vector.
+            //#############################################################################
+            template<
+                typename TVec,
+                typename TSfinae = void>
+            struct Reverse;
+        }
+
+        //-----------------------------------------------------------------------------
+        //! Builds a new vector by selecting the elements of the source vector in the given order.
+        //! Repeating and swizzling elements is allowed.
+        //! \return The sub-vector consisting of the elements specified by the indices.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TIndexSequence,
+            typename TVec>
+        ALPAKA_FN_HOST_ACC auto subVecFromIndices(
+            TVec const & vec)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            traits::SubVecFromIndices<
+                TVec,
+                TIndexSequence>
+            ::subVecFromIndices(
+                vec))
+#endif
+        {
+            return
+                traits::SubVecFromIndices<
+                    TVec,
+                    TIndexSequence>
+                ::subVecFromIndices(
+                    vec);
+        }
+        //-----------------------------------------------------------------------------
+        //! \return The sub-vector consisting of the first N elements of the source vector.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TSubDim,
+            typename TVec>
+        ALPAKA_FN_HOST_ACC auto subVecBegin(
+            TVec const & vec)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            subVecFromIndices<
+                meta::MakeIntegerSequence<
+                    std::size_t,
+                    TSubDim::value
+                >
+            >(
+                vec))
+#endif
+        {
+            static_assert(
+                TSubDim::value <= dim::Dim<TVec>::value,
+                "The sub-Vec has to be smaller (or same size) then the original Vec.");
+
+            //! A sequence of integers from 0 to dim-1.
+            using IdxSubSequence =
+                meta::MakeIntegerSequence<
+                    std::size_t,
+                    TSubDim::value>;
+            return
+                subVecFromIndices<
+                    IdxSubSequence>(
+                        vec);
+        }
+        //-----------------------------------------------------------------------------
+        //! \return The sub-vector consisting of the last N elements of the source vector.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TSubDim,
+            typename TVec>
+        ALPAKA_FN_HOST_ACC auto subVecEnd(
+            TVec const & vec)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            subVecFromIndices<
+                meta::MakeIntegerSequenceOffset<
+                    std::size_t,
+                    dim::Dim<TVec>::value - TSubDim::value,
+                    TSubDim::value
+                >
+            >(
+                vec))
+#endif
+        {
+            static_assert(
+                TSubDim::value <= dim::Dim<TVec>::value,
+                "The sub-Vec has to be smaller (or same size) then the original Vec.");
+
+            constexpr std::size_t idxOffset = dim::Dim<TVec>::value - TSubDim::value;
+
+            //! A sequence of integers from 0 to dim-1.
+            using IdxSubSequence =
+                meta::MakeIntegerSequenceOffset<
+                    std::size_t,
+                    idxOffset,
+                    TSubDim::value>;
+            return
+                subVecFromIndices<
+                    IdxSubSequence>(
+                        vec);
+        }
+
+        //-----------------------------------------------------------------------------
+        //! \return The casted vector.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TSize,
+            typename TVec>
+        ALPAKA_FN_HOST_ACC auto cast(
+            TVec const & vec)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            traits::Cast<
+                TSize,
+                TVec>
+            ::cast(
+                vec))
+#endif
+        {
+            return
+                traits::Cast<
+                    TSize,
+                    TVec>
+                ::cast(
+                    vec);
+        }
+
+        //-----------------------------------------------------------------------------
+        //! \return The reverse vector.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TVec>
+        ALPAKA_FN_HOST_ACC auto reverse(
+            TVec const & vec)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            traits::Reverse<
+                TVec>
+            ::reverse(
+                vec))
+#endif
+        {
+            return
+                traits::Reverse<
+                    TVec>
+                ::reverse(
+                    vec);
         }
     }
 }

--- a/test/common/commonConfig.cmake
+++ b/test/common/commonConfig.cmake
@@ -92,6 +92,10 @@ append_recursive_files_add_to_src_group("${_COMMON_INCLUDE_DIRECTORY}" "${_COMMO
 append_recursive_files_add_to_src_group("${_COMMON_SOURCE_DIRECTORY}" "${_COMMON_SOURCE_DIRECTORY}" "cpp" _COMMON_FILES_SOURCE)
 LIST(APPEND _COMMON_FILES_CMAKE "${_COMMON_ROOT_DIR}/commonConfig.cmake" "${_COMMON_ROOT_DIR}/Findcommon.cmake")
 
+IF(MSVC)
+    LIST(APPEND common_DEFINITIONS "/bigobj")
+ENDIF()
+
 #-------------------------------------------------------------------------------
 # Target.
 #-------------------------------------------------------------------------------

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -24,6 +24,110 @@
 
 BOOST_AUTO_TEST_SUITE(vec)
 
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(
+    basicVecTraits)
+{
+    using Dim = alpaka::dim::DimInt<3u>;
+    using Size = std::size_t;
+    using Vec = alpaka::Vec<Dim, Size>;
+
+    auto const vec(
+        Vec(
+            static_cast<std::size_t>(0u),
+            static_cast<std::size_t>(8u),
+            static_cast<std::size_t>(15u)));
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::subVecFromIndices
+    {
+        using IdxSequence =
+            alpaka::meta::IntegerSequence<
+                std::size_t,
+                0u,
+                Dim::value -1u,
+                0u>;
+        auto const vecSubIndices(
+            alpaka::vec::subVecFromIndices<
+                IdxSequence>(
+                    vec));
+
+        BOOST_REQUIRE_EQUAL(vecSubIndices[0u], vec[0u]);
+        BOOST_REQUIRE_EQUAL(vecSubIndices[1u], vec[Dim::value -1u]);
+        BOOST_REQUIRE_EQUAL(vecSubIndices[2u], vec[0u]);
+    }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::subVecBegin
+    {
+        using DimSubVecEnd =
+            alpaka::dim::DimInt<2u>;
+        auto const vecSubBegin(
+            alpaka::vec::subVecBegin<
+                DimSubVecEnd>(
+                    vec));
+
+        for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecSubBegin[i], vec[i]);
+        }
+    }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::subVecEnd
+    {
+        using DimSubVecEnd =
+            alpaka::dim::DimInt<2u>;
+        auto const vecSubEnd(
+            alpaka::vec::subVecEnd<
+                DimSubVecEnd>(
+                    vec));
+
+        for(typename Dim::value_type i(0); i < DimSubVecEnd::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecSubEnd[i], vec[Dim::value - DimSubVecEnd::value + i]);
+        }
+    }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::cast
+    {
+        using SizeCast = std::uint16_t;
+        auto const vecCast(
+            alpaka::vec::cast<
+                SizeCast>(
+                    vec));
+
+        using VecCast = typename std::decay<decltype(vecCast)>::type;
+        static_assert(
+            std::is_same<
+                alpaka::size::Size<VecCast>,
+                SizeCast
+            >::value,
+            "The size type of the casted vec is wrong");
+
+        for(typename Dim::value_type i(0); i < Dim::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecCast[i], static_cast<SizeCast>(vec[i]));
+        }
+    }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::reverse
+    {
+        auto const vecReverse(
+            alpaka::vec::reverse(
+                vec));
+
+        for(typename Dim::value_type i(0); i < Dim::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecReverse[i], vec[Dim::value - 1u - i]);
+        }
+    }
+}
+
 //#############################################################################
 //!
 //#############################################################################


### PR DESCRIPTION
MSVC 2015 Update 1 introduced a bug into the compiler that leads to an ICE (Internal Compiler Error) when compiling the `vec::subVecEnd` method. My hope was that this would be fixed in Update 2. However, this was not the case.
I have now worked around this by refactoring and reworking the affected parts of the `Vec` class. Furthermore, the affected methods have been converted to traits and have been transfered to the `vec/Traits.hpp` header. The previous functionality should be fully preserved and a new unit test has been added.