### PR TITLE
fix that atomic operations are not grid atomics

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -27,7 +27,7 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtRefFiberIdMap.hpp> // IdxBtRefFiberIdMap
-#include <alpaka/atomic/AtomicNoOp.hpp>         // AtomicNoOp
+#include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
@@ -82,7 +82,7 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtRefFiberIdMap<TDim, TSize>,
-            public atomic::AtomicNoOp,
+            public atomic::AtomicStlLock,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
@@ -111,7 +111,7 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefFiberIdMap<TDim, TSize>(m_fibersToIndices),
-                    atomic::AtomicNoOp(),
+                    atomic::AtomicStlLock(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -69,8 +69,11 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~AtomicStlLock() = default;
 
-        private:
-            std::mutex mutable m_mtxAtomic; //!< The mutex protecting access for a atomic operation.
+            std::mutex & getMutex() const
+            {
+                static std::mutex m_mtxAtomic; //!< The mutex protecting access for a atomic operation.
+                return m_mtxAtomic;
+            }
         };
 
         namespace traits
@@ -97,7 +100,7 @@ namespace alpaka
                 {
                     // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
                     // We could use a list of mutexes and lock the mutex depending on the target memory location to allow multiple atomic ops on different targets concurrently.
-                    std::lock_guard<std::mutex> lock(atomic.m_mtxAtomic);
+                    std::lock_guard<std::mutex> lock(atomic.getMutex());
                     return TOp()(addr, value);
                 }
                 //-----------------------------------------------------------------------------
@@ -112,7 +115,7 @@ namespace alpaka
                 {
                     // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
                     // We could use a list of mutexes and lock the mutex depending on the target memory location to allow multiple atomic ops on different targets concurrently.
-                    std::lock_guard<std::mutex> lock(atomic.m_mtxAtomic);
+                    std::lock_guard<std::mutex> lock(atomic.getMutex());
                     return TOp()(addr, compare, value);
                 }
             };


### PR DESCRIPTION
close #222

- AccCpuFiber: inherit now from `AtomicStlLock`
- AtomicStlLock: use static mutex member to allow grid global atomics

With this fix all atomics are know grid atomic. In difference to Cuda atomics those are device atomics.