### PR TITLE
remove unnecessary parameter

### DIFF
--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -114,8 +114,6 @@ namespace alpaka
 #if (!__GLIBCXX__) // libstdc++ even for gcc-4.9 does not support std::is_trivially_copyable.
             static_assert(
                 meta::Conjunction<
-                    // This true_ is required for the zero argument case because and_ requires at least two arguments.
-                    std::true_type,
                     std::is_trivially_copyable<
                         TKernelFnObj>,
                     std::is_trivially_copyable<


### PR DESCRIPTION
The parameter is not necessary because there is already at least one argument. The removal of the true_type has been forgotten long ago.
