### PR TITLE
add TBB to the windows CI tests

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -85,6 +85,14 @@ SET(_ALPAKA_FOUND TRUE)
 # Add module search path
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${_ALPAKA_ROOT_DIR}/cmake/modules/")
 
+IF(${ALPAKA_DEBUG} GREATER 1)
+    MESSAGE(STATUS "_ALPAKA_ROOT_DIR : ${_ALPAKA_ROOT_DIR}")
+    MESSAGE(STATUS "_ALPAKA_COMMON_FILE : ${_ALPAKA_COMMON_FILE}")
+    MESSAGE(STATUS "_ALPAKA_ADD_EXECUTABLE_FILE : ${_ALPAKA_ADD_EXECUTABLE_FILE}")
+    MESSAGE(STATUS "_ALPAKA_ADD_LIBRARY_FILE : ${_ALPAKA_ADD_LIBRARY_FILE}")
+    MESSAGE(STATUS "CMAKE_BUILD_TYPE : ${CMAKE_BUILD_TYPE}")
+ENDIF()
+
 #-------------------------------------------------------------------------------
 # Options.
 #-------------------------------------------------------------------------------
@@ -205,8 +213,9 @@ IF(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE)
         MESSAGE(WARNING "Optional alpaka dependency TBB could not be found! TBB grid block back-end disabled!")
         SET(ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE OFF CACHE BOOL "Enable the TBB grid block back-end" FORCE)
     ELSE()
-        LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC "${TBB_LIBRARIES}")
+        LIST(APPEND _ALPAKA_LINK_LIBRARIES_PUBLIC ${TBB_LIBRARIES})
         LIST(APPEND _ALPAKA_INCLUDE_DIRECTORIES_PUBLIC ${TBB_INCLUDE_DIRS})
+        LIST(APPEND _ALPAKA_COMPILE_OPTIONS_PUBLIC ${TBB_DEFINITIONS})
     ENDIF()
 ENDIF()
 
@@ -324,7 +333,7 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
                     SET(CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
                 ENDIF()
 
-                IF(CMAKE_BUILD_TYPE MATCHES "Debug")
+                if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
                     LIST(APPEND CUDA_NVCC_FLAGS "-g" "-G")
                 ENDIF()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,24 +63,24 @@ environment:
         ALPAKA_ACC_CPU_BT_OMP4_ENABLE: OFF
         ALPAKA_ACC_GPU_CUDA_ENABLE: OFF
         ALPAKA_ACC_GPU_CUDA_ONLY_MODE: OFF
+        ALPAKA_DEBUG: 0
 
     matrix:
-        - ALPAKA_DEBUG: 0
+        - ALPAKA_DEBUG: 2
           OMP_NUM_THREADS: 4
-          ALPAKA_BOOST_BRANCH: boost-1.60.0
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 3
           ALPAKA_BOOST_BRANCH: boost-1.61.0
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 4
+        - OMP_NUM_THREADS: 3
+          ALPAKA_BOOST_BRANCH: boost-1.60.0
+        - OMP_NUM_THREADS: 1
+          ALPAKA_BOOST_BRANCH: boost-1.59.0
+        - OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop
 
 matrix:
     fast_finish: true
 
     allow_failures:
-        - ALPAKA_DEBUG: 0
-          OMP_NUM_THREADS: 4
+        - OMP_NUM_THREADS: 4
           ALPAKA_BOOST_BRANCH: develop
 
 ################################################################################
@@ -147,11 +147,6 @@ before_build:
     - cmd: git clone -b %ALPAKA_BOOST_BRANCH% --recursive --single-branch --depth 1 https://github.com/boostorg/boost.git %BOOST_ROOT%
     - cmd: cd %BOOST_ROOT%
 
-    # Clone boost.fiber.
-    - cmd: cd libs
-    - cmd: if "%ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE%"=="ON" git clone -b develop --single-branch --depth 1 https://github.com/olk/boost-fiber.git fiber
-    - cmd: cd ..
-
     # Prepare building of boost.
     - cmd: call bootstrap.bat
     # Create file links.
@@ -169,8 +164,15 @@ before_build:
 
     #-------------------------------------------------------------------------------
     # Install TBB
+    - cmd: set TBB_ARCHIVE_VER=tbb44_20160526oss
     - cmd: set TBB_ROOT_DIR=C:\projects\tbb
-
+    - cmd: mkdir %TBB_ROOT_DIR%
+    - cmd: curl https://www.threadingbuildingblocks.org/sites/default/files/software_releases/windows/%TBB_ARCHIVE_VER%_win_0.zip > %TBB_ROOT_DIR%\tbb.zip
+    - cmd: 7z x %TBB_ROOT_DIR%\tbb.zip -o%TBB_ROOT_DIR% -y
+    - cmd: set TBB_ROOT_DIR=%TBB_ROOT_DIR%\%TBB_ARCHIVE_VER%
+    - cmd: if "%PLATFORM%"=="Win32" set ALPAKA_TBB_BIN_DIR=%TBB_ROOT_DIR%\bin\ia32\vc14
+    - cmd: if "%PLATFORM%"=="x64" set ALPAKA_TBB_BIN_DIR=%TBB_ROOT_DIR%\bin\intel64\vc14
+    - cmd: set PATH=%PATH%;%ALPAKA_TBB_BIN_DIR%
 
     #-------------------------------------------------------------------------------
     # Build the visual studio soultion from the cmake files.
@@ -180,13 +182,7 @@ before_build:
     - cmd: if "%PLATFORM%"=="x64" set ALPAKA_CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
     - cmd: mkdir build
     - cmd: cd build
-    - cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DTBB_ROOT_DIR=%TBB_ROOT_DIR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF -DALPAKA_DEBUG="%ALPAKA_DEBUG%" -DALPAKA_CI=ON ".."
-
-    # TODO: Use something like the following if clang fully supports to build alpaka on Windows.
-    #- cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -T LLVM-vs2014 -DCMAKE_CXX_COMPILER="C:\\Program Files\\LLVM\\msbuild-bin\\cl.exe" ..
-    #- cmd: cmake .. -DCMAKE_CXX_COMPILER="C:\\projects\\alpaka\\$_OUTDIR\\bin\\clang++.exe"
-
-
+    - cmd: cmake -G "%ALPAKA_CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DTBB_ROOT_DIR="%TBB_ROOT_DIR%" -DBOOST_ROOT="%BOOST_ROOT%" -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DBoost_USE_STATIC_LIBS=ON -DBoost_USE_MULTITHREADED=ON -DBoost_USE_STATIC_RUNTIME=OFF -DALPAKA_DEBUG="%ALPAKA_DEBUG%" -DALPAKA_CI=ON ".."
 
 build:
     project: C:\projects\alpaka\build\alpakaAll.sln

--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -89,7 +89,8 @@ if(NOT TBB_FOUND)
   ##################################
   
   if(NOT DEFINED TBB_USE_DEBUG_BUILD)
-    if(CMAKE_BUILD_TYPE MATCHES "[Debug|DEBUG|debug|RelWithDebInfo|RELWITHDEBINFO|relwithdebinfo]")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+      message(STATUS "Set TBB_USE_DEBUG_BUILD to TRUE because CMAKE_BUILD_TYPE is one of the debug configurations.")
       set(TBB_USE_DEBUG_BUILD TRUE)
     else()
       set(TBB_USE_DEBUG_BUILD FALSE)
@@ -175,13 +176,12 @@ if(NOT TBB_FOUND)
     find_library(TBB_${_comp}_LIBRARY_RELEASE ${_comp}
         HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
         PATHS ${TBB_DEFAULT_SEARCH_DIR}
-        PATH_SUFFIXES "${TBB_LIB_PATH_SUFFIX}")
+        PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
 
     find_library(TBB_${_comp}_LIBRARY_DEBUG ${_comp}_debug
         HINTS ${TBB_LIBRARY} ${TBB_SEARCH_DIR}
         PATHS ${TBB_DEFAULT_SEARCH_DIR} ENV LIBRARY_PATH
-        PATH_SUFFIXES "${TBB_LIB_PATH_SUFFIX}")
-    
+        PATH_SUFFIXES ${TBB_LIB_PATH_SUFFIX})
     
     # Set the library to be used for the component
     if(NOT TBB_${_comp}_LIBRARY)
@@ -191,6 +191,7 @@ if(NOT TBB_FOUND)
         set(TBB_${_comp}_LIBRARY "${TBB_${_comp}_LIBRARY_RELEASE}")
       elseif(TBB_${_comp}_LIBRARY_DEBUG)
         set(TBB_${_comp}_LIBRARY "${TBB_${_comp}_LIBRARY_DEBUG}")
+        message(STATUS "Using the debug library of '${_comp}' because the release library could not be found!")
       endif()
     endif()
     


### PR DESCRIPTION
Appveyor has changed its build farm and the build times have been reduced to 1/4. This allows us to extend the tests.