### PR TITLE
enhance documentation for getExtentVec, getOffsetVec, ...

### DIFF
--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -92,6 +92,7 @@ namespace alpaka
                     vec);
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TVec has to specialize SubVecFromIndices.
         //! \return The sub-vector consisting of the first N elements of the source vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
@@ -126,6 +127,7 @@ namespace alpaka
                         vec);
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TVec has to specialize SubVecFromIndices.
         //! \return The sub-vector consisting of the last N elements of the source vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -952,6 +952,7 @@ namespace alpaka
             };
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TExtent has to specialize extent::GetExtent.
         //! \return The extent vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
@@ -973,6 +974,7 @@ namespace alpaka
                         extent);
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TExtent has to specialize extent::GetExtent.
         //! \return The extent but only the last N elements.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
@@ -1024,6 +1026,7 @@ namespace alpaka
             };
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TExtent has to specialize offset::GetOffset.
         //! \return The offset vector.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING
@@ -1045,6 +1048,7 @@ namespace alpaka
                         offsets);
         }
         //-----------------------------------------------------------------------------
+        //! \tparam TExtent has to specialize offset::GetOffset.
         //! \return The offset vector but only the last N elements.
         //-----------------------------------------------------------------------------
         ALPAKA_NO_HOST_ACC_WARNING


### PR DESCRIPTION
When this is merged, #76 can be closed.

This can be merged even though the calng builds have failed due to the existing CI issue fixed in a different branch. 