### PR TITLE
use BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION for decltype return types

### DIFF
--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -24,6 +24,8 @@
 #include <boost/predef.h>   // workarounds
 #include <boost/version.hpp>// workarounds
 
+#include <boost/config.hpp> // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 // nvcc does not currently support boost correctly.
 // boost/utility/detail/result_of_iterate.hpp:148:75: error: invalid use of qualified-name 'std::allocator_traits<_Alloc>::propagate_on_container_swap'
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDACC__)
@@ -376,8 +378,10 @@ namespace alpaka
                 auto enqueueTask(
                     TFnObj && task,
                     TArgs && ... args)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 // NOTE: The first argument to the get_future() function call is the this pointer.
                 -> typename std::result_of< decltype(&TPromise<typename std::result_of<TFnObj(TArgs...)>::type>::get_future)(TPromise<typename std::result_of<TFnObj(TArgs...)>::type> *) >::type
+#endif
                 {
                     auto boundTask(std::bind(std::forward<TFnObj>(task), std::forward<TArgs>(args)...));
 
@@ -599,8 +603,10 @@ namespace alpaka
                 auto enqueueTask(
                     TFnObj && task,
                     TArgs && ... args)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 // NOTE: The first argument to the get_future() function call is the this pointer.
                 -> typename std::result_of< decltype(&TPromise<typename std::result_of<TFnObj(TArgs...)>::type>::get_future)(TPromise<typename std::result_of<TFnObj(TArgs...)>::type> *) >::type
+#endif
                 {
                     auto boundTask(std::bind(std::forward<TFnObj>(task), std::forward<TArgs>(args)...));
 

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
 
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <vector>                       // std::vector
 
 namespace alpaka
@@ -115,7 +117,9 @@ namespace alpaka
             typename T>
         ALPAKA_FN_HOST auto getDev(
             T const & t)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(traits::GetDev<T>::getDev(t))
+#endif
         {
             return
                 traits::GetDev<

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -30,6 +30,8 @@
 #include <alpaka/vec/Vec.hpp>               // Vec<N>
 #include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <utility>                          // std::forward
 
 namespace alpaka
@@ -189,10 +191,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto getIdx(
                     TIdx const & idx,
                     TWorkDiv const & workDiv)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     idx::getIdx<origin::Grid, unit::Blocks>(idx, workDiv)
                     * workdiv::getWorkDiv<origin::Block, unit::Threads>(workDiv)
                     + idx::getIdx<origin::Block, unit::Threads>(idx, workDiv))
+#endif
                 {
                     return
                         idx::getIdx<origin::Grid, unit::Blocks>(idx, workDiv)

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -59,6 +61,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto abs(
             T const & abs,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Abs<
                 T,
@@ -66,6 +69,7 @@ namespace alpaka
             ::abs(
                 abs,
                 arg))
+#endif
         {
             return
                 traits::Abs<
@@ -98,10 +102,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto abs(
                     T const & abs,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::abs(
                         static_cast<typename T::AbsBase const &>(abs),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -55,6 +57,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto acos(
             T const & acos,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Acos<
                 T,
@@ -62,6 +65,7 @@ namespace alpaka
             ::acos(
                 acos,
                 arg))
+#endif
         {
             return
                 traits::Acos<
@@ -94,10 +98,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto acos(
                     T const & acos,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::acos(
                         static_cast<typename T::AcosBase const &>(acos),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -55,6 +57,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto asin(
             T const & asin,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Asin<
                 T,
@@ -62,6 +65,7 @@ namespace alpaka
             ::asin(
                 asin,
                 arg))
+#endif
         {
             return
                 traits::Asin<
@@ -94,10 +98,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto asin(
                     T const & asin,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::asin(
                         static_cast<typename T::AsinBase const &>(asin),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -55,6 +57,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto atan(
             T const & atan,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Atan<
                 T,
@@ -62,6 +65,7 @@ namespace alpaka
             ::atan(
                 atan,
                 arg))
+#endif
         {
             return
                 traits::Atan<
@@ -94,10 +98,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto atan(
                     T const & atan,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan(
                         static_cast<typename T::AtanBase const &>(atan),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -61,6 +63,7 @@ namespace alpaka
             T const & atan2,
             Ty const & y,
             Tx const & x)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Atan2<
                 T,
@@ -70,6 +73,7 @@ namespace alpaka
                 atan2,
                 y,
                 x))
+#endif
         {
             return
                 traits::Atan2<
@@ -107,11 +111,13 @@ namespace alpaka
                     T const & atan2,
                     Ty const & y,
                     Tx const & x)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::atan2(
                         static_cast<typename T::Atan2Base const &>(atan2),
                         y,
                         x))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto cbrt(
             T const & cbrt,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Cbrt<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::cbrt(
                 cbrt,
                 arg))
+#endif
         {
             return
                 traits::Cbrt<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto cbrt(
                     T const & cbrt,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cbrt(
                         static_cast<typename T::CbrtBase const &>(cbrt),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto ceil(
             T const & ceil,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Ceil<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::ceil(
                 ceil,
                 arg))
+#endif
         {
             return
                 traits::Ceil<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto ceil(
                     T const & ceil,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::ceil(
                         static_cast<typename T::CeilBase const &>(ceil),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto cos(
             T const & cos,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Cos<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::cos(
                 cos,
                 arg))
+#endif
         {
             return
                 traits::Cos<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto cos(
                     T const & cos,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::cos(
                         static_cast<typename T::CosBase const &>(cos),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto erf(
             T const & erf,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Erf<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::erf(
                 erf,
                 arg))
+#endif
         {
             return
                 traits::Erf<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto erf(
                     T const & erf,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::erf(
                         static_cast<typename T::ErfBase const &>(erf),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -55,6 +57,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto exp(
             T const & exp,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Exp<
                 T,
@@ -62,6 +65,7 @@ namespace alpaka
             ::exp(
                 exp,
                 arg))
+#endif
         {
             return
                 traits::Exp<
@@ -94,10 +98,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto exp(
                     T const & exp,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::exp(
                         static_cast<typename T::ExpBase const &>(exp),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto floor(
             T const & floor,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Floor<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::floor(
                 floor,
                 arg))
+#endif
         {
             return
                 traits::Floor<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto floor(
                     T const & floor,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::floor(
                         static_cast<typename T::FloorBase const &>(floor),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -61,6 +63,7 @@ namespace alpaka
             T const & fmod,
             Tx const & x,
             Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Fmod<
                 T,
@@ -70,6 +73,7 @@ namespace alpaka
                 fmod,
                 x,
                 y))
+#endif
         {
             return
                 traits::Fmod<
@@ -104,10 +108,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto fmod(
                     T const & fmod,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::fmod(
                         static_cast<typename T::FmodBase const &>(fmod),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto log(
             T const & log,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Log<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::log(
                 log,
                 arg))
+#endif
         {
             return
                 traits::Log<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto log(
                     T const & log,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::log(
                         static_cast<typename T::LogBase const &>(log),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -62,6 +64,7 @@ namespace alpaka
             T const & max,
             Tx const & x,
             Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Max<
                 T,
@@ -71,6 +74,7 @@ namespace alpaka
                 max,
                 x,
                 y))
+#endif
         {
             return
                 traits::Max<
@@ -108,11 +112,13 @@ namespace alpaka
                     T const & max,
                     Tx const & x,
                     Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::max(
                         static_cast<typename T::MaxBase const &>(max),
                         x,
                         y))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -62,6 +64,7 @@ namespace alpaka
             T const & min,
             Tx const & x,
             Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Min<
                 T,
@@ -71,6 +74,7 @@ namespace alpaka
                 min,
                 x,
                 y))
+#endif
         {
             return
                 traits::Min<
@@ -108,11 +112,13 @@ namespace alpaka
                     T const & min,
                     Tx const & x,
                     Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::min(
                         static_cast<typename T::MinBase const &>(min),
                         x,
                         y))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -61,6 +63,7 @@ namespace alpaka
             T const & pow,
             TBase const & base,
             TExp const & exp)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Pow<
                 T,
@@ -70,6 +73,7 @@ namespace alpaka
                 pow,
                 base,
                 exp))
+#endif
         {
             return
                 traits::Pow<
@@ -107,11 +111,13 @@ namespace alpaka
                     T const & pow,
                     TBase const & base,
                     TExp const & exp)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::pow(
                         static_cast<typename T::PowBase const &>(pow),
                         base,
                         exp))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -61,6 +63,7 @@ namespace alpaka
             T const & remainder,
             Tx const & x,
             Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Remainder<
                 T,
@@ -70,6 +73,7 @@ namespace alpaka
                 remainder,
                 x,
                 y))
+#endif
         {
             return
                 traits::Remainder<
@@ -107,11 +111,13 @@ namespace alpaka
                     T const & remainder,
                     Tx const & x,
                     Ty const & y)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::remainder(
                         static_cast<typename T::RemainderBase const &>(remainder),
                         x,
                         y))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -74,6 +76,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto round(
             T const & round,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Round<
                 T,
@@ -81,6 +84,7 @@ namespace alpaka
             ::round(
                 round,
                 arg))
+#endif
         {
             return
                 traits::Round<
@@ -163,10 +167,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto round(
                     T const & round,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::round(
                         static_cast<typename T::RoundBase const &>(round),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return
@@ -195,10 +201,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto lround(
                     T const & lround,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::lround(
                         static_cast<typename T::RoundBase const &>(lround),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return
@@ -227,10 +235,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto llround(
                     T const & llround,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::llround(
                         static_cast<typename T::RoundBase const &>(llround),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto rsqrt(
             T const & rsqrt,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Rsqrt<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::rsqrt(
                 rsqrt,
                 arg))
+#endif
         {
             return
                 traits::Rsqrt<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto rsqrt(
                     T const & rsqrt,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::rsqrt(
                         static_cast<typename T::RsqrtBase const &>(rsqrt),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto sin(
             T const & sin,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Sin<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::sin(
                 sin,
                 arg))
+#endif
         {
             return
                 traits::Sin<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto sin(
                     T const & sin,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sin(
                         static_cast<typename T::SinBase const &>(sin),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto sqrt(
             T const & sqrt,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Sqrt<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::sqrt(
                 sqrt,
                 arg))
+#endif
         {
             return
                 traits::Sqrt<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto sqrt(
                     T const & sqrt,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::sqrt(
                         static_cast<typename T::SqrtBase const &>(sqrt),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto tan(
             T const & tan,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Tan<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::tan(
                 tan,
                 arg))
+#endif
         {
             return
                 traits::Tan<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto tan(
                     T const & tan,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::tan(
                         static_cast<typename T::TanBase const &>(tan),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
 
 namespace alpaka
@@ -56,6 +58,7 @@ namespace alpaka
         ALPAKA_FN_HOST_ACC auto trunc(
             T const & trunc,
             TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             traits::Trunc<
                 T,
@@ -63,6 +66,7 @@ namespace alpaka
             ::trunc(
                 trunc,
                 arg))
+#endif
         {
             return
                 traits::Trunc<
@@ -95,10 +99,12 @@ namespace alpaka
                 ALPAKA_FN_HOST_ACC static auto trunc(
                     T const & trunc,
                     TArg const & arg)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     math::trunc(
                         static_cast<typename T::TruncBase const &>(trunc),
                         arg))
+#endif
                 {
                     // Delegate the call to the base class.
                     return

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -25,6 +25,8 @@
 
 #include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
 
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 namespace alpaka
 {
     //-----------------------------------------------------------------------------
@@ -135,6 +137,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto alloc(
                 TDev const & dev,
                 TExtent const & extent = TExtent())
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::Alloc<
                     TElem,
@@ -144,6 +147,7 @@ namespace alpaka
                 ::alloc(
                     dev,
                     extent))
+#endif
             {
                 return
                     traits::Alloc<

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -33,6 +33,8 @@
 #include <alpaka/meta/Fold.hpp>         // meta::foldr
 #include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
 
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <iosfwd>                       // std::ostream
 
 namespace alpaka
@@ -306,6 +308,7 @@ namespace alpaka
                 TView & view,
                 std::uint8_t const & byte,
                 TExtent const & extent)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::TaskSet<
                     dim::Dim<TView>,
@@ -314,6 +317,7 @@ namespace alpaka
                     view,
                     byte,
                     extent))
+#endif
             {
                 static_assert(
                     dim::Dim<TView>::value == dim::Dim<TExtent>::value,
@@ -371,6 +375,7 @@ namespace alpaka
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::TaskCopy<
                     dim::Dim<TViewDst>,
@@ -380,6 +385,7 @@ namespace alpaka
                     viewDst,
                     viewSrc,
                     extent))
+#endif
             {
                 static_assert(
                     dim::Dim<TViewDst>::value == dim::Dim<TViewSrc>::value,

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -23,8 +23,10 @@
 
 #include <alpaka/meta/IntegerSequence.hpp>
 
-#include <utility>      // std::forward
-#include <type_traits>  // std::decay
+#include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <utility>                          // std::forward
+#include <type_traits>                      // std::decay
 
 namespace alpaka
 {
@@ -73,7 +75,9 @@ namespace alpaka
 
         template< class F, class... ArgTypes>
         auto invoke(F && f, ArgTypes &&... args)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(detail::invoke_impl(std::forward<F>(f), std::forward<ArgTypes>(args)...))
+#endif
         {
             return detail::invoke_impl(std::forward<F>(f), std::forward<ArgTypes>(args)...);
         }
@@ -85,10 +89,12 @@ namespace alpaka
         {
             template<class F, class Tuple, std::size_t... I>
             auto apply_impl( F && f, Tuple && t, meta::IndexSequence<I...> )
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 meta::invoke(
                     std::forward<F>(f),
                     std::get<I>(std::forward<Tuple>(t))...))
+#endif
             {
                 return
                     meta::invoke(
@@ -99,11 +105,13 @@ namespace alpaka
 
         template<class F, class Tuple>
         auto apply(F && f, Tuple && t)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(
             detail::apply_impl(
                 std::forward<F>(f),
                 std::forward<Tuple>(t),
                 meta::MakeIndexSequence<std::tuple_size<typename std::decay<Tuple>::type>::value>{}))
+#endif
         {
             return
                 detail::apply_impl(

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #if !defined(__CUDA_ARCH__)
     #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 #endif
@@ -52,25 +54,7 @@ namespace alpaka
 #endif
             return t;
         }
-#if __cplusplus >= 201402L
-        //-----------------------------------------------------------------------------
-        //!
-        //-----------------------------------------------------------------------------
-        ALPAKA_NO_HOST_ACC_WARNING
-        template<
-            typename TFnObj,
-            typename T0,
-            typename T1,
-            typename... Ts>
-        ALPAKA_FN_HOST_ACC auto foldr(
-            TFnObj const & f,
-            T0 const & t0,
-            T1 const & t1,
-            Ts const & ... ts)
-        {
-            return f(t0, foldr(f, t1, ts...));
-        }
-#else
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         namespace detail
         {
             //#############################################################################
@@ -131,6 +115,24 @@ namespace alpaka
         // http://stackoverflow.com/questions/11596898/variadic-template-and-inferred-return-type-in-concat/11597196#11597196
         //-> decltype(f(t0, foldr(f, t1, ts...)))
         -> typename detail::TypeOfFold<TFnObj, T0, T1, Ts...>::type
+        {
+            return f(t0, foldr(f, t1, ts...));
+        }
+#else
+        //-----------------------------------------------------------------------------
+        //!
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TFnObj,
+            typename T0,
+            typename T1,
+            typename... Ts>
+        ALPAKA_FN_HOST_ACC auto foldr(
+            TFnObj const & f,
+            T0 const & t0,
+            T1 const & t1,
+            Ts const & ... ts)
         {
             return f(t0, foldr(f, t1, ts...));
         }

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <utility>                  // std::declval
 #include <type_traits>              // std::is_integral, std::is_floating_point, ...
 
@@ -80,12 +82,14 @@ namespace alpaka
                 typename TRand>
             ALPAKA_FN_HOST_ACC auto createNormalReal(
                 TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::CreateNormalReal<
                     TRand,
                     T>
                 ::createNormalReal(
                     std::declval<TRand const &>()))
+#endif
             {
                 static_assert(
                     std::is_floating_point<T>::value,
@@ -107,12 +111,14 @@ namespace alpaka
                 typename TRand>
             ALPAKA_FN_HOST_ACC auto createUniformReal(
                 TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::CreateUniformReal<
                     TRand,
                     T>
                 ::createUniformReal(
                     std::declval<TRand const &>()))
+#endif
             {
                 static_assert(
                     std::is_floating_point<T>::value,
@@ -134,12 +140,14 @@ namespace alpaka
                 typename TRand>
             ALPAKA_FN_HOST_ACC auto createUniformUint(
                 TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::CreateUniformUint<
                     TRand,
                     T>
                 ::createUniformUint(
                     std::declval<TRand const &>()))
+#endif
             {
                 static_assert(
                     std::is_integral<T>::value && std::is_unsigned<T>::value,
@@ -173,9 +181,11 @@ namespace alpaka
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto createNormalReal(
                         TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                     -> decltype(
                         rand::distribution::createNormalReal<T>(
                             static_cast<typename TRand::RandBase const &>(rand)))
+#endif
                     {
                         // Delegate the call to the base class.
                         return
@@ -202,9 +212,11 @@ namespace alpaka
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto createUniformReal(
                         TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                     -> decltype(
                         rand::distribution::createUniformReal<T>(
                             static_cast<typename TRand::RandBase const &>(rand)))
+#endif
                     {
                         // Delegate the call to the base class.
                         return
@@ -231,9 +243,11 @@ namespace alpaka
                     ALPAKA_NO_HOST_ACC_WARNING
                     ALPAKA_FN_HOST_ACC static auto createUniformUint(
                         TRand const & rand)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                     -> decltype(
                         rand::distribution::createUniformUint<T>(
                             static_cast<typename TRand::RandBase const &>(rand)))
+#endif
                     {
                         // Delegate the call to the base class.
                         return
@@ -271,6 +285,7 @@ namespace alpaka
                 TRand const & rand,
                 std::uint32_t const & seed,
                 std::uint32_t const & subsequence)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 traits::CreateDefault<
                     TRand>
@@ -278,6 +293,7 @@ namespace alpaka
                     std::declval<TRand const &>(),
                     std::declval<std::uint32_t const &>(),
                     std::declval<std::uint32_t const &>()))
+#endif
             {
                 return
                     traits::CreateDefault<
@@ -308,11 +324,13 @@ namespace alpaka
                         TRand const & rand,
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                     -> decltype(
                         rand::generator::createDefault(
                             static_cast<typename TRand::RandBase const &>(rand),
                             seed,
                             subsequence))
+#endif
                     {
                         // Delegate the call to the base class.
                         return

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -27,6 +27,8 @@
 #include <alpaka/core/Positioning.hpp>      // origin::Grid/Blocks, unit::Blocks, unit::Threads
 #include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 
+#include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
 #include <type_traits>                      // std::enable_if, std::is_base_of, std::is_same, std::decay
 #include <utility>                          // std::forward
 
@@ -180,9 +182,11 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getWorkDiv(
                     TWorkDiv const & workDiv)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     workdiv::getWorkDiv<origin::Grid, unit::Blocks>(workDiv)
                     * workdiv::getWorkDiv<origin::Block, unit::Threads>(workDiv))
+#endif
                 {
                     return
                         workdiv::getWorkDiv<origin::Grid, unit::Blocks>(workDiv)
@@ -205,9 +209,11 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getWorkDiv(
                     TWorkDiv const & workDiv)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     workdiv::getWorkDiv<origin::Grid, unit::Threads>(workDiv)
                     * workdiv::getWorkDiv<origin::Thread, unit::Elems>(workDiv))
+#endif
                 {
                     return
                         workdiv::getWorkDiv<origin::Grid, unit::Threads>(workDiv)
@@ -230,9 +236,11 @@ namespace alpaka
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto getWorkDiv(
                     TWorkDiv const & workDiv)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
                 -> decltype(
                     workdiv::getWorkDiv<origin::Block, unit::Threads>(workDiv)
                     * workdiv::getWorkDiv<origin::Thread, unit::Elems>(workDiv))
+#endif
                 {
                     return
                         workdiv::getWorkDiv<origin::Block, unit::Threads>(workDiv)


### PR DESCRIPTION
Defining the return type of forwarding functions is not only cumbersome but leads to harder error messages. Using `BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION` to only include those `decltype` return type declarations for non C++14 capable compilers has many advantages:
* The compile time decreases by a factor of 2 in each template instantiation.
* Error messages for users specializing the traits get much better. Currently a wrong specialization leads to a message that the forwarding function itself could not be instantiated. However, there is no note about the user template that was tried to compile as the compilation already failed within the return type. By failing within the function, now the correct error messages get printed out to the user.