### PR TITLE
Fixed bug #298 about broken BOOST_INTEL_COMP define in recent boost versions

### DIFF
--- a/include/alpaka/core/BoostPredefWorkaround.hpp
+++ b/include/alpaka/core/BoostPredefWorkaround.hpp
@@ -1,0 +1,37 @@
+/**
+ * \file
+ * Copyright 2017 Alexander Matthes
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <boost/predef.h>
+//Workaround as old boost versions do not set BOOST_COMP_INTEL correctly
+#if BOOST_COMP_INTEL == 0 // Work around for broken intel detection
+    #if defined(__INTEL_COMPILER)
+        #ifdef BOOST_COMP_INTEL_DETECTION
+            #undef BOOST_COMP_INTEL_DETECTION
+        #endif
+        #define BOOST_COMP_INTEL_DETECTION BOOST_PREDEF_MAKE_10_VVRR(__INTEL_COMPILER)
+        #if defined(BOOST_COMP_INTEL)
+            #undef BOOST_COMP_INTEL
+        #endif
+        #define BOOST_COMP_INTEL BOOST_COMP_INTEL_DETECTION
+    #endif
+#endif

--- a/include/alpaka/core/Debug.hpp
+++ b/include/alpaka/core/Debug.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <boost/current_function.hpp>
-#include <boost/predef.h>                   // workarounds
+#include <alpaka/core/BoostPredefWorkaround.hpp> // workarounds
 /*#include <boost/preprocessor/stringize.hpp> // BOOST_PP_STRINGIZE
 
 #include <stdexcept>                        // std::runtime_error*/


### PR DESCRIPTION
Fixed bug https://github.com/ComputationalRadiationPhysics/alpaka/issues/298 about broken BOOST_INTEL_COMP define in recent boost versions