### PR TITLE
fix `getFreeGlobalMemSizeBytes`

### DIFF
--- a/include/alpaka/dev/cpu/SysInfo.hpp
+++ b/include/alpaka/dev/cpu/SysInfo.hpp
@@ -221,7 +221,7 @@ namespace alpaka
                                 std::size_t freeGlobalMemSizeBytes(0);
                                 if(file >> freeGlobalMemSizeBytes)
                                 {
-                                    return freeGlobalMemSizeBytes;
+                                    return freeGlobalMemSizeBytes * size_t(1024);
                                 }
                                 else
                                 {


### PR DESCRIPTION
`/proc/meminfo` defines memory in `KiB` and not byte.
add missing factor `1024` to fix the issue