### PR TITLE
add code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ compiler:
 # ALPAKA_CI_CMAKE_VER                           : {3.3.2, 3.4.3, 3.5.2}
 # ALPAKA_CI_SANITIZERS                          : {ASan+UBsan, TSan+UBsan, MSan+UBsan}
 # ALPAKA_CI_ANALYSIS                            : {ON, OFF}
+# ALPAKA_CI_COVERAGE                            : {ON, OFF}
 # ALPAKA_DEBUG                                  : {0, 1, 2}
 # ALPAKA_ACC_GPU_CUDA_ONLY_MODE                 : {ON, OFF}
 # ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE             : {ON, OFF}
@@ -72,6 +73,7 @@ compiler:
 env:
     global:
         - ALPAKA_CI_ANALYSIS=OFF
+        - ALPAKA_CI_COVERAGE=OFF
         - ALPAKA_DEBUG=0
         - ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=ON
         - ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=ON
@@ -88,6 +90,9 @@ env:
         # Analysis builds
         - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.8.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.61.0 ALPAKA_CI_CMAKE_VER=3.4.3 ALPAKA_CI_SANITIZERS=           ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=7.5 ALPAKA_CUDA_COMPILER=clang
         - ALPAKA_GCC_VER=6   ALPAKA_CLANG_VER=3.8.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.60.0 ALPAKA_CI_CMAKE_VER=3.4.3 ALPAKA_CI_SANITIZERS=           ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2
+
+        # Coverage builds
+        - ALPAKA_GCC_VER=6   ALPAKA_CLANG_VER=3.8.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.61.0 ALPAKA_CI_CMAKE_VER=3.4.3 ALPAKA_CI_SANITIZERS=           ALPAKA_CI_COVERAGE=ON OMP_NUM_THREADS=4
 
         # Debug builds
         - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.8.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.59.0 ALPAKA_CI_CMAKE_VER=3.5.2 ALPAKA_CI_SANITIZERS=           ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=7.5 ALPAKA_CUDA_COMPILER=clang ALPAKA_ACC_GPU_CUDA_ONLY_MODE=ON ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF ALPAKA_ACC_CPU_BT_OMP4_ENABLE=OFF ALPAKA_ACC_CPU_BT_OPENACC2_ENABLE=OFF
@@ -242,6 +247,17 @@ install:
     - git --version
     - travis_retry sudo apt-get -y install git
     - git --version
+
+    #-------------------------------------------------------------------------------
+    # We only want to generate coverage for a single gcc build.
+    - if [ "${ALPAKA_CI_COVERAGE}" == "ON" ]
+      ; then
+          if [ "${CXX}" != "g++" ]
+          ;then
+              export ALPAKA_CI_COVERAGE=OFF
+              && echo ALPAKA_CI_COVERAGE=${ALPAKA_CI_COVERAGE} because we only generate coverage for gcc!
+          ;fi
+      ; fi
 
     #-------------------------------------------------------------------------------
     # We can only use clang as a CUDA compiler when clang is used as the main compiler.
@@ -504,6 +520,13 @@ install:
     # Install TBB
     - travis_retry sudo apt-get -y install libtbb-dev
 
+    #-------------------------------------------------------------------------------
+    # Install cpp-coveralls
+    - if [ "${ALPAKA_CI_COVERAGE}" == "ON" ]
+      ; then
+           pip install --user cpp-coveralls
+      ; fi
+
 
 ################################################################################
 # Use this to prepare your build for testing.
@@ -526,6 +549,11 @@ before_script:
               && nvcc -V
           ;fi
       ;fi
+
+    - if [ "${ALPAKA_CI_COVERAGE}" == "ON" ]
+      ; then
+           gcov --version
+      ; fi
 
 ################################################################################
 # All commands must exit with code 0 on success. Anything else is considered failure.
@@ -618,6 +646,16 @@ script:
     - if [ "${ALPAKA_CI_ANALYSIS}" == "ON" ] ;then ./travis/compileExec.sh "test/analysis/headerCheck/" ./headerCheck ;fi
 
     #-------------------------------------------------------------------------------
+    # code-coverage
+    # Compiling with -O0 provides much better results because inlining and other optimizations have influence on the coverage.
+    # -coverage resolves to -fprofile-arcs -ftest-coverage (compile) and -lgcov (link)
+    - if [ "${ALPAKA_CI_COVERAGE}" == "ON" ]
+      ; then
+          export CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -O0 -coverage"
+          export CMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS} -coverage"
+      ; fi
+
+    #-------------------------------------------------------------------------------
     # FIXME: Not all tests are running successfully on all platforms:
     # - clang as CUDA compiler currently fails for some of the tests with:
     #   build/boost/boost/test/utils/lazy_ostream.hpp:35:29: Generating code for declaration 'boost::unit_test::lazy_ostream::instance'
@@ -657,3 +695,19 @@ script:
 ################################################################################
 notifications:
     email: false
+
+after_success:
+    #-------------------------------------------------------------------------------
+    # code-coverage
+    # Push coverage info on coveralls.io.
+    # The "example" and "test" folders can not be excluded as header-only template code is only really compiled
+    # within the executables resulting in a wrong coverage if their results are not included.
+    - if [ "${ALPAKA_CI_COVERAGE}" == "ON" ]
+      ; then
+           oldPath=${PWD}
+           && cd "../../alpaka_build/"
+           && coveralls
+               --verbose
+               --gcov-options '\--long-file-names --preserve-paths'
+           && cd "${oldPath}"
+      ;fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Build Status](https://travis-ci.org/ComputationalRadiationPhysics/alpaka.svg?branch=develop)](https://travis-ci.org/ComputationalRadiationPhysics/alpaka)
 [![Build status](https://ci.appveyor.com/api/projects/status/xjeyugcg1cb0662s/branch/develop?svg=true)](https://ci.appveyor.com/project/BenjaminW3/alpaka-vuiya/branch/develop)
+[![Coverage Status](https://coveralls.io/repos/github/ComputationalRadiationPhysics/alpaka/badge.svg?branch=develop)](https://coveralls.io/github/ComputationalRadiationPhysics/alpaka?branch=develop)
 
 The **alpaka** library is a header-only C++11 abstraction library for accelerator development.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,16 +64,16 @@ environment:
         ALPAKA_ACC_GPU_CUDA_ENABLE: OFF
         ALPAKA_ACC_GPU_CUDA_ONLY_MODE: OFF
 
-    matrix:
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 4
-          ALPAKA_BOOST_BRANCH: boost-1.60.0
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 3
-          ALPAKA_BOOST_BRANCH: boost-1.61.0
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 4
-          ALPAKA_BOOST_BRANCH: develop
+#    matrix:
+#        - ALPAKA_DEBUG: 0
+#          OMP_NUM_THREADS: 4
+#          ALPAKA_BOOST_BRANCH: boost-1.60.0
+#        - ALPAKA_DEBUG: 0
+#          OMP_NUM_THREADS: 3
+#          ALPAKA_BOOST_BRANCH: boost-1.61.0
+#        - ALPAKA_DEBUG: 0
+#          OMP_NUM_THREADS: 4
+#          ALPAKA_BOOST_BRANCH: develop
 
 matrix:
     fast_finish: true

--- a/travis/compileExec.sh
+++ b/travis/compileExec.sh
@@ -30,11 +30,9 @@ set -ev
 #-------------------------------------------------------------------------------
 # Build and execute all tests.
 oldPath=${PWD}
-cd ${1}
-mkdir build/
-cd build/
-mkdir make/
-cd make/
+cd ../../
+mkdir -p "alpaka_build/${1}"
+cd "alpaka_build/${1}"
 cmake -G "Unix Makefiles" \
     -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_EXE_LINKER_FLAGS="${CMAKE_EXE_LINKER_FLAGS}" \
     -DBOOST_ROOT="${ALPAKA_BOOST_ROOT_DIR}" -DBOOST_LIBRARYDIR="${ALPAKA_BOOST_LIB_DIR}" -DBoost_COMPILER="${ALPAKA_BOOST_COMPILER}" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF \
@@ -43,7 +41,7 @@ cmake -G "Unix Makefiles" \
     -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE="${ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE}" -DALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE="${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE}" -DALPAKA_ACC_CPU_BT_OMP4_ENABLE="${ALPAKA_ACC_CPU_BT_OMP4_ENABLE}" \
     -DALPAKA_ACC_GPU_CUDA_ENABLE="${ALPAKA_ACC_GPU_CUDA_ENABLE}" -DALPAKA_CUDA_VERSION="${ALPAKA_CUDA_VERSION}" -DALPAKA_CUDA_COMPILER="${ALPAKA_CUDA_COMPILER}" -DALPAKA_ACC_GPU_CUDA_ONLY_MODE="${ALPAKA_ACC_GPU_CUDA_ONLY_MODE}" \
     -DALPAKA_DEBUG="${ALPAKA_DEBUG}" -DALPAKA_CI=ON \
-    "../../"
+    "${oldPath}/${1}"
 make VERBOSE=1
 if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "OFF" ]
 then


### PR DESCRIPTION
This measures the coverage of the code by all tests.
* for each [template] [member] function that is called during any of the tests run in CI, you can find out which lines are executed and how often. This branch coverage allows you to enhance the tests by adding specific tests triggering the branch/lines missing in the CI.

The method used has some drawbacks:
* non instantiated templates are not counted as uncovered
* the tests and examples are included within the coverage analysis even though they should not. When they are not included, there was no coverage for any header at all

General drawbacks of code coverage analysis:
* template meta-programming can not be measured as it occurs at compile time but coverage is computed at run-time.