### PR TITLE
fix flaky tests

### DIFF
--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -78,9 +78,7 @@ struct StaticDeviceMemoryTestKernel
         auto const offset = gridThreadExtent[1u] * gridThreadIdx[0u] + gridThreadIdx[1u];
         auto const val = offset;
 
-        BOOST_REQUIRE_EQUAL(
-            val,
-            *(pConstantMem + offset));
+        BOOST_VERIFY(val == *(pConstantMem + offset));
     }
 };
 

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -66,8 +66,9 @@ public:
             alpaka::time::clock(acc));
         BOOST_VERIFY(0u != end);
 
-        // 'end' has to be greater then 'start'.
-        BOOST_VERIFY(end > start);
+        // 'end' has to be greater equal 'start'.
+        // CUDA clock will never be equal for two calls, but the clock implementations for CPUs can be.
+        BOOST_VERIFY(end >= start);
     }
 };
 


### PR DESCRIPTION
This hopefully fixes the flaky tests (#261) by removing an invalid `BOOST_REQUIRE_XXX` call from within a test kernel and fixing the non-deterministic time test.