### PR TITLE
add default constructor to `Xor` RNG

### DIFF
--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -65,6 +65,15 @@ namespace alpaka
                 class Xor
                 {
                 public:
+
+                    //-----------------------------------------------------------------------------
+                    //! Constructor.
+                    //
+                    // After calling this constructor the instance is not valid initialized and
+                    // need to be overwritten with a valid object
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_ACC_CUDA_ONLY Xor() = default;
+
                     //-----------------------------------------------------------------------------
                     //! Constructor.
                     //-----------------------------------------------------------------------------


### PR DESCRIPTION
add default constructor

This change allows that Xor can used in an `std::Array` or plain array.

Not allowed before`
```C++
Xor myArray[5]; // call the default constructor which not exists
for(int i=0; i<5; ++i)
    myArray[i] = Xor(i);
```

With this commit the example is allowed. The `RandStl` supported the example without changes because there is a default constructor avail.
This feature is enhancement is needed to use the random number generator inside the element level.