### PR TITLE
close #197: fix race condition

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 3
           ALPAKA_BOOST_BRANCH: boost-1.59.0
-        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: ON
+        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop


### PR DESCRIPTION
- avoid that references are given to threads
- guard `notify_one` to avoid race conditions
- close #197

This branch removes also some `forward<>()` to avoid that a thread get the functors and parameters by reference to temporary resources of an other tread.

This pull request is rebased against #211 to avoid that appveyor fiber test always fails.