### PR TITLE
fix warning call `__host__` function

### DIFF
--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -98,6 +98,7 @@ namespace alpaka
                 //! \tparam TBlockSharedMemSt The block shared allocator implementation type.
                 //! \param blockSharedMemSt The block shared allocator implementation.
                 //-----------------------------------------------------------------------------
+                ALPAKA_NO_HOST_ACC_WARNING
                 template<
                     typename TBlockSharedMemSt>
                 ALPAKA_FN_ACC auto freeMem(


### PR DESCRIPTION
fix `warning: calling a __host__ function from a __host__ __device__ function is not allowed`