### PR TITLE
consistently use meta::IsStrictBase

### DIFF
--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
-
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
+
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -21,9 +21,11 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -92,8 +94,11 @@ namespace alpaka
                         T,
                         TBlockSharedMemDyn,
                         typename std::enable_if<
-                            std::is_base_of<typename TBlockSharedMemDyn::BlockSharedMemDynBase, typename std::decay<TBlockSharedMemDyn>::type>::value
-                            && (!std::is_same<typename TBlockSharedMemDyn::BlockSharedMemDynBase, typename std::decay<TBlockSharedMemDyn>::type>::value)>::type>
+                            meta::IsStrictBase<
+                                typename TBlockSharedMemDyn::BlockSharedMemDynBase,
+                                TBlockSharedMemDyn
+                            >::value
+                        >::type>
                     {
                         //-----------------------------------------------------------------------------
                         //!

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -21,9 +21,11 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -167,8 +169,11 @@ namespace alpaka
                         TuniqueId,
                         TBlockSharedMemSt,
                         typename std::enable_if<
-                            std::is_base_of<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value
-                            && (!std::is_same<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value)>::type>
+                            meta::IsStrictBase<
+                                typename TBlockSharedMemSt::BlockSharedMemStBase,
+                                TBlockSharedMemSt
+                            >::value
+                        >::type>
                     {
                         //-----------------------------------------------------------------------------
                         //!
@@ -200,8 +205,11 @@ namespace alpaka
                         TuniqueId,
                         TBlockSharedMemSt,
                         typename std::enable_if<
-                            std::is_base_of<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value
-                            && (!std::is_same<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value)>::type>
+                            meta::IsStrictBase<
+                                typename TBlockSharedMemSt::BlockSharedMemStBase,
+                                TBlockSharedMemSt
+                            >::value
+                        >::type>
                     {
                         //-----------------------------------------------------------------------------
                         //!
@@ -228,8 +236,11 @@ namespace alpaka
                     struct FreeMem<
                         TBlockSharedMemSt,
                         typename std::enable_if<
-                            std::is_base_of<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value
-                            && (!std::is_same<typename TBlockSharedMemSt::BlockSharedMemStBase, typename std::decay<TBlockSharedMemSt>::type>::value)>::type>
+                            meta::IsStrictBase<
+                                typename TBlockSharedMemSt::BlockSharedMemStBase,
+                                TBlockSharedMemSt
+                            >::value
+                        >::type>
                     {
                         //-----------------------------------------------------------------------------
                         //!

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -21,9 +21,11 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -80,8 +82,11 @@ namespace alpaka
                 struct SyncBlockThread<
                     TBlockSync,
                     typename std::enable_if<
-                        std::is_base_of<typename TBlockSync::BlockSyncBase, typename std::decay<TBlockSync>::type>::value
-                        && (!std::is_same<typename TBlockSync::BlockSyncBase, typename std::decay<TBlockSync>::type>::value)>::type>
+                        meta::IsStrictBase<
+                            typename TBlockSync::BlockSyncBase,
+                            TBlockSync
+                        >::value
+                    >::type>
                 {
                     //-----------------------------------------------------------------------------
                     //!

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -27,12 +27,12 @@
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
-#include <alpaka/meta/IntegerSequence.hpp>  // IntegerSequence
 #include <alpaka/elem/Traits.hpp>           // ElemType
 #include <alpaka/offset/Traits.hpp>         // GetOffset/SetOffset
 #include <alpaka/extent/Traits.hpp>         // GetExtent/SetExtent
 #include <alpaka/size/Traits.hpp>           // SizeType
 #include <alpaka/vec/Vec.hpp>               // Vec
+#include <alpaka/meta/IntegerSequence.hpp>  // IntegerSequence
 #include <alpaka/meta/Metafunctions.hpp>    // meta::Conjunction
 #include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST
 

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -21,14 +21,17 @@
 
 #pragma once
 
+#include <alpaka/meta/IsStrictBase.hpp>     // meta::IsStrictBase
+
+#include <alpaka/core/Positioning.hpp>      // origin::Grid/Blocks, unit::Blocks, unit::Threads
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+
+#include <alpaka/vec/Vec.hpp>               // Vec<N>
+
 #include <alpaka/dim/Traits.hpp>            // dim::DimType
 #include <alpaka/dim/DimIntegralConst.hpp>  // dim::DimInt<N>
 #include <alpaka/size/Traits.hpp>           // size::traits::SizeType
 #include <alpaka/workdiv/Traits.hpp>        // workdiv::getWorkDiv
-
-#include <alpaka/core/Positioning.hpp>      // origin::Grid/Blocks, unit::Blocks, unit::Threads
-#include <alpaka/vec/Vec.hpp>               // Vec<N>
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 
 #include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 
@@ -114,8 +117,11 @@ namespace alpaka
                 origin::Grid,
                 unit::Blocks,
                 typename std::enable_if<
-                    std::is_base_of<typename TIdxGb::IdxGbBase, typename std::decay<TIdxGb>::type>::value
-                    && (!std::is_same<typename TIdxGb::IdxGbBase, typename std::decay<TIdxGb>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TIdxGb::IdxGbBase,
+                        TIdxGb
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //! \return The index of the current thread in the grid.
@@ -148,8 +154,11 @@ namespace alpaka
                 origin::Block,
                 unit::Threads,
                 typename std::enable_if<
-                    std::is_base_of<typename TIdxBt::IdxBtBase, typename std::decay<TIdxBt>::type>::value
-                    && (!std::is_same<typename TIdxBt::IdxBtBase, typename std::decay<TIdxBt>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TIdxBt::IdxBtBase,
+                        TIdxBt
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //! \return The index of the current thread in the grid.

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -92,8 +94,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::AbsBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::AbsBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::AbsBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -88,8 +90,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::AcosBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::AcosBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::AcosBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -88,8 +90,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::AsinBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::AsinBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::AsinBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -88,8 +90,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::AtanBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::AtanBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::AtanBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -100,8 +102,11 @@ namespace alpaka
                 Ty,
                 Tx,
                 typename std::enable_if<
-                    std::is_base_of<typename T::Atan2Base, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::Atan2Base, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::Atan2Base,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::CbrtBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::CbrtBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::CbrtBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::CeilBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::CeilBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::CeilBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::CosBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::CosBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::CosBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::ErfBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::ErfBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::ErfBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -88,8 +90,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::ExpBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::ExpBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::ExpBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::FloorBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::FloorBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::FloorBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -98,8 +100,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::FmodBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::FmodBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::FmodBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::LogBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::LogBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::LogBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -101,8 +103,11 @@ namespace alpaka
                 Tx,
                 Ty,
                 typename std::enable_if<
-                    std::is_base_of<typename T::MaxBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::MaxBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::MaxBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -101,8 +103,11 @@ namespace alpaka
                 Tx,
                 Ty,
                 typename std::enable_if<
-                    std::is_base_of<typename T::MinBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::MinBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::MinBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -100,8 +102,11 @@ namespace alpaka
                 TBase,
                 TExp,
                 typename std::enable_if<
-                    std::is_base_of<typename T::PowBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::PowBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::PowBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -100,8 +102,11 @@ namespace alpaka
                 Tx,
                 Ty,
                 typename std::enable_if<
-                    std::is_base_of<typename T::RemainderBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::RemainderBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::RemainderBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -157,8 +159,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::RoundBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::RoundBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::RoundBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -191,8 +196,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::RoundBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::RoundBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::RoundBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -225,8 +233,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::RoundBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::RoundBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::RoundBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::RsqrtBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::RsqrtBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::RsqrtBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::SinBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::SinBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::SinBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::SqrtBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::SqrtBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::SqrtBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::TanBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::TanBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::TanBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -21,11 +21,13 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -89,8 +91,11 @@ namespace alpaka
                 T,
                 TArg,
                 typename std::enable_if<
-                    std::is_base_of<typename T::TruncBase, typename std::decay<T>::type>::value
-                    && (!std::is_same<typename T::TruncBase, typename std::decay<T>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename T::TruncBase,
+                        T
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -20,11 +20,12 @@
 */
 
 #pragma once
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/dev/Traits.hpp>    // dev::Dev
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
-#include <alpaka/dev/Traits.hpp>        // dev::Dev
+#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 
-#include <vector>                       // std::vector
+#include <vector>                   // std::vector
 
 namespace alpaka
 {
@@ -76,7 +77,9 @@ namespace alpaka
         template<
             typename TPltf>
         ALPAKA_FN_HOST auto getDevCount()
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(traits::GetDevCount<TPltf>::getDevCount())
+#endif
         {
             return
                 traits::GetDevCount<
@@ -91,7 +94,9 @@ namespace alpaka
             typename TPltf>
         ALPAKA_FN_HOST auto getDevByIdx(
             std::size_t const & devIdx)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> decltype(traits::GetDevByIdx<TPltf>::getDevByIdx(devIdx))
+#endif
         {
             return
                 traits::GetDevByIdx<

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -21,12 +21,14 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <utility>                  // std::declval
-#include <type_traits>              // std::is_integral, std::is_floating_point, ...
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <utility>                      // std::declval
+#include <type_traits>                  // std::is_integral, std::is_floating_point, ...
 
 namespace alpaka
 {
@@ -313,8 +315,11 @@ namespace alpaka
                 struct CreateDefault<
                     TRand,
                     typename std::enable_if<
-                        std::is_base_of<typename TRand::RandBase, typename std::decay<TRand>::type>::value
-                        && (!std::is_same<typename TRand::RandBase, typename std::decay<TRand>::type>::value)>::type>
+                        meta::IsStrictBase<
+                            typename TRand::RandBase,
+                            TRand
+                        >::value
+                    >::type>
                 {
                     //-----------------------------------------------------------------------------
                     //

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -21,9 +21,11 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <type_traits>              // std::enable_if, std::is_base_of, std::is_same, std::decay
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+
+#include <type_traits>                  // std::enable_if
 
 namespace alpaka
 {
@@ -76,8 +78,11 @@ namespace alpaka
             struct Clock<
                 TTime,
                 typename std::enable_if<
-                    std::is_base_of<typename TTime::TimeBase, typename std::decay<TTime>::type>::value
-                    && (!std::is_same<typename TTime::TimeBase, typename std::decay<TTime>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TTime::TimeBase,
+                        TTime
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //!

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -28,10 +28,10 @@
 #include <alpaka/offset/Traits.hpp>         // offset::getOffsetX, ...
 #include <alpaka/size/Traits.hpp>           // size::traits::SizeType
 
-#include <alpaka/core/Align.hpp>            // ALPAKA_OPTIMAL_ALIGNMENT_SIZE
 #include <alpaka/meta/IntegerSequence.hpp>  // meta::MakeIntegerSequence
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 #include <alpaka/meta/Fold.hpp>             // meta::foldr
+#include <alpaka/core/Align.hpp>            // ALPAKA_OPTIMAL_ALIGNMENT_SIZE
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
 
 #include <boost/predef.h>                   // workarounds
 #include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -21,16 +21,18 @@
 
 #pragma once
 
-#include <alpaka/size/Traits.hpp>           // Size
+#include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/vec/Vec.hpp>               // Vec<N>
-#include <alpaka/core/Positioning.hpp>      // origin::Grid/Blocks, unit::Blocks, unit::Threads
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/size/Traits.hpp>       // Size
 
-#include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <alpaka/vec/Vec.hpp>           // Vec<N>
+#include <alpaka/core/Positioning.hpp>  // origin::Grid/Blocks, unit::Blocks, unit::Threads
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
-#include <type_traits>                      // std::enable_if, std::is_base_of, std::is_same, std::decay
-#include <utility>                          // std::forward
+#include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+
+#include <type_traits>                  // std::enable_if
+#include <utility>                      // std::forward
 
 namespace alpaka
 {
@@ -88,8 +90,11 @@ namespace alpaka
                 origin::Grid,
                 unit::Blocks,
                 typename std::enable_if<
-                    std::is_base_of<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value
-                    && (!std::is_same<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TWorkDiv::WorkDivBase,
+                        TWorkDiv
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //!
@@ -117,8 +122,11 @@ namespace alpaka
                 origin::Block,
                 unit::Threads,
                 typename std::enable_if<
-                    std::is_base_of<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value
-                    && (!std::is_same<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TWorkDiv::WorkDivBase,
+                        TWorkDiv
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //!
@@ -146,8 +154,11 @@ namespace alpaka
                 origin::Thread,
                 unit::Elems,
                 typename std::enable_if<
-                    std::is_base_of<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value
-                    && (!std::is_same<typename TWorkDiv::WorkDivBase, typename std::decay<TWorkDiv>::type>::value)>::type>
+                    meta::IsStrictBase<
+                        typename TWorkDiv::WorkDivBase,
+                        TWorkDiv
+                    >::value
+                >::type>
             {
                 //-----------------------------------------------------------------------------
                 //!


### PR DESCRIPTION
By consistently using the `alpaka::meta::IsStrictBase` trait instead of the inconveniant `std::is_base_of && !std::is_same`, the code is better understandable.