### PR TITLE
more intricate argument evaluation for alpaka_add_library

### DIFF
--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -18,22 +18,107 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
 
 #------------------------------------------------------------------------------
-# Calls CUDA_ADD_EXECUTABLE or ADD_EXECUTABLE depending on the enabled alpaka accelerators.
+# Calls CUDA_ADD_LIBRARY or ADD_LIBRARY depending on the enabled alpaka
+# accelerators.
+#
+# ALPAKA_ADD_LIBRARY( cuda_target file0 file1 ... [STATIC | SHARED | MODULE]
+#   [EXCLUDE_FROM_ALL] [OPTIONS <nvcc-flags> ... ] )
+#
+# In order to be compliant with both ADD_LIBRARY and CUDA_ADD_LIBRARY
+# the position of STATIC, SHARED, MODULE, EXCLUDE_FROM_ALL options don't matter.
+# This also means you won't be able to include files with those exact same
+# case-sensitive names.
+# After OPTIONS only nvcc compiler flags are allowed though. And for readiblity
+# and portability you shouldn't completely mix STATIC, ... with the source
+# code filenames!
+# OPTIONS and the arguments thereafter are ignored if not using CUDA, they
+# won't throw an error in that case.
 #------------------------------------------------------------------------------
-FUNCTION(ALPAKA_ADD_LIBRARY In_Name)
-    IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
-        FOREACH(_file ${ARGN})
-            IF((${_file} MATCHES "\\.cpp$") OR (${_file} MATCHES "\\.cxx$"))
-                SET_SOURCE_FILES_PROPERTIES(${_file} PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ)
+FUNCTION(ALPAKA_ADD_LIBRARY libraryName)
+    # CUDA_ADD_LIBRARY( cuda_target file0 file1 ...
+    #                   [STATIC | SHARED | MODULE]
+    #                   [EXCLUDE_FROM_ALL] [OPTIONS <nvcc-flags> ... ] )
+    # add_library( <name> [STATIC | SHARED | MODULE]
+    #              [EXCLUDE_FROM_ALL]
+    #              source1 [source2 ...] )
+
+    # traverse arguments and sort them by option and source files
+    SET( arguments ${ARGN} )
+    SET( optionsEncountered OFF )
+    UNSET( libraryType )
+    UNSET( excludeFromAll )
+    UNSET( optionArguments )
+    FOREACH( argument IN LISTS arguments )
+        # 1.) check for OPTIONS
+        IF( argument STREQUAL "OPTIONS" )
+            IF ( optionsEncountered )
+                MESSAGE( FATAL_ERROR "[ALPAKA_ADD_LIBRARY] OPTIONS subcommand specified more than one time. This is not allowed!" )
+            ELSE()
+                SET( optionsEncountered ON )
+            ENDIF()
+        ENDIF()
+
+        # 2.) check if inside OPTIONS, because then all other checks are
+        # unnecessary although they could give hints about wrong locations
+        # of those subcommands
+        IF( optionsEncountered )
+            LIST( APPEND optionArguments "${argument}" )
+            CONTINUE()
+        ENDIF()
+
+        # 3.) check for libraryType and EXCLUDE_FROM_ALL
+        IF( ( argument STREQUAL "STATIC" ) OR
+            ( argument STREQUAL "SHARED" ) OR
+            ( argument STREQUAL "MODULE" )
+        )
+            IF( DEFINED libraryType )
+                message( FATAL_ERROR "Setting more than one library type option ( STATIC SHARED MODULE ) not allowed!" )
+            ENDIF()
+            set( libraryType ${argument} )
+            CONTINUE()
+        ENDIF()
+        IF( argument STREQUAL "EXCLUDE_FROM_ALL" )
+            SET( excludeFromAll ${argument} )
+            CONTINUE()
+        ENDIF()
+
+        # 4.) ELSE the argument is a file name
+        list( APPEND sourceFileNames "${argument}" )
+    ENDFOREACH()
+    UNSET( optionsEncountered )
+    #message( "libraryType = ${libraryType}" )
+    #message( "sourceFileNames = ${sourceFileNames}" )
+
+    # call add_library or cuda_add_library now
+    IF( ALPAKA_ACC_GPU_CUDA_ENABLE )
+        FOREACH( _file ${ARGN} )
+            IF( ( ${_file} MATCHES "\\.cpp$" ) OR
+                ( ${_file} MATCHES "\\.cxx$" )
+            )
+                SET_SOURCE_FILES_PROPERTIES( ${_file} PROPERTIES CUDA_SOURCE_PROPERTY_FORMAT OBJ )
             ENDIF()
         ENDFOREACH()
         CMAKE_POLICY(SET CMP0023 OLD)   # CUDA_ADD_LIBRARY calls TARGET_LINK_LIBRARIES without keywords.
         CUDA_ADD_LIBRARY(
-            ${In_Name}
-            ${ARGN})
+            ${libraryName}
+            ${sourceFileNames}
+            ${libraryType}
+            ${excludeFromAll}
+            ${optionArguments}
+        )
     ELSE()
+        #message( "add_library( ${libraryName} ${libraryType} ${excludeFromAll} ${sourceFileNames} )" )
         ADD_LIBRARY(
-            ${In_Name}
-            ${ARGN})
+            ${libraryName}
+            ${libraryType}
+            ${excludeFromAll}
+            ${sourceFileNames}
+        )
     ENDIF()
+
+    # UNSET variables (not sure if necessary)
+    UNSET( libraryType )
+    UNSET( sourceFileNames )
+    UNSET( excludeFromAll )
+    UNSET( optionArguments )
 ENDFUNCTION()


### PR DESCRIPTION
The problem here is the following positional argument difference:

    CUDA_ADD_LIBRARY( <name> file0 file1 ...  [STATIC | SHARED | MODULE]
    add_library( <name> [STATIC | SHARED | MODULE]  source1 [source2 ...] )

If one works, then the other won't work. E.g. the error message would be:

    CMake Error at cupla/alpaka/cmake/addLibrary.cmake:35 (ADD_LIBRARY):
      Cannot find source file:

        STATIC

      Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp
      .hxx .in .txx
    Call Stack (most recent call first):
      CMakeLists.txt:146 (alpaka_add_library)

This commit automatically reorders `STATIC` and other arguments as needed. Of course this means, that for more complex library calls this function may need to be extended. E.g. `add_library` supports an `ALIAS` subcommand which `ADD_CUDA_LIBRARY` doesn't and so on.