### PR TITLE
fix broken compile with intel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 3
           ALPAKA_BOOST_BRANCH: boost-1.59.0
-        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: ON
+        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -45,8 +45,8 @@
 #include <type_traits>                      // std::enable_if, std::decay, std::is_same
 #include <algorithm>                        // std::min, std::max, std::min_element, std::max_element
 
-// The nvcc compiler does not support the out of class version.
-#ifdef __CUDACC__
+// The nvcc and intel compiler does not support the out of class version.
+#if defined(__CUDACC__) || defined(__INTEL_COMPILER)
     #define ALPAKA_CREATE_VEC_IN_CLASS
 #endif
 


### PR DESCRIPTION
define `ALPAKA_CREATE_VEC_IN_CLASS` in `vec/Vec.hpp` for intel compiler

**Testet with `intel/15.2`.**

This pull request is rebased against #211 to avoid that appveyor fiber test always fails.