### PR TITLE
fix warnings

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -104,13 +104,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuFibers(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefFiberIdMap<TDim, TSize>(m_fibersToIndices),
                     atomic::AtomicNoOp(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_masterFiberId == boost::this_fiber::get_id());}),

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -105,13 +105,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Blocks(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
                     atomic::AtomicOmpCritSec(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStNoSync(),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStl(),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -104,13 +104,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Threads(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
                     atomic::AtomicOmpCritSec(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [](){return (::omp_get_thread_num() == 0);}),

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -104,13 +104,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuOmp4(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
                     atomic::AtomicOmpCritSec(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [](){return (::omp_get_thread_num() == 0);}),

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -98,13 +98,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuSerial(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
                     atomic::AtomicNoOp(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStNoSync(),
                     block::sync::BlockSyncNoOp(),
                     rand::RandStl(),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -101,13 +101,13 @@ namespace alpaka
                 typename TWorkDiv>
             ALPAKA_FN_ACC_NO_CUDA AccCpuThreads(
                 TWorkDiv const & workDiv,
-                std::size_t const & blockSharedMemDynSizeBytes) :
+                TSize const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefThreadIdMap<TDim, TSize>(m_threadToIndexMap),
                     atomic::AtomicStlLock(),
                     math::MathStl(),
-                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(blockSharedMemDynSizeBytes),
+                    block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(
                         [this](){block::sync::syncBlockThreads(*this);},
                         [this](){return (m_idMasterThread == std::this_thread::get_id());}),

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -299,7 +299,7 @@ namespace alpaka
                     TSize concurrentExecutionCount,
                     TSize queueSize = 128u) :
                     m_vConcurrentExecs(),
-                    m_qTasks(queueSize),
+                    m_qTasks(static_cast<std::size_t>(queueSize)),
                     m_bShutdownFlag(false)
                 {
                     if(concurrentExecutionCount < 1)
@@ -311,7 +311,7 @@ namespace alpaka
                         throw std::invalid_argument("The argument 'queueSize' has to be greate or equal to one!");
                     }
 
-                    m_vConcurrentExecs.reserve(concurrentExecutionCount);
+                    m_vConcurrentExecs.reserve(static_cast<std::size_t>(concurrentExecutionCount));
 
                     // Create all concurrent executors.
                     for(TSize concurrentExec(0u); concurrentExec < concurrentExecutionCount; ++concurrentExec)
@@ -516,7 +516,7 @@ namespace alpaka
                     TSize concurrentExecutionCount,
                     TSize queueSize = 128u) :
                     m_vConcurrentExecs(),
-                    m_qTasks(queueSize),
+                    m_qTasks(static_cast<std::size_t>(queueSize)),
                     m_mtxWakeup(),
                     m_bShutdownFlag(false),
                     m_cvWakeup()
@@ -530,7 +530,7 @@ namespace alpaka
                         throw std::invalid_argument("The argument 'queueSize' has to be greate or equal to one!");
                     }
 
-                    m_vConcurrentExecs.reserve(concurrentExecutionCount);
+                    m_vConcurrentExecs.reserve(static_cast<std::size_t>(concurrentExecutionCount));
 
                     // Create all concurrent executors.
                     for(TSize concurrentExec(0u); concurrentExec < concurrentExecutionCount; ++concurrentExec)

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -191,7 +191,7 @@ namespace alpaka
                                 std::memcpy(
                                     reinterpret_cast<void *>(m_dstMemNative),
                                     reinterpret_cast<void const *>(m_srcMemNative),
-                                    m_dstPitchBytesX * m_extentHeight * m_extentDepth);
+                                    static_cast<std::size_t>(m_dstPitchBytesX * m_extentHeight * m_extentDepth));
                             }
                             else
                             {
@@ -202,7 +202,7 @@ namespace alpaka
                                         std::memcpy(
                                             reinterpret_cast<void *>(m_dstMemNative + z*m_dstPitchBytesY),
                                             reinterpret_cast<void const *>(m_srcMemNative + z*m_srcPitchBytesY),
-                                            m_dstPitchBytesX*m_extentHeight);
+                                            static_cast<std::size_t>(m_dstPitchBytesX*m_extentHeight));
                                     }
                                     else
                                     {
@@ -211,7 +211,7 @@ namespace alpaka
                                             std::memcpy(
                                                 reinterpret_cast<void *>(m_dstMemNative + y*m_dstPitchBytesX + z*m_dstPitchBytesY),
                                                 reinterpret_cast<void const *>(m_srcMemNative + y*m_srcPitchBytesX + z*m_srcPitchBytesY),
-                                                m_extentWidthBytes);
+                                                static_cast<std::size_t>(m_extentWidthBytes));
                                         }
                                     }
                                 }

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -23,6 +23,7 @@
 
 #include <alpaka/meta/IntegerSequence.hpp>
 
+#include <boost/core/ignore_unused.hpp>     // boost::ignore_unused
 #include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 
 #include <utility>                          // std::forward
@@ -96,6 +97,8 @@ namespace alpaka
                     std::get<I>(std::forward<Tuple>(t))...))
 #endif
             {
+                // If the the index sequence is empty, t will not be used at all.
+                boost::ignore_unused(t);
                 return
                     meta::invoke(
                         std::forward<F>(f),

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -33,6 +33,7 @@
 #include <alpaka/test/mem/view/Iterator.hpp>    // Iterator
 
 #include <boost/test/unit_test.hpp>
+#include <boost/predef.h>                       // workarounds
 
 #include <type_traits>                          // std::is_same
 #include <numeric>                              // std::iota
@@ -366,7 +367,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     View view(buf, extentView, offsetView);
 
     // Init buf with increasing values
-    std::vector<Elem> v(extentBuf.prod(), static_cast<Elem>(0u));
+    std::vector<Elem> v(static_cast<std::size_t>(extentBuf.prod()), static_cast<Elem>(0u));
     std::iota(v.begin(), v.end(), static_cast<Elem>(0u));
     ViewPlainPtr plainBuf(v.data(), devHost, extentBuf);
     alpaka::mem::view::copy(stream, buf, plainBuf, extentBuf);
@@ -466,7 +467,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     using View = alpaka::mem::view::ViewSubView<DevAcc, Elem, Dim, Size>;
     using ViewPlainPtr = alpaka::mem::view::ViewPlainPtr<DevHost, Elem, Dim, Size>;
 
+#if BOOST_COMP_MSVC
+    #pragma warning(push)
+    #pragma warning(disable: 4127) // conditional expression is constant
+#endif
+
     if(Dim::value != 4)
+
+#if BOOST_COMP_MSVC
+    #pragma warning(pop)
+#endif
     {
         DevHost devHost (alpaka::dev::DevMan<Host>::getDevByIdx(0));
         DevAcc devAcc(alpaka::dev::DevMan<TAcc>::getDevByIdx(0u));


### PR DESCRIPTION
This fixes many of the remaining warnings by introducing explicit casts or explicitly ignoring them.