### PR TITLE
fix MSVC CUDA incompatibility but document no support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This library uses C++11 (or newer when available).
 |OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|:x:|:x:|
 | std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Boost.Fiber |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|CUDA 7.0+|:white_check_mark: (nvcc 7.0+)|:white_check_mark: (nvcc 8.0+)|:x:|:x:|:x:|:white_check_mark: (native/nvcc 8.0+)|:white_check_mark: (native)|:white_check_mark: (nvcc 8.0+)|
+|CUDA 7.0+|:white_check_mark: (nvcc 7.0+)|:white_check_mark: (nvcc 8.0+)|:x:|:x:|:x:|:white_check_mark: (native/nvcc 8.0+)|:white_check_mark: (native)|:x:|
 
 
 Dependencies

--- a/include/alpaka/meta/ForEachType.hpp
+++ b/include/alpaka/meta/ForEachType.hpp
@@ -96,7 +96,7 @@ namespace alpaka
                 -> void
                 {
                     // Call the function object template call operator.
-#if BOOST_COMP_MSVC
+#if BOOST_COMP_MSVC && !BOOST_COMP_NVCC
                     f.operator()<T>(
                         std::forward<TArgs>(args)...);
 #else


### PR DESCRIPTION
As I now had time to test CUDA support on MSVC 2015 with the new CUDA 8.0 (because it is the first version to support MSVC 2015) I found many incompatibilities.
One issue was easy to fix because the nvcc version emulating MSVC is not bug compatible. But there are more issues (especially in combination with boost).
For now we can not claim support for CUDA on MSVC 2015.