### PR TITLE
disable appveyor fiber test case

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ environment:
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 3
           ALPAKA_BOOST_BRANCH: boost-1.59.0
-        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: ON
+        - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE: OFF
           ALPAKA_DEBUG: 0
           OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop


### PR DESCRIPTION
Disable boost fibers test.

To disable the broken fiber test were suggested [here](https://github.com/ComputationalRadiationPhysics/alpaka/pull/198#issuecomment-192217032)