### PR TITLE
remove std::err messages before exceptions

### DIFF
--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -107,7 +107,9 @@ namespace alpaka
                     if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error) == aIgnoredErrorCodes.cend())
                     {
                         std::string const sError(std::string(file) + "(" + std::to_string(line) + ") '" + std::string(cmd) + "' returned error: '" + std::string(cudaGetErrorString(error)) + "'!");
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                         std::cerr << sError << std::endl;
+#endif
                         ALPAKA_DEBUG_BREAK;
                         throw std::runtime_error(sError);
                     }
@@ -126,7 +128,9 @@ namespace alpaka
                 if(lastError != cudaSuccess)
                 {
                     std::string const sError(std::string(file) + "(" + std::to_string(line) + ") '" + std::string(cmd) + "' A previous CUDA call (not this one) set the error: '" + std::string(cudaGetErrorString(lastError)) + "'!");
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                     std::cerr << sError << std::endl;
+#endif
                     ALPAKA_DEBUG_BREAK;
                     throw std::runtime_error(sError);
                 }
@@ -177,7 +181,9 @@ namespace alpaka
                 if(error != CUDA_SUCCESS)
                 {
                     std::string const sError(std::to_string(file) + "(" + std::to_string(line) + ") '" + std::to_string(cmd) + "' returned error: '" + std::to_string(error) + "' (possibly from a previous CUDA call)!");
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                     std::cerr << sError << std::endl;
+#endif
                     ALPAKA_DEBUG_BREAK;
                     throw std::runtime_error(sError);
                 }


### PR DESCRIPTION
Disable error message before exceptions if debug mode of alpaka is not activated.

If something inside alpaka goes wrong an exception is triggered. 
The exception can be handled inside the user code. 
The problem is that in some cases a error message is written directly to `std::err` even if the user catch the exception.

This pull request removes the error message before an exception if the debug mode for alpaka is disabled.