### PR TITLE
add hierarchy atomics

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -27,7 +27,9 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtRefFiberIdMap.hpp> // IdxBtRefFiberIdMap
+#include <alpaka/atomic/AtomicNoOp.hpp>         // AtomicNoOp
 #include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
@@ -82,7 +84,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtRefFiberIdMap<TDim, TSize>,
-            public atomic::AtomicStlLock,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock, // grid atomics
+                atomic::AtomicStlLock, // block atomics
+                atomic::AtomicNoOp     // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
@@ -111,7 +117,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefFiberIdMap<TDim, TSize>(m_fibersToIndices),
-                    atomic::AtomicStlLock(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock, // atomics between grids
+                        atomic::AtomicStlLock, // atomics between blocks
+                        atomic::AtomicNoOp     // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -31,7 +31,10 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtZero.hpp>          // IdxBtZero
+#include <alpaka/atomic/AtomicNoOp.hpp>         // AtomicNoOp
+#include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
 #include <alpaka/atomic/AtomicOmpCritSec.hpp>   // AtomicOmpCritSec
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>                // BlockSharedMemStNoSync
@@ -83,7 +86,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
-            public atomic::AtomicOmpCritSec,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicOmpCritSec,    // block atomics
+                atomic::AtomicNoOp           // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStNoSync,
@@ -112,7 +119,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
-                    atomic::AtomicOmpCritSec(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicOmpCritSec, // atomics between blocks
+                        atomic::AtomicNoOp        // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStNoSync(),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -31,7 +31,9 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtOmp.hpp>           // IdxBtOmp
+#include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
 #include <alpaka/atomic/AtomicOmpCritSec.hpp>   // AtomicOmpCritSec
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
@@ -82,7 +84,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtOmp<TDim, TSize>,
-            public atomic::AtomicOmpCritSec,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicOmpCritSec,    // block atomics
+                atomic::AtomicOmpCritSec     // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
@@ -111,7 +117,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
-                    atomic::AtomicOmpCritSec(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicOmpCritSec, // atomics between blocks
+                        atomic::AtomicOmpCritSec  // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -31,7 +31,9 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtOmp.hpp>           // IdxBtOmp
+#include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
 #include <alpaka/atomic/AtomicOmpCritSec.hpp>   // AtomicOmpCritSec
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
@@ -82,7 +84,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtOmp<TDim, TSize>,
-            public atomic::AtomicOmpCritSec,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicOmpCritSec,    // block atomics
+                atomic::AtomicOmpCritSec     // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
@@ -111,7 +117,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
-                    atomic::AtomicOmpCritSec(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicOmpCritSec, // atomics between blocks
+                        atomic::AtomicOmpCritSec  // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -28,6 +28,8 @@
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtZero.hpp>          // IdxBtZero
 #include <alpaka/atomic/AtomicNoOp.hpp>         // AtomicNoOp
+#include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>                // BlockSharedMemStNoSync
@@ -76,7 +78,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
-            public atomic::AtomicNoOp,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock, // grid atomics
+                atomic::AtomicNoOp,    // block atomics
+                atomic::AtomicNoOp     // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStNoSync,
@@ -105,7 +111,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
-                    atomic::AtomicNoOp(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock, // atomics between grids
+                        atomic::AtomicNoOp,    // atomics between blocks
+                        atomic::AtomicNoOp     // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStNoSync(),

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz, Erik Zenker
+* Copyright 2014-2016 Benjamin Worpitz, Erik Zenker, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -27,7 +27,9 @@
 #include <alpaka/workdiv/WorkDivMembers.hpp>    // workdiv::WorkDivMembers
 #include <alpaka/idx/gb/IdxGbRef.hpp>           // IdxGbRef
 #include <alpaka/idx/bt/IdxBtZero.hpp>          // IdxBtZero
+#include <alpaka/atomic/AtomicNoOp.hpp>         // AtomicNoOp
 #include <alpaka/atomic/AtomicStlLock.hpp>      // AtomicStlLock
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>              // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStNoSync.hpp>                // BlockSharedMemStNoSync
@@ -74,7 +76,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
-            public atomic::AtomicStlLock,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock, // grid atomics
+                atomic::AtomicStlLock, // block atomics
+                atomic::AtomicNoOp     // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStNoSync,
@@ -103,7 +109,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
-                    atomic::AtomicStlLock(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock, // atomics between grids
+                        atomic::AtomicStlLock, // atomics between blocks
+                        atomic::AtomicNoOp     // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStNoSync(),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -28,6 +28,7 @@
 #include <alpaka/idx/gb/IdxGbRef.hpp>               // IdxGbRef
 #include <alpaka/idx/bt/IdxBtRefThreadIdMap.hpp>    // IdxBtRefThreadIdMap
 #include <alpaka/atomic/AtomicStlLock.hpp>          // AtomicStlLock
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathStl.hpp>                  // MathStl
 #include <alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp>   // BlockSharedMemDynBoostAlignedAlloc
 #include <alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp>            // BlockSharedMemStMasterSync
@@ -79,7 +80,11 @@ namespace alpaka
             public workdiv::WorkDivMembers<TDim, TSize>,
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtRefThreadIdMap<TDim, TSize>,
-            public atomic::AtomicStlLock,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicStlLock, // grid atomics
+                atomic::AtomicStlLock, // block atomics
+                atomic::AtomicStlLock  // thread atomics
+            >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
             public block::shared::st::BlockSharedMemStMasterSync,
@@ -108,7 +113,11 @@ namespace alpaka
                     workdiv::WorkDivMembers<TDim, TSize>(workDiv),
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefThreadIdMap<TDim, TSize>(m_threadToIndexMap),
-                    atomic::AtomicStlLock(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicStlLock, // atomics between grids
+                        atomic::AtomicStlLock, // atomics between blocks
+                        atomic::AtomicStlLock  // atomics between threads
+                    >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),
                     block::shared::st::BlockSharedMemStMasterSync(

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2016 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -34,6 +34,7 @@
 #include <alpaka/idx/gb/IdxGbCudaBuiltIn.hpp>       // IdxGbCudaBuiltIn
 #include <alpaka/idx/bt/IdxBtCudaBuiltIn.hpp>       // IdxBtCudaBuiltIn
 #include <alpaka/atomic/AtomicCudaBuiltIn.hpp>      // AtomicCudaBuiltIn
+#include <alpaka/atomic/AtomicHierarchy.hpp>    // AtomicHierarchy
 #include <alpaka/math/MathCudaBuiltIn.hpp>          // MathCudaBuiltIn
 #include <alpaka/block/shared/dyn/BlockSharedMemDynCudaBuiltIn.hpp> // BlockSharedMemDynCudaBuiltIn
 #include <alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp>   // BlockSharedMemStCudaBuiltIn
@@ -82,7 +83,11 @@ namespace alpaka
             public workdiv::WorkDivCudaBuiltIn<TDim, TSize>,
             public idx::gb::IdxGbCudaBuiltIn<TDim, TSize>,
             public idx::bt::IdxBtCudaBuiltIn<TDim, TSize>,
-            public atomic::AtomicCudaBuiltIn,
+            public atomic::AtomicHierarchy<
+                atomic::AtomicCudaBuiltIn, // grid atomics
+                atomic::AtomicCudaBuiltIn, // block atomics
+                atomic::AtomicCudaBuiltIn  // thread atomics
+            >,
             public math::MathCudaBuiltIn,
             public block::shared::dyn::BlockSharedMemDynCudaBuiltIn,
             public block::shared::st::BlockSharedMemStCudaBuiltIn,
@@ -102,7 +107,11 @@ namespace alpaka
                     workdiv::WorkDivCudaBuiltIn<TDim, TSize>(threadElemExtent),
                     idx::gb::IdxGbCudaBuiltIn<TDim, TSize>(),
                     idx::bt::IdxBtCudaBuiltIn<TDim, TSize>(),
-                    atomic::AtomicCudaBuiltIn(),
+                    atomic::AtomicHierarchy<
+                        atomic::AtomicCudaBuiltIn, // atomics between grids
+                        atomic::AtomicCudaBuiltIn, // atomics between blocks
+                        atomic::AtomicCudaBuiltIn  // atomics between threads
+                    >(),
                     math::MathCudaBuiltIn(),
                     block::shared::dyn::BlockSharedMemDynCudaBuiltIn(),
                     block::shared::st::BlockSharedMemStCudaBuiltIn(),

--- a/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2014-2015 Benjamin Worpitz
+ * Copyright 2014-2016 Benjamin Worpitz, Rene Widera
  *
  * This file is part of alpaka.
  *
@@ -38,11 +38,13 @@ namespace alpaka
     {
         //#############################################################################
         //! The GPU CUDA accelerator atomic ops.
+        //
+        //  Atomics can used in the hierarchy level grids, blocks and threads.
+        //  Atomics are not guaranteed to be save between devices
         //#############################################################################
         class AtomicCudaBuiltIn
         {
         public:
-            using AtomicBase = AtomicCudaBuiltIn;
 
             //-----------------------------------------------------------------------------
             //! Default constructor.
@@ -82,11 +84,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Add,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -103,11 +107,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Add,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -124,11 +130,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Add,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -145,11 +153,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Add,
                 atomic::AtomicCudaBuiltIn,
-                float>
+                float,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -166,11 +176,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Add,
                 atomic::AtomicCudaBuiltIn,
-                double>
+                double,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -202,11 +214,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Sub,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -223,11 +237,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Sub,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -247,11 +263,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Min,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -268,11 +286,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Min,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -289,11 +309,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            /*template<>
+            /*template<
+               typename THierarchy>
             struct AtomicOp<
                 op::Min,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -313,11 +335,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Max,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -334,11 +358,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Max,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
@@ -352,11 +378,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            /*template<>
+            /*template<
+               typename THierarchy>
             struct AtomicOp<
                 op::Max,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -376,11 +404,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Exch,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -397,11 +427,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Exch,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -418,11 +450,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Exch,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -439,11 +473,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Exch,
                 atomic::AtomicCudaBuiltIn,
-                float>
+                float,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -463,11 +499,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Inc,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -487,11 +525,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Dec,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -511,11 +551,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::And,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -532,11 +574,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::And,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -553,11 +597,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            /*template<>
+            /*template<
+                typename THierarchy>
             struct AtomicOp<
                 op::And,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -577,11 +623,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Or,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -598,11 +646,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Or,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -619,11 +669,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            /*template<>
+            /*template<
+               typename THierarchy>
             struct AtomicOp<
                 op::Or,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -643,11 +695,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Xor,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -664,11 +718,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Xor,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -685,11 +741,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            /*template<>
+            /*template<
+               typename THierarchy>
             struct AtomicOp<
                 op::Xor,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -709,11 +767,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Cas,
                 atomic::AtomicCudaBuiltIn,
-                int>
+                int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -731,11 +791,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Cas,
                 atomic::AtomicCudaBuiltIn,
-                unsigned int>
+                unsigned int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //
@@ -753,11 +815,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! The GPU CUDA accelerator atomic operation.
             //-----------------------------------------------------------------------------
-            template<>
+            template<
+                typename THierarchy>
             struct AtomicOp<
                 op::Cas,
                 atomic::AtomicCudaBuiltIn,
-                unsigned long long int>
+                unsigned long long int,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/atomic/AtomicHierarchy.hpp
+++ b/include/alpaka/atomic/AtomicHierarchy.hpp
@@ -1,0 +1,131 @@
+/**
+* \file
+* Copyright 2016 Rene Widera
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/core/Positioning.hpp>
+#include <alpaka/atomic/Traits.hpp>                 // AtomicOp
+
+#include <type_traits>                              // std::conditional, std::is_same
+
+namespace alpaka
+{
+    namespace atomic
+    {
+        namespace atomicHierarchy
+        {
+            class Empty0{};
+            class Empty1{};
+            class Empty2{};
+        }
+        //#############################################################################
+        //! build a single class to inherit from different atomic implementations
+        //
+        //  This implementation inherit from all three hierarchies.
+        //  The multiple usage of the same type for different levels is allowed.
+        //  The class provide the feature that each atomic operation can be focused
+        //  to a hierarchy level in Alpaka. A operation to a hierarchy is independent
+        //  to the memory hierarchy.
+        //
+        //  \tparam TGridAtomic atomic implementation for atomic operations between grids within a device
+        //  \tparam TBlockAtomic atomic implementation for atomic operations between blocks within a grid
+        //  \tparam TThreadAtomic atomic implementation for atomic operations between threads within a block
+        //#############################################################################
+        template<
+            typename TGridAtomic,
+            typename TBlockAtomic,
+            typename TThreadAtomic
+        >
+        class AtomicHierarchy :
+            public TGridAtomic,
+            public std::conditional<
+                std::is_same<TGridAtomic,TBlockAtomic>::value,
+                atomicHierarchy::Empty1,
+                TBlockAtomic
+            >::type,
+            public std::conditional<
+                std::is_same<TGridAtomic,TThreadAtomic>::value ||
+                    std::is_same<TBlockAtomic,TThreadAtomic>::value,
+                atomicHierarchy::Empty2,
+                TThreadAtomic
+            >::type
+        {
+            public:
+            using UsedAtomicHierarchies = AtomicHierarchy<
+                TGridAtomic,
+                TBlockAtomic,
+                TThreadAtomic
+            >;
+        };
+
+        namespace traits
+        {
+            template<
+                typename TGridAtomic,
+                typename TBlockAtomic,
+                typename TThreadAtomic
+            >
+            struct AtomicBase<
+                AtomicHierarchy<
+                    TGridAtomic,
+                    TBlockAtomic,
+                    TThreadAtomic
+                >,
+                hierarchy::Threads>
+            {
+                using type = TThreadAtomic;
+            };
+
+            template<
+                typename TGridAtomic,
+                typename TBlockAtomic,
+                typename TThreadAtomic
+            >
+            struct AtomicBase<
+                AtomicHierarchy<
+                    TGridAtomic,
+                    TBlockAtomic,
+                    TThreadAtomic
+                >,
+                hierarchy::Blocks>
+            {
+                using type = TBlockAtomic;
+            };
+
+            template<
+                typename TGridAtomic,
+                typename TBlockAtomic,
+                typename TThreadAtomic
+            >
+            struct AtomicBase<
+                AtomicHierarchy<
+                    TGridAtomic,
+                    TBlockAtomic,
+                    TThreadAtomic
+                >,
+                hierarchy::Grids>
+            {
+                using type = TGridAtomic;
+            };
+
+        }
+    }
+}

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -35,7 +35,6 @@ namespace alpaka
         class AtomicNoOp
         {
         public:
-            using AtomicBase = AtomicNoOp;
 
             //-----------------------------------------------------------------------------
             //! Default constructor.
@@ -70,11 +69,13 @@ namespace alpaka
             //#############################################################################
             template<
                 typename TOp,
-                typename T>
+                typename T,
+                typename THierarchy>
             struct AtomicOp<
                 TOp,
                 atomic::AtomicNoOp,
-                T>
+                T,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/atomic/AtomicOmpCritSec.hpp
+++ b/include/alpaka/atomic/AtomicOmpCritSec.hpp
@@ -33,6 +33,9 @@ namespace alpaka
     {
         //#############################################################################
         //! The OpenMP accelerator atomic ops.
+        //
+        //  Atomics can be used in the blocks and threads hierarchy levels.
+        //  Atomics are not guaranteed to be save between devices or grids.
         //#############################################################################
         class AtomicOmpCritSec
         {
@@ -75,11 +78,13 @@ namespace alpaka
             //#############################################################################
             template<
                 typename TOp,
-                typename T>
+                typename T,
+                typename THierarchy>
             struct AtomicOp<
                 TOp,
                 atomic::AtomicOmpCritSec,
-                T>
+                T,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -31,6 +31,9 @@ namespace alpaka
     {
         //#############################################################################
         //! The CPU threads accelerator atomic ops.
+        //
+        //  Atomics can be used in the grids, blocks and threads hierarchy levels.
+        //  Atomics are not guaranteed to be save between devices.
         //#############################################################################
         class AtomicStlLock
         {
@@ -39,10 +42,9 @@ namespace alpaka
                 typename TAtomic,
                 typename TOp,
                 typename T,
+                typename THierarchy,
                 typename TSfinae>
             friend struct atomic::traits::AtomicOp;
-
-            using AtomicBase = AtomicStlLock;
 
             //-----------------------------------------------------------------------------
             //! Default constructor.
@@ -83,11 +85,13 @@ namespace alpaka
             //#############################################################################
             template<
                 typename TOp,
-                typename T>
+                typename T,
+                typename THierarchy>
             struct AtomicOp<
                 TOp,
                 atomic::AtomicStlLock,
-                T>
+                T,
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -23,6 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
+#include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
 
 #include <type_traits>                  // std::enable_if
@@ -46,8 +47,19 @@ namespace alpaka
                 typename TOp,
                 typename TAtomic,
                 typename T,
+                typename THierarchy,
                 typename TSfinae = void>
             struct AtomicOp;
+
+            //#############################################################################
+            //! Get the atomic implementation for a hierarchy level
+            //#############################################################################
+            template<
+                typename TAtomic,
+                typename THierarchy
+            >
+            struct AtomicBase;
+
         }
 
         //-----------------------------------------------------------------------------
@@ -64,18 +76,21 @@ namespace alpaka
         template<
             typename TOp,
             typename TAtomic,
-            typename T>
+            typename T,
+            typename THierarchy = hierarchy::Grids>
         ALPAKA_FN_HOST_ACC auto atomicOp(
             TAtomic const & atomic,
             T * const addr,
-            T const & value)
+            T const & value,
+            THierarchy const & = THierarchy())
         -> T
         {
             return
                 traits::AtomicOp<
                     TOp,
                     TAtomic,
-                    T>
+                    T,
+                    THierarchy>
                 ::atomicOp(
                     atomic,
                     addr,
@@ -97,19 +112,22 @@ namespace alpaka
         template<
             typename TOp,
             typename TAtomic,
-            typename T>
+            typename T,
+            typename THierarchy = hierarchy::Grids>
         ALPAKA_FN_HOST_ACC auto atomicOp(
             TAtomic const & atomic,
             T * const addr,
             T const & compare,
-            T const & value)
+            T const & value,
+            THierarchy const & = THierarchy())
         -> T
         {
             return
                 traits::AtomicOp<
                     TOp,
                     TAtomic,
-                    T>
+                    T,
+                    THierarchy>
                 ::atomicOp(
                     atomic,
                     addr,
@@ -120,22 +138,19 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The AtomicOp trait specialization for classes with AtomicBase member type.
+            //! The AtomicOp trait specialization for classes with `UsedAtomicHierarchies`
+            //  member type.
             //#############################################################################
             template<
                 typename TOp,
                 typename TAtomic,
-                typename T>
+                typename T,
+                typename THierarchy>
             struct AtomicOp<
                 TOp,
                 TAtomic,
                 T,
-                typename std::enable_if<
-                    meta::IsStrictBase<
-                        typename TAtomic::AtomicBase,
-                        TAtomic
-                    >::value
-                >::type>
+                THierarchy>
             {
                 //-----------------------------------------------------------------------------
                 //!
@@ -151,9 +166,14 @@ namespace alpaka
                     return
                         atomic::atomicOp<
                             TOp>(
-                                static_cast<typename TAtomic::AtomicBase const &>(atomic),
+                                static_cast<
+                                    typename AtomicBase<
+                                        typename TAtomic::UsedAtomicHierarchies,
+                                        THierarchy
+                                    >::type const &>(atomic),
                                 addr,
-                                value);
+                                value,
+                                THierarchy());
                 }
                 //-----------------------------------------------------------------------------
                 //!
@@ -170,10 +190,15 @@ namespace alpaka
                     return
                         atomic::atomicOp<
                             TOp>(
-                                static_cast<typename TAtomic::AtomicBase const &>(atomic),
+                                static_cast<
+                                    typename AtomicBase<
+                                        typename TAtomic::UsedAtomicHierarchies,
+                                        THierarchy
+                                    >::type const &>(atomic),
                                 addr,
                                 compare,
-                                value);
+                                value,
+                                THierarchy());
                 }
             };
         }

--- a/include/alpaka/core/Positioning.hpp
+++ b/include/alpaka/core/Positioning.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2016 Benjamin Worpitz, Rene Widera
 *
 * This file is part of alpaka.
 *
@@ -23,6 +23,17 @@
 
 namespace alpaka
 {
+    //#############################################################################
+    //! Defines the parallelism hierarchy levels of Alpaka
+    //#############################################################################
+    namespace hierarchy
+    {
+        struct Grids{};
+
+        struct Blocks{};
+
+        struct Threads{};
+    }
     //-----------------------------------------------------------------------------
     //! Defines the origins available for getting extent and indices of kernel executions.
     //-----------------------------------------------------------------------------


### PR DESCRIPTION
close #200
close #201 

- add namespace hierarchy and add
  - class Grids
  - class Blocks
  - class Threads
- add class `AtomicHierarchy`
- add the needed hierarchies to the accelerators

This pull request solve #201 and should be a base for discussion.

There is a new namespace introduced named `hierarchy` and contains `Grids`,`Blocks` and `Threads`.
Each atomic operation can have a *optional* parameter which describe the scope were the atomic operation is guaranteed atomic (default: `Grids()`).

**The meaning of the hierarchies:**
- `Grids` -> the operation is atomic between independent grids in a single device and one accelerator type (**attention:** not between different accelerator types,` AccCpuOmp2Blocks` operations are not atomic to `AccCpuOmp2Threads` operations)
- `Blocks` -> the operation is atomic between blocks in a grid
- `Threads` -> the operation is atomic between threads in a block

There is no guarantee that a atomic operation in the `Grids` hierarchy to a address `x` is atomic to a operation to the same address in the `Blocks` hierarchy.
It is not possible to write generic concepts that atomics between different accelerators are atomic therefore all atomics are restricted to one accelerator type.
Currently atomic operations are atomic to the address which means that a atomic `Add` and a `Exch` to the same address  can be mixed.

```C++
//...
template< typename TAcc>
ALPAKA_FN_ACC void operator()( const TAcc & acc, int* x)
{
    // atomic between grids in a device of the same accelerator
    atomic::atomicOp<atomic::op::Add>(acc, x, 1, hierarchy::Grids()); 
    // atomic between blocks in a grid
    // there is no guarantee that the next operation is atomic to the first
    atomic::atomicOp<atomic::op::Add>(acc, x, 1, hierarchy::Blocks()); 
}
```

Maybe the namespace `hierarchy` should be renamed to `between` than a atomic operation is human readable `atomic::atomicOp<atomic::op::Add>(acc, x, 1, between::Blocks()); `

**TODO:**
- [x] add documentation to `class AtomicHierarchy`
- [x] rebase against #221 and modify the TBB backend

@ComputationalRadiationPhysics/alpaka-maintainers please participate the discussion