### PR TITLE
add viewTestMutable

### DIFF
--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -72,6 +72,10 @@ namespace alpaka
                             std::is_same<elem::Elem<TViewDst>, typename std::remove_const<elem::Elem<TViewSrc>>::type>::value,
                             "The source and the destination view are required to have the same element type!");
 
+                        static_assert(
+                            dim::Dim<TExtent>::value <= 3u,
+                            "TaskCopy for DevCpu does not currently support views with more than 3 dimensions!");
+
                         //-----------------------------------------------------------------------------
                         //! Constructor.
                         //-----------------------------------------------------------------------------

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -62,6 +62,10 @@ namespace alpaka
                             dim::Dim<TView>::value == dim::Dim<TExtent>::value,
                             "The destination view and the extent are required to have the same dimensionality!");
 
+                        static_assert(
+                            dim::Dim<TView>::value <= 3u,
+                            "TaskSet for DevCpu does not currently support views with more than 3 dimensions!");
+
                         //-----------------------------------------------------------------------------
                         //! Constructor.
                         //-----------------------------------------------------------------------------

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -99,7 +99,7 @@ namespace alpaka
             namespace traits
             {
                 //#############################################################################
-                //! The CPU device memory set trait specialization.
+                //! The CUDA device memory set trait specialization.
                 //#############################################################################
                 template<
                     typename TDim>

--- a/test/common/include/alpaka/test/acc/Acc.hpp
+++ b/test/common/include/alpaka/test/acc/Acc.hpp
@@ -27,7 +27,8 @@
 #include <type_traits>                      // std::is_class
 #include <iosfwd>                           // std::ostream
 
-// When compiling the tests with nvcc on the CI infrastructure we have to dramatically reduce the number of tested combinations.
+// When compiling the tests with CUDA enabled (nvcc or native clang) on the CI infrastructure
+// we have to dramatically reduce the number of tested combinations.
 // Else the log length would be exceeded.
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA && ALPAKA_CI
     #define ALPAKA_CUDA_CI
@@ -218,8 +219,12 @@ namespace alpaka
                 std::tuple<
                     alpaka::dim::DimInt<1u>,
                     //alpaka::dim::DimInt<2u>,
-                    alpaka::dim::DimInt<3u>/*,
-                    alpaka::dim::DimInt<4u>*/>;
+                    alpaka::dim::DimInt<3u>
+            // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
+#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
+                    /*,alpaka::dim::DimInt<4u>*/
+#endif
+                >;
 
             //#############################################################################
             //! A std::tuple holding size types.
@@ -244,10 +249,13 @@ namespace alpaka
                 std::tuple<
                     alpaka::dim::DimInt<1u>,
                     alpaka::dim::DimInt<2u>,
-                    alpaka::dim::DimInt<3u>,
+                    alpaka::dim::DimInt<3u>
+            // The CPU buffers do not support copy and set with more than 3 dimensions
+#if 0
             // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
 #if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
-                    alpaka::dim::DimInt<4u>
+                    ,alpaka::dim::DimInt<4u>
+#endif
 #endif
                 >;
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2015 Benjamin Worpitz
+ * Copyright 2015-2017 Benjamin Worpitz
  *
  * This file is part of alpaka.
  *
@@ -104,12 +104,14 @@ static auto basicBufferOperationsTest(
 {
     using Dev = alpaka::dev::Dev<TAcc>;
     using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Stream = alpaka::test::stream::DefaultStream<Dev>;
 
     using Elem = float;
     using Dim = alpaka::dim::Dim<TAcc>;
     using Size = alpaka::size::Size<TAcc>;
 
     Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    Stream stream(dev);
 
     //-----------------------------------------------------------------------------
     // alpaka::mem::buf::alloc
@@ -123,6 +125,12 @@ static auto basicBufferOperationsTest(
             dev,
             extent,
             offset);
+
+    //-----------------------------------------------------------------------------
+    alpaka::test::mem::view::viewTestMutable<
+        TAcc>(
+            stream,
+            buf);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This adds the generic test function `viewTestMutable` which tests the operation `set` and the `copy` operation on the given view/buffer. The view/buffer contents are checked for correctness with a kernel.

* adds static asserts for dim<=3 for CPU copy and set
* disables 4D tests even for CPU accelerators as long as it is not fully supported

Prework for n-dimensional copy/set support (See #159 and #290).