### PR TITLE
extend the list of warnings enabled in CI for gcc

### DIFF
--- a/cmake/dev.cmake
+++ b/cmake/dev.cmake
@@ -38,6 +38,78 @@ ELSE()
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wextra")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-pedantic")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Werror")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wdouble-promotion")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wmissing-include-dirs")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wunknown-pragmas")
+        # Higher levels (max is 5) produce some strange warnings
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wstrict-overflow=2")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wtrampolines")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wfloat-equal")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wundef")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wshadow")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wcast-qual")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wcast-align")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wwrite-strings")
+        # Too noisy as it warns for every operation using numeric types smaller then int.
+        # Such values are converted to int implicitly before the calculation is done.
+        # E.g.: uint16_t = uint16_t * uint16_t will trigger the following warning:
+        # conversion to ‘short unsigned int’ from ‘int’ may alter its value
+        #LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wconversion")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsign-conversion")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wvector-operation-performance")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wzero-as-null-pointer-constant")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wdate-time")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wuseless-cast")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wlogical-op")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wno-aggressive-loop-optimizations")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wmissing-declarations")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wno-multichar")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wopenmp-simd")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wpacked")
+        # Too much noise
+        #LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wpadded")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wredundant-decls")
+        # Too much noise
+        #LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Winline")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wdisabled-optimization")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wformat-nonliteral")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wformat-security")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wformat-y2k")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wabi-tag")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wctor-dtor-privacy")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wdelete-non-virtual-dtor")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wliteral-suffix")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wnon-virtual-dtor")
+        # This warns about members that have not explicitly been listed in the constructor initializer list.
+        # This could be useful even for members that have a default constructor.
+        # However, it also issues this warning for defaulted constructurs.
+        #LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Weffc++")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Woverloaded-virtual")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsign-promo")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wconditionally-supported")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wnoexcept")
+        LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wold-style-cast")
+        IF(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsuggest-final-types")
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsuggest-final-methods")
+            # This does not work correctly as it suggests override to methods that are already marked with final.
+            # Because final implies override, this is not useful.
+            #LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsuggest-override")
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wnormalized")
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wformat-signedness")
+        ENDIF()
+        IF(NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wnull-dereference")
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wduplicated-cond")
+            LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Wsubobject-linkage")
+        ENDIF()
+        # By marking the boost headers as system headers, warnings produced within them are ignored.
+        FIND_PACKAGE(Boost QUIET)
+        IF(NOT Boost_FOUND)
+            MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+        ENDIF()
+        INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIRS})
+
     # Clang or AppleClang
     ELSEIF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         LIST(APPEND ALPAKA_DEV_COMPILE_OPTIONS "-Werror")

--- a/example/vectorAdd/src/main.cpp
+++ b/example/vectorAdd/src/main.cpp
@@ -176,11 +176,16 @@ auto main()
         auto const correctResult(alpaka::mem::view::getPtrNative(memBufHostA)[i]+alpaka::mem::view::getPtrNative(memBufHostB)[i]);
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe" but we want to do exactly this
+    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
+#elif BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
 #endif
         if(val != correctResult)
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic pop
+#elif BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
 #endif
         {
             std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -174,7 +174,7 @@ namespace alpaka
                 template<typename TFnObjReturn> class TPromise,
                 typename TFnObj,
                 typename TFnObjReturn>
-            class TaskPkg :
+            class TaskPkg final :
                 public ITaskPkg
             {
             public:
@@ -228,7 +228,7 @@ namespace alpaka
             class TaskPkg<
                 TPromise,
                 TFnObj,
-                void> :
+                void> final :
                 public ITaskPkg
             {
             public:

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -158,7 +158,7 @@ namespace alpaka
 
                             for(Size dim_i(0); dim_i + 1 < static_cast<Size>(Dim::value); ++dim_i)
                             {
-                                ptr += (currentIdxDimx[dim_i] * m_pitchBytes[dim_i+1]) / static_cast<Size>(sizeof(Elem));
+                                ptr += static_cast<Size>(currentIdxDimx[dim_i] * m_pitchBytes[dim_i+1]) / static_cast<Size>(sizeof(Elem));
                             }
 
                             ptr += currentIdxDimx[Dim::value - 1];

--- a/test/integ/axpy/src/main.cpp
+++ b/test/integ/axpy/src/main.cpp
@@ -86,6 +86,10 @@ public:
 //#############################################################################
 struct AxpyKernelTester
 {
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
+#endif
     template<
         typename TAcc,
         typename TSize>
@@ -212,7 +216,7 @@ struct AxpyKernelTester
             auto const correctResult(alpha * alpaka::mem::view::getPtrNative(memBufHostX)[i] + alpaka::mem::view::getPtrNative(memBufHostOrigY)[i]);
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe" but we want to do exactly this
+    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
 #endif
             if(val != correctResult)
 #if BOOST_COMP_CLANG
@@ -233,6 +237,9 @@ struct AxpyKernelTester
 
         allResultsCorrect = allResultsCorrect && resultCorrect;
     }
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
 
 public:
     bool allResultsCorrect = true;

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -299,7 +299,7 @@ auto main()
         alpaka::meta::forEachType<
             alpaka::test::acc::EnabledAccs<alpaka::dim::DimInt<1u>, std::uint32_t>>(
                 sharedMemTester,
-                static_cast<std::uint32_t>(512u),
+                512u,
                 mult2);
 
         return sharedMemTester.allResultsCorrect ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -121,6 +121,10 @@ static auto createVecFromIndexedFn()
 //#############################################################################
 //! Compares iterators element-wise
 //#############################################################################
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
+#endif
 struct CompareBufferKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
@@ -148,6 +152,9 @@ struct CompareBufferKernel
         }
     }
 };
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
 
 //-----------------------------------------------------------------------------
 //


### PR DESCRIPTION
This enables most of all available GCC warnings for the CI builds.
This closes #262.
