### PR TITLE
remove boost test usage from kernels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -624,12 +624,12 @@ script:
     # Build and execute all unit tests.
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/acc/" ./acc ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/atomic/" ./atomic ;fi
-    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" -a ${ALPAKA_CUDA_COMPILER} != "clang" -a "${ALPAKA_ACC_GPU_CUDA_ONLY_MODE}" != "ON" ] ;then ./travis/compileExec.sh "test/unit/block/shared/" ./blockShared ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/block/shared/" ./blockShared ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/kernel/" ./kernel ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/mem/buf/" ./memBuf ;fi
-    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" -a ${ALPAKA_CUDA_COMPILER} != "clang" -a "${ALPAKA_ACC_GPU_CUDA_ONLY_MODE}" != "ON" ] ;then ./travis/compileExec.sh "test/unit/mem/view/" ./memView ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/mem/view/" ./memView ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/meta/" ./meta ;fi
-    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" -a ${ALPAKA_CUDA_COMPILER} != "clang" -a "${ALPAKA_ACC_GPU_CUDA_ONLY_MODE}" != "ON" ] ;then ./travis/compileExec.sh "test/unit/time/" ./time ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/time/" ./time ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/vec/" ./vec ;fi
 
     #-------------------------------------------------------------------------------

--- a/test/common/include/alpaka/test/KernelExecutionFixture.hpp
+++ b/test/common/include/alpaka/test/KernelExecutionFixture.hpp
@@ -38,7 +38,7 @@ namespace alpaka
             using Dim = alpaka::dim::Dim<Acc>;
             using Size = alpaka::size::Size<Acc>;
             using DevAcc = alpaka::dev::Dev<Acc>;
-            using PltfAcc  = alpaka::pltf::Pltf<DevAcc>;
+            using PltfAcc = alpaka::pltf::Pltf<DevAcc>;
             using StreamAcc = alpaka::test::stream::DefaultStream<DevAcc>;
 
         public:

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -31,6 +31,7 @@
 #include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
 #include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
 
+#include <boost/assert.hpp>                         // BOOST_VERIFY
 #include <boost/test/unit_test.hpp>
 
 //#############################################################################
@@ -62,9 +63,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig + value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -78,9 +79,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig - value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -94,9 +95,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = std::min(operandOrig, value);
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -110,9 +111,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = std::max(operandOrig, value);
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -126,9 +127,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -143,9 +144,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig + 1;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -160,9 +161,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig - 1;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -176,9 +177,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig & value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -192,9 +193,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig | value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -208,9 +209,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig ^ value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -226,9 +227,9 @@ public:
                         &operand,
                         compare,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = value;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -244,9 +245,9 @@ public:
                         &operand,
                         compare,
                         value);
-            BOOST_REQUIRE_EQUAL(operandOrig, ret);
+            BOOST_VERIFY(operandOrig == ret);
             T const reference = operandOrig;
-            BOOST_REQUIRE_EQUAL(operand, reference);
+            BOOST_VERIFY(operand == reference);
         }
     }
 };

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -32,6 +32,7 @@
 #include <alpaka/test/stream/Stream.hpp>            // alpaka::test::stream::DefaultStream
 #include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
 
+#include <boost/assert.hpp>                         // BOOST_VERIFY
 #include <boost/test/unit_test.hpp>
 
 //#############################################################################
@@ -52,15 +53,15 @@ public:
     {
         // Assure that the pointer is non null.
         auto && a = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), a);
+        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != a);
 
         // Each call should return the same pointer ...
         auto && b = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
-        BOOST_REQUIRE_EQUAL(a, b);
+        BOOST_VERIFY(a == b);
 
         // ... even for different types.
         auto && c = alpaka::block::shared::dyn::getMem<float>(acc);
-        BOOST_REQUIRE_EQUAL(a, reinterpret_cast<std::uint32_t *>(c));
+        BOOST_VERIFY(a == reinterpret_cast<std::uint32_t *>(c));
     }
 };
 

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -32,6 +32,7 @@
 #include <alpaka/test/stream/Stream.hpp>            // alpaka::test::stream::DefaultStream
 #include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
 
+#include <boost/assert.hpp>                         // BOOST_VERIFY
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(blockSharedMemSt)
@@ -79,29 +80,29 @@ public:
     -> void
     {
         auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &a);
+        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &a);
 
         auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &b);
+        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &b);
 
         auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<float *>(nullptr), &c);
+        BOOST_VERIFY(static_cast<float *>(nullptr) != &c);
 
         auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<double *>(nullptr), &d);
+        BOOST_VERIFY(static_cast<double *>(nullptr) != &d);
 
         auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint64_t *>(nullptr), &e);
+        BOOST_VERIFY(static_cast<std::uint64_t *>(nullptr) != &e);
 
 
         auto && f = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &f[0]);
+        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
         auto && g = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<std::uint32_t *>(nullptr), &g[0]);
+        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
         auto && h = alpaka::block::shared::st::allocVar<Array<double, 16>, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(static_cast<double *>(nullptr), &h[0]);
+        BOOST_VERIFY(static_cast<double *>(nullptr) != &h[0]);
     }
 };
 
@@ -145,21 +146,21 @@ public:
     {
         auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
         auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&a, &b);
+        BOOST_VERIFY(&a != &b);
         auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&b, &c);
-        BOOST_REQUIRE_NE(&a, &c);
-        BOOST_REQUIRE_NE(&b, &c);
+        BOOST_VERIFY(&b != &c);
+        BOOST_VERIFY(&a != &c);
+        BOOST_VERIFY(&b != &c);
 
         auto && d = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&a, &d[0]);
-        BOOST_REQUIRE_NE(&b, &d[0]);
-        BOOST_REQUIRE_NE(&c, &d[0]);
+        BOOST_VERIFY(&a != &d[0]);
+        BOOST_VERIFY(&b != &d[0]);
+        BOOST_VERIFY(&c != &d[0]);
         auto && e = alpaka::block::shared::st::allocVar<Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_REQUIRE_NE(&a, &e[0]);
-        BOOST_REQUIRE_NE(&b, &e[0]);
-        BOOST_REQUIRE_NE(&c, &e[0]);
-        BOOST_REQUIRE_NE(&d[0], &e[0]);
+        BOOST_VERIFY(&a != &e[0]);
+        BOOST_VERIFY(&b != &e[0]);
+        BOOST_VERIFY(&c != &e[0]);
+        BOOST_VERIFY(&d[0] != &e[0]);
     }
 };
 

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -33,6 +33,7 @@
 #include <alpaka/test/mem/view/ViewTest.hpp>    // viewTest
 #include <alpaka/test/mem/view/Iterator.hpp>    // Iterator
 
+#include <boost/assert.hpp>                     // BOOST_VERIFY
 #include <boost/test/unit_test.hpp>
 #include <boost/predef.h>                       // workarounds
 
@@ -130,9 +131,7 @@ struct CompareBufferKernel
         (void)acc;
         for(; beginA != endA; ++beginA, ++beginB)
         {
-            BOOST_REQUIRE_EQUAL(
-                *beginA,
-                *beginB);
+            BOOST_VERIFY(*beginA == *beginB);
         }
     }
 };

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -31,6 +31,7 @@
 #include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
 #include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
 
+#include <boost/assert.hpp>                         // BOOST_VERIFY
 #include <boost/test/unit_test.hpp>
 
 //#############################################################################
@@ -51,14 +52,14 @@ public:
     {
         std::uint64_t const start(
             alpaka::time::clock(acc));
-        BOOST_REQUIRE_NE(0u, start);
+        BOOST_VERIFY(0u != start);
 
         std::uint64_t const end(
             alpaka::time::clock(acc));
-        BOOST_REQUIRE_NE(0u, end);
+        BOOST_VERIFY(0u != end);
 
         // 'end' has to be greater then 'start'.
-        BOOST_REQUIRE_GT(end, start);
+        BOOST_VERIFY(end > start);
     }
 };
 


### PR DESCRIPTION
This solves #230.

Removes the usage of the `__host__` only  `BOOST_REQUIRE_XXX` macros from the test kernels which produce warnings from nvcc and can neither compile in CUDA only mode nor with native clang CUDA support.
It has been replaced by `BOOST_VERIFY` which does not rely on host memory.