### PR TITLE
disable infunctional clang-3.8 OpenMP4 accelerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ env:
         - ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
         - ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=ON
         - ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=ON
-        - ALPAKA_ACC_CPU_BT_OMP4_ENABLE=OFF
+        - ALPAKA_ACC_CPU_BT_OMP4_ENABLE=ON
         - ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON
         - ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
         - ALPAKA_CLANG_LIBSTDCPP_VERSION=4.9
@@ -210,7 +210,8 @@ install:
           && echo ${ALPAKA_CLANG_VER_MAJOR}
           && echo ${ALPAKA_CLANG_VER_MINOR}
       ;fi
-    # clang versions lower than 3.7 do not support OpenMP 2.0, OpenMP 4.0 is supported starting with clang-3.8.
+    # clang versions lower than 3.7 do not support OpenMP 2.0.
+    # clang-3.8 is able to parse OpenMP 4.0 but does not implement code generation for all used constructs, but does not print any error message!
     - if [ "${CXX}" == "clang++" ]
       ;then
           if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 7 )) ) ))
@@ -226,7 +227,7 @@ install:
                   && echo ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE} because the clang version does not support it!
               ;fi
           ;fi
-          && if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 8 )) ) ))
+          && if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 9 )) ) ))
           ;then
               if [ "${ALPAKA_ACC_CPU_BT_OMP4_ENABLE}" == "ON" ]
               ;then

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This library uses C++11 (or newer when available).
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ threads|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:x:|:x:|:white_check_mark:|:x:|
+|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|:x:|
 | std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |CUDA 7.0+|:white_check_mark:|:x:|:x:|:x:|:x:|:x:|
 

--- a/example/vectorAdd/src/main.cpp
+++ b/example/vectorAdd/src/main.cpp
@@ -138,8 +138,8 @@ auto main()
     // Initialize the host input vectors
     for (Size i(0); i < numElements; ++i)
     {
-        alpaka::mem::view::getPtrNative(memBufHostA)[i] = static_cast<Val>(rand());
-        alpaka::mem::view::getPtrNative(memBufHostB)[i] = static_cast<Val>(rand());
+        alpaka::mem::view::getPtrNative(memBufHostA)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+        alpaka::mem::view::getPtrNative(memBufHostB)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
     }
 
     // Allocate the buffers on the accelerator.

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -34,6 +34,7 @@
 #include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 
 #include <iosfwd>                       // std::ostream
 
@@ -506,6 +507,9 @@ namespace alpaka
                         std::string const & rowSuffix)
                     -> void
                     {
+                        boost::ignore_unused(view);
+                        boost::ignore_unused(rowSeparator);
+
                         os << rowPrefix;
 
                         auto const lastIdx(extent[dim::Dim<TView>::value-1u]-1u);

--- a/test/integ/axpy/src/main.cpp
+++ b/test/integ/axpy/src/main.cpp
@@ -144,10 +144,21 @@ struct AxpyKernelTester
         // Initialize the host input vectors
         for (TSize i(0); i < numElements; ++i)
         {
-            alpaka::mem::view::getPtrNative(memBufHostX)[i] = static_cast<Val>(rand());
-            alpaka::mem::view::getPtrNative(memBufHostOrigY)[i] = static_cast<Val>(rand());
+            alpaka::mem::view::getPtrNative(memBufHostX)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
+            alpaka::mem::view::getPtrNative(memBufHostOrigY)[i] = static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX);
         }
-        auto const alpha(static_cast<Val>(rand()));
+        auto const alpha(static_cast<Val>(rand()) / static_cast<Val>(RAND_MAX));
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+        std::cout << BOOST_CURRENT_FUNCTION
+            << " alpha: " << alpha << std::endl;
+        std::cout << BOOST_CURRENT_FUNCTION << " X_host: ";
+        alpaka::mem::view::print(memBufHostX, std::cout);
+        std::cout << std::endl;
+        std::cout << BOOST_CURRENT_FUNCTION << " Y_host: ";
+        alpaka::mem::view::print(memBufHostOrigY, std::cout);
+        std::cout << std::endl;
+#endif
 
         // Allocate the buffer on the accelerator.
         auto memBufAccX(alpaka::mem::buf::alloc<Val, TSize>(devAcc, extent));
@@ -156,6 +167,17 @@ struct AxpyKernelTester
         // Copy Host -> Acc.
         alpaka::mem::view::copy(stream, memBufAccX, memBufHostX, extent);
         alpaka::mem::view::copy(stream, memBufAccY, memBufHostOrigY, extent);
+
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
+        alpaka::wait::wait(stream);
+
+        std::cout << BOOST_CURRENT_FUNCTION << " X_Dev: ";
+        alpaka::mem::view::print(memBufHostX, std::cout);
+        std::cout << std::endl;
+        std::cout << BOOST_CURRENT_FUNCTION << " Y_Dev: ";
+        alpaka::mem::view::print(memBufHostX, std::cout);
+        std::cout << std::endl;
+#endif
 
         // Create the executor task.
         auto const exec(alpaka::exec::create<TAcc>(


### PR DESCRIPTION
This enables the OpenMP 4.0 accelerator within the CI tests.
Clang 3.8 OpenMP 4.0 support had to be removed, as clang 3.8 can parse OpenMP 4.0 correctly but is not able to generate code for all pragmas and therefore does not produce correct results in the tests (without any compiler warning!).
Furthermore, this adds some code that should make the debugging of such cases (clang-3.9?) easier.