### PR TITLE
Removed allocArr

### DIFF
--- a/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
@@ -111,42 +111,6 @@ namespace alpaka
                     //#############################################################################
                     //!
                     //#############################################################################
-                    template<
-                        typename T,
-                        std::size_t TnumElements,
-                        std::size_t TuniqueId>
-                    struct AllocArr<
-                        T,
-                        TnumElements,
-                        TuniqueId,
-                        BlockSharedMemStCudaBuiltIn>
-                    {
-                        // NOTE: CUDA requires the constructor and destructor of shared objects to be empty.
-                        //  That means it is either std::is_trivially_default_constructible or of the form Type(){}.
-                        //static_assert(
-                        //    std::is_trivially_default_constructible<T>::value,
-                        //    "The type of the objects to allocate in block shared memory has to be trivially default constructible!");
-                        //static_assert(
-                        //    std::is_trivially_destructible<T>::value,
-                        //    "The type of the objects to allocate in block shared memory has to be trivially destructible!");
-                        static_assert(
-                            TnumElements > 0,
-                            "The number of elements to allocate in block shared memory must not be zero!");
-
-                        //-----------------------------------------------------------------------------
-                        //
-                        //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_CUDA_ONLY static auto allocArr(
-                            block::shared::st::BlockSharedMemStCudaBuiltIn const &)
-                        -> T *
-                        {
-                            __shared__ T shMem[TnumElements];
-                            return shMem;
-                        }
-                    };
-                    //#############################################################################
-                    //!
-                    //#############################################################################
                     template<>
                     struct FreeMem<
                         BlockSharedMemStCudaBuiltIn>

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -131,47 +131,6 @@ namespace alpaka
                     //#############################################################################
                     //!
                     //#############################################################################
-                    template<
-                        typename T,
-                        std::size_t TnumElements,
-                        std::size_t TuniqueId>
-                    struct AllocArr<
-                        T,
-                        TnumElements,
-                        TuniqueId,
-                        BlockSharedMemStMasterSync>
-                    {
-                        static_assert(
-                            TnumElements > 0,
-                            "The number of elements to allocate in block shared memory must not be zero!");
-
-                        //-----------------------------------------------------------------------------
-                        //
-                        //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto allocArr(
-                            block::shared::st::BlockSharedMemStMasterSync const & blockSharedMemSt)
-                        -> T *
-                        {
-                            // Assure that all threads have executed the return of the last allocBlockSharedArr function (if there was one before).
-                            blockSharedMemSt.m_syncFn();
-
-                            // Arbitrary decision: The fiber that was created first has to allocate the memory.
-                            if(blockSharedMemSt.m_isMasterThreadFn())
-                            {
-                                blockSharedMemSt.m_sharedAllocs.emplace_back(
-                                    reinterpret_cast<uint8_t *>(
-                                        boost::alignment::aligned_alloc(16u, sizeof(T) * TnumElements)));
-                            }
-                            blockSharedMemSt.m_syncFn();
-
-                            return
-                                reinterpret_cast<T*>(
-                                    blockSharedMemSt.m_sharedAllocs.back().get());
-                        }
-                    };
-                    //#############################################################################
-                    //!
-                    //#############################################################################
                     template<>
                     struct FreeMem<
                         BlockSharedMemStMasterSync>

--- a/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
@@ -113,38 +113,6 @@ namespace alpaka
                     //#############################################################################
                     //!
                     //#############################################################################
-                    template<
-                        typename T,
-                        std::size_t TnumElements,
-                        std::size_t TuniqueId>
-                    struct AllocArr<
-                        T,
-                        TnumElements,
-                        TuniqueId,
-                        BlockSharedMemStNoSync>
-                    {
-                        static_assert(
-                            TnumElements > 0,
-                            "The number of elements to allocate in block shared memory must not be zero!");
-
-                        //-----------------------------------------------------------------------------
-                        //
-                        //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto allocArr(
-                            block::shared::st::BlockSharedMemStNoSync const & blockSharedMemSt)
-                        -> T *
-                        {
-                            blockSharedMemSt.m_sharedAllocs.emplace_back(
-                                reinterpret_cast<uint8_t *>(
-                                    boost::alignment::aligned_alloc(16u, sizeof(T) * TnumElements)));
-                            return
-                                reinterpret_cast<T*>(
-                                    blockSharedMemSt.m_sharedAllocs.back().get());
-                        }
-                    };
-                    //#############################################################################
-                    //!
-                    //#############################################################################
                     template<>
                     struct FreeMem<
                         BlockSharedMemStNoSync>

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -59,16 +59,6 @@ namespace alpaka
                         typename TSfinae = void>
                     struct AllocVar;
                     //#############################################################################
-                    //! The block shared static memory array allocation operation trait.
-                    //#############################################################################
-                    template<
-                        typename T,
-                        std::size_t TnumElements,
-                        std::size_t TuniqueId,
-                        typename TBlockSharedMemSt,
-                        typename TSfinae = void>
-                    struct AllocArr;
-                    //#############################################################################
                     //! The block shared static memory free operation trait.
                     //#############################################################################
                     template<
@@ -99,38 +89,6 @@ namespace alpaka
                             TuniqueId,
                             TBlockSharedMemSt>
                         ::allocVar(
-                            blockSharedMemSt);
-                }
-
-                //-----------------------------------------------------------------------------
-                //! Allocates an array in block shared static memory.
-                //!
-                //! \tparam T The element type.
-                //! \tparam TnumElements The Number of elements.
-                //! \tparam TuniqueId id those is unique inside a kernel
-                //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
-                //! \param blockSharedMemSt The block shared allocator implementation.
-                //-----------------------------------------------------------------------------
-                template<
-                    typename T,
-                    std::size_t TnumElements,
-                    std::size_t TuniqueId,
-                    typename TBlockSharedMemSt>
-                ALPAKA_FN_ACC auto allocArr(
-                    TBlockSharedMemSt const & blockSharedMemSt)
-                -> T *
-                {
-                    static_assert(
-                        TnumElements > 0,
-                        "The number of elements to allocate in block shared memory must not be zero!");
-
-                    return
-                        traits::AllocArr<
-                            T,
-                            TnumElements,
-                            TuniqueId,
-                            TBlockSharedMemSt>
-                        ::allocArr(
                             blockSharedMemSt);
                 }
 
@@ -183,42 +141,6 @@ namespace alpaka
                             return
                                 block::shared::st::allocVar<
                                     T,
-                                    TuniqueId>(
-                                        static_cast<typename TBlockSharedMemSt::BlockSharedMemStBase const &>(blockSharedMemSt));
-                        }
-                    };
-                    //#############################################################################
-                    //! The AllocArr trait specialization for classes with BlockSharedMemStBase member type.
-                    //#############################################################################
-                    template<
-                        typename T,
-                        std::size_t TnumElements,
-                        std::size_t TuniqueId,
-                        typename TBlockSharedMemSt>
-                    struct AllocArr<
-                        T,
-                        TnumElements,
-                        TuniqueId,
-                        TBlockSharedMemSt,
-                        typename std::enable_if<
-                            meta::IsStrictBase<
-                                typename TBlockSharedMemSt::BlockSharedMemStBase,
-                                TBlockSharedMemSt
-                            >::value
-                        >::type>
-                    {
-                        //-----------------------------------------------------------------------------
-                        //!
-                        //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC static auto allocArr(
-                            TBlockSharedMemSt const & blockSharedMemSt)
-                        -> T *
-                        {
-                            // Delegate the call to the base class.
-                            return
-                                block::shared::st::allocArr<
-                                    T,
-                                    TnumElements,
                                     TuniqueId>(
                                         static_cast<typename TBlockSharedMemSt::BlockSharedMemStBase const &>(blockSharedMemSt));
                         }

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -39,6 +39,32 @@ BOOST_AUTO_TEST_SUITE(blockSharedMemSt)
 //#############################################################################
 //!
 //#############################################################################
+template<
+    typename TType,
+    size_t TSize>
+struct Array {
+    TType m_data[TSize];
+
+    template<
+        typename T_Idx>
+    ALPAKA_FN_HOST_ACC const TType &operator[](
+        const T_Idx idx) const
+    {
+        return m_data[idx];
+    }
+
+    template<
+        typename TIdx>
+    ALPAKA_FN_HOST_ACC TType & operator[](
+        const TIdx idx)
+    {
+        return m_data[idx];
+    }
+};
+
+//#############################################################################
+//!
+//#############################################################################
 class BlockSharedMemStNonNullTestKernel
 {
 public:
@@ -68,14 +94,14 @@ public:
         BOOST_REQUIRE_NE(static_cast<std::uint64_t *>(nullptr), &e);
 
 
-        auto * f = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), f);
+        auto && f = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &f[0]);
 
-        auto * g = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), g);
+        auto && g = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &g[0]);
 
-        auto * h = alpaka::block::shared::st::allocArr<double, 16u, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<double *>(nullptr), h);
+        auto && h = alpaka::block::shared::st::allocVar<Array<double, 16>, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(static_cast<double *>(nullptr), &h[0]);
     }
 };
 
@@ -125,15 +151,15 @@ public:
         BOOST_REQUIRE_NE(&a, &c);
         BOOST_REQUIRE_NE(&b, &c);
 
-        auto * d = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&a, d);
-        BOOST_REQUIRE_NE(&b, d);
-        BOOST_REQUIRE_NE(&c, d);
-        auto * e = alpaka::block::shared::st::allocArr<std::uint32_t, 32u, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&a, e);
-        BOOST_REQUIRE_NE(&b, e);
-        BOOST_REQUIRE_NE(&c, e);
-        BOOST_REQUIRE_NE(d, e);
+        auto && d = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(&a, &d[0]);
+        BOOST_REQUIRE_NE(&b, &d[0]);
+        BOOST_REQUIRE_NE(&c, &d[0]);
+        auto && e = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
+        BOOST_REQUIRE_NE(&a, &e[0]);
+        BOOST_REQUIRE_NE(&b, &e[0]);
+        BOOST_REQUIRE_NE(&c, &e[0]);
+        BOOST_REQUIRE_NE(&d[0], &e[0]);
     }
 };
 


### PR DESCRIPTION
This PR fixes issue #80. The free function `alpaka::block::shared::st::allocArr<type, nElements, __COUNTER__>` was simply removed and can now be "emulated" by `alpaka::block::shared::st::allocVar<Array<type, nElements>, __COUNTER__>`. The kind of array type to use is left open to the user.