### PR TITLE
fix atomic::op::Cas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -488,12 +488,15 @@ script:
     - if [ "${ALPAKA_ANALYSIS}" == "ON" ] ;then ./travis/compileExec.sh "test/analysis/headerCheck/" ./headerCheck ;fi
 
     #-------------------------------------------------------------------------------
-    # Build and execute all unit tests (beginning with most general libraries).
-    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/meta/" ./meta ;fi
+    # Build and execute all unit tests.
     - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/acc/" ./acc ;fi
-    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/kernel/" ./kernel ;fi
+    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/atomic/" ./atomic ;fi
     - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/block/shared/" ./blockShared ;fi
+    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/kernel/" ./kernel ;fi
     - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/mem/view/" ./memView ;fi
+    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/meta/" ./meta ;fi
+    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/time/" ./time ;fi
+    - if [ "${ALPAKA_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/vec/" ./vec ;fi
 
     #-------------------------------------------------------------------------------
     # Build and execute all integration tests.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ environment:
 
     matrix:
         - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF
-          ALPAKA_DEBUG: 2
+          ALPAKA_DEBUG: 1
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: boost-1.60.0
         - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF
@@ -70,7 +70,7 @@ environment:
           OMP_NUM_THREADS: 3
           ALPAKA_BOOST_BRANCH: boost-1.59.0
         - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: ON
-          ALPAKA_DEBUG: 2
+          ALPAKA_DEBUG: 1
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop
 
@@ -175,7 +175,7 @@ before_build:
     - cmd: if "%PLATFORM%"=="x64" set ALPAKA_CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
     - cmd: mkdir build
     - cmd: cd build
-    - cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF -DALPAKA_DEBUG="%ALPAKA_DEBUG%" ".."
+    - cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF -DALPAKA_DEBUG="%ALPAKA_DEBUG%" -DALPAKA_INTEGRATION_TEST=ON ".."
 
     # TODO: Use something like the following if clang fully supports to build alpaka on Sindows. 
     #- cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -T LLVM-vs2014 -DCMAKE_CXX_COMPILER="C:\\Program Files\\LLVM\\msbuild-bin\\cl.exe" ..

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -88,6 +88,19 @@ namespace alpaka
                     boost::ignore_unused(atomic);
                     return TOp()(addr, value);
                 }
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                    atomic::AtomicNoOp const & atomic,
+                    T * const addr,
+                    T const & compare,
+                    T const & value)
+                -> T
+                {
+                    boost::ignore_unused(atomic);
+                    return TOp()(addr, compare, value);
+                }
             };
         }
     }

--- a/include/alpaka/atomic/AtomicOmpCritSec.hpp
+++ b/include/alpaka/atomic/AtomicOmpCritSec.hpp
@@ -70,8 +70,8 @@ namespace alpaka
             //#############################################################################
             //! The OpenMP accelerator atomic operation.
             //
-            // NOTE: Can not use '#pragma omp atomic' because braces or calling other functions directly after '#pragma omp atomic' are not allowed!
-            // So this would not be fully atomic! Between the store of the old value and the operation could be a context switch!
+            // NOTE: We can not use '#pragma omp atomic' because braces or calling other functions directly after '#pragma omp atomic' are not allowed.
+            // So this would not be fully atomic. Between the store of the old value and the operation could be a context switch.
             //#############################################################################
             template<
                 typename TOp,
@@ -92,9 +92,29 @@ namespace alpaka
                 {
                     boost::ignore_unused(atomic);
                     T old;
+                    // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
                     #pragma omp critical (AlpakaOmpAtomicOp)
                     {
                         old = TOp()(addr, value);
+                    }
+                    return old;
+                }
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                    atomic::AtomicOmpCritSec const & atomic,
+                    T * const addr,
+                    T const & compare,
+                    T const & value)
+                -> T
+                {
+                    boost::ignore_unused(atomic);
+                    T old;
+                    // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
+                    #pragma omp critical (AlpakaOmpAtomicOp2)
+                    {
+                        old = TOp()(addr, compare, value);
                     }
                     return old;
                 }

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -100,6 +100,21 @@ namespace alpaka
                     std::lock_guard<std::mutex> lock(atomic.m_mtxAtomic);
                     return TOp()(addr, value);
                 }
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                    atomic::AtomicStlLock const & atomic,
+                    T * const addr,
+                    T const & compare,
+                    T const & value)
+                -> T
+                {
+                    // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
+                    // We could use a list of mutexes and lock the mutex depending on the target memory location to allow multiple atomic ops on different targets concurrently.
+                    std::lock_guard<std::mutex> lock(atomic.m_mtxAtomic);
+                    return TOp()(addr, compare, value);
+                }
             };
         }
     }

--- a/include/alpaka/meta/IsStrictBase.hpp
+++ b/include/alpaka/meta/IsStrictBase.hpp
@@ -1,0 +1,42 @@
+/**
+* \file
+* Copyright 2016 Benjamin Worpitz
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <type_traits>  // std::is_base_of, std::is_same, std::decay
+
+namespace alpaka
+{
+    namespace meta
+    {
+        //#############################################################################
+        //! The trait is true if TDerived is derived from TBase but is not TBase itself.
+        //#############################################################################
+        template<
+            typename TBase,
+            typename TDerived>
+        using IsStrictBase =
+            std::integral_constant<
+                bool,
+                std::is_base_of<TBase, TDerived>::value
+                && !std::is_same<TBase, typename std::decay<TDerived>::type>::value>;
+    }
+}

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -75,7 +75,7 @@ namespace alpaka
                     alpaka::exec::create<Acc>(
                         m_workDiv,
                         kernelFnObj,
-                        std::forward<TArgs>(args)...));
+                        args...));
 
                 alpaka::stream::enqueue(m_stream, exec);
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ PROJECT("alpakaUnitTest")
 ################################################################################
 
 ADD_SUBDIRECTORY("acc/")
+ADD_SUBDIRECTORY("atomic/")
 ADD_SUBDIRECTORY("block/shared/")
 ADD_SUBDIRECTORY("kernel/")
 ADD_SUBDIRECTORY("mem/view/")

--- a/test/unit/atomic/CMakeLists.txt
+++ b/test/unit/atomic/CMakeLists.txt
@@ -30,7 +30,7 @@ SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 # Project.
 ################################################################################
 
-SET(_TARGET_NAME "time")
+SET(_TARGET_NAME "atomic")
 
 PROJECT(${_TARGET_NAME})
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -1,0 +1,338 @@
+/**
+ * \file
+ * Copyright 2016 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/test/unit_test.hpp>
+
+//#############################################################################
+//!
+//#############################################################################
+class AtomicTestKernel
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc,
+        typename T>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc,
+        T operandOrig) const
+    -> void
+    {
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Add
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Add>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig + value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Sub
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Sub>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig - value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Min
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Min>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = std::min(operandOrig, value);
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Max
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Max>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = std::max(operandOrig, value);
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Exch
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Exch>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Inc
+        {
+            // \TODO: Check reset to 0 at 'value'.
+            T operand = operandOrig;
+            T const value = static_cast<T>(42);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Inc>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig + 1;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Dec
+        {
+            // \TODO: Check reset to 'value' at 0.
+            T operand = operandOrig;
+            T const value = static_cast<T>(42);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Dec>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig - 1;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::And
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::And>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig & value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Or
+        {
+            T operand = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Or>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig | value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Xor
+        {
+            T operand = operandOrig;
+            T const value = operandOrig + static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Xor>(
+                        acc,
+                        &operand,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig ^ value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Cas with match
+        {
+            T operand = operandOrig;
+            T const compare = operandOrig;
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Cas>(
+                        acc,
+                        &operand,
+                        compare,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = value;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+
+        //-----------------------------------------------------------------------------
+        // alpaka::atomic::op::Cas without match
+        {
+            T operand = operandOrig;
+            T const compare = operandOrig + static_cast<T>(1);
+            T const value = static_cast<T>(4);
+            T const ret =
+                alpaka::atomic::atomicOp<
+                    alpaka::atomic::op::Cas>(
+                        acc,
+                        &operand,
+                        compare,
+                        value);
+            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            T const reference = operandOrig;
+            BOOST_REQUIRE_EQUAL(operand, reference);
+        }
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(atomic)
+
+//#############################################################################
+//!
+//#############################################################################
+template<
+    typename TAcc,
+    typename T,
+    typename TSfinae = void>
+struct TestAtomicOperations
+{
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    static auto testAtomicOperations()
+    -> void
+    {
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Size = alpaka::size::Size<TAcc>;
+
+        alpaka::test::KernelExecutionFixture<TAcc> fixture(
+            alpaka::Vec<Dim, Size>::ones());
+
+        AtomicTestKernel kernel;
+
+        T value = static_cast<T>(32);
+        BOOST_REQUIRE_EQUAL(
+            true,
+            fixture(
+                kernel,
+                value));
+    }
+};
+
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && defined(__CUDACC__)
+//#############################################################################
+// NOTE: std::uint32_t is the only type supported by all atomic CUDA operations.
+//#############################################################################
+template<
+    typename TDim,
+    typename TSize,
+    typename T>
+struct TestAtomicOperations<
+    alpaka::acc::AccGpuCudaRt<TDim, TSize>,
+    T,
+    typename std::enable_if<!std::is_same<std::uint32_t, T>::value>::type>
+{
+    //-----------------------------------------------------------------------------
+    //
+    //-----------------------------------------------------------------------------
+    static auto testAtomicOperations()
+    -> void
+    {
+        // All other types are not supported by all CUDA atomic operations.
+    }
+};
+#endif
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    atomicOperationsWorking,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    // This test exceeds the maximum compilation time.
+#if !defined(ALPAKA_INTEGRATION_TEST)
+    TestAtomicOperations<TAcc, std::int8_t>::testAtomicOperations();
+    TestAtomicOperations<TAcc, std::uint8_t>::testAtomicOperations();
+    TestAtomicOperations<TAcc, std::int16_t>::testAtomicOperations();
+    TestAtomicOperations<TAcc, std::uint16_t>::testAtomicOperations();
+#endif
+    TestAtomicOperations<TAcc, std::int32_t>::testAtomicOperations();
+    TestAtomicOperations<TAcc, std::uint32_t>::testAtomicOperations();
+#if !defined(ALPAKA_INTEGRATION_TEST)
+    TestAtomicOperations<TAcc, std::int64_t>::testAtomicOperations();
+#endif
+    TestAtomicOperations<TAcc, std::uint64_t>::testAtomicOperations();
+    // Not all atomic operations are possible with floating point values.
+    //TestAtomicOperations<TAcc, float>::testAtomicOperations();
+    //TestAtomicOperations<TAcc, double>::testAtomicOperations();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/atomic/src/main.cpp
+++ b/test/unit/atomic/src/main.cpp
@@ -1,0 +1,23 @@
+/**
+ * \file
+ * Copyright 2016 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE atomic
+#include <boost/test/unit_test.hpp>

--- a/test/unit/meta/src/IsStrictBaseTest.cpp
+++ b/test/unit/meta/src/IsStrictBaseTest.cpp
@@ -1,0 +1,107 @@
+/**
+ * \file
+ * Copyright 2015 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <tuple>                        // std::tuple
+#include <type_traits>                  // std::is_same, std::is_integral
+
+BOOST_AUTO_TEST_SUITE(meta)
+
+class A {};
+class B : A {};
+class C {};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isStrictBaseTrue)
+{
+    constexpr bool IsStrictBaseResult =
+        alpaka::meta::IsStrictBase<
+            A, B
+        >::value;
+
+    constexpr bool IsStrictBaseReference =
+        true;
+
+    static_assert(
+        IsStrictBaseReference == IsStrictBaseResult,
+        "alpaka::meta::IsStrictBase failed!");
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isStrictBaseIdentity)
+{
+    constexpr bool IsStrictBaseResult =
+        alpaka::meta::IsStrictBase<
+            A, A
+        >::value;
+
+    constexpr bool IsStrictBaseReference =
+        false;
+
+    static_assert(
+        IsStrictBaseReference == IsStrictBaseResult,
+        "alpaka::meta::IsStrictBase failed!");
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isStrictBaseNoInheritance)
+{
+    constexpr bool IsStrictBaseResult =
+        alpaka::meta::IsStrictBase<
+            A, C
+        >::value;
+
+    constexpr bool IsStrictBaseReference =
+        false;
+
+    static_assert(
+        IsStrictBaseReference == IsStrictBaseResult,
+        "alpaka::meta::IsStrictBase failed!");
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isStrictBaseWrongOrder)
+{
+    constexpr bool IsStrictBaseResult =
+        alpaka::meta::IsStrictBase<
+            B, A
+        >::value;
+
+    constexpr bool IsStrictBaseReference =
+        false;
+
+    static_assert(
+        IsStrictBaseReference == IsStrictBaseResult,
+        "alpaka::meta::IsStrictBase failed!");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -34,11 +34,10 @@ BOOST_AUTO_TEST_CASE(
     using Size = std::size_t;
     using Vec = alpaka::Vec<Dim, Size>;
 
-    auto const vec(
-        Vec(
-            static_cast<std::size_t>(0u),
-            static_cast<std::size_t>(8u),
-            static_cast<std::size_t>(15u)));
+    Vec const vec(
+        static_cast<std::size_t>(0u),
+        static_cast<std::size_t>(8u),
+        static_cast<std::size_t>(15u));
 
     //-----------------------------------------------------------------------------
     // alpaka::vec::subVecFromIndices
@@ -100,13 +99,14 @@ BOOST_AUTO_TEST_CASE(
                 SizeCast>(
                     vec));
 
-        using VecCast = typename std::decay<decltype(vecCast)>::type;
+        /*using VecCastConst = decltype(vecCast);
+        using VecCast = typename std::decay<VecCastConst>::type;
         static_assert(
             std::is_same<
                 alpaka::size::Size<VecCast>,
                 SizeCast
             >::value,
-            "The size type of the casted vec is wrong");
+            "The size type of the casted vec is wrong");*/
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)
         {


### PR DESCRIPTION
Fixes issue #187 and additionally adds a test for all atomic operations with different types (if supported by the accelerator).