### PR TITLE
add more Vec functions

### DIFF
--- a/include/alpaka/vec/Traits.hpp
+++ b/include/alpaka/vec/Traits.hpp
@@ -65,6 +65,15 @@ namespace alpaka
                 typename TVec,
                 typename TSfinae = void>
             struct Reverse;
+
+            //#############################################################################
+            //! Trait for concatenating two vectors.
+            //#############################################################################
+            template<
+                typename TVecL,
+                typename TVecR,
+                typename TSfinae = void>
+            struct Concat;
         }
 
         //-----------------------------------------------------------------------------
@@ -216,6 +225,35 @@ namespace alpaka
                     TVec>
                 ::reverse(
                     vec);
+        }
+
+        //-----------------------------------------------------------------------------
+        //! \return The concatenated vector.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TVecL,
+            typename TVecR>
+        ALPAKA_FN_HOST_ACC auto concat(
+            TVecL const & vecL,
+            TVecR const & vecR)
+#ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+        -> decltype(
+            traits::Concat<
+                TVecL,
+                TVecR>
+            ::concat(
+                vecL,
+                vecR))
+#endif
+        {
+            return
+                traits::Concat<
+                    TVecL,
+                    TVecR>
+                ::concat(
+                    vecL,
+                    vecR);
         }
     }
 }

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -1,23 +1,23 @@
 /**
-* \file
-* Copyright 2014-2015 Benjamin Worpitz
-*
-* This file is part of alpaka.
-*
-* alpaka is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Lesser General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* alpaka is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-* GNU Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public License
-* along with alpaka.
-* If not, see <http://www.gnu.org/licenses/>.
-*/
+ * \file
+ * Copyright 2014-2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -700,6 +700,57 @@ namespace alpaka
                         q);
         }
 
+        namespace detail
+        {
+            //#############################################################################
+            //! A function object that returns the element wise less than relation of two vectors.
+            //#############################################################################
+            template<
+                std::size_t Tidx>
+            struct CreateLessEqual
+            {
+                //-----------------------------------------------------------------------------
+                //!
+                //-----------------------------------------------------------------------------
+                ALPAKA_NO_HOST_ACC_WARNING
+                template<
+                    typename TDim,
+                    typename TSize>
+                ALPAKA_FN_HOST_ACC static auto create(
+                    Vec<TDim, TSize> const & p,
+                    Vec<TDim, TSize> const & q)
+                -> bool
+                {
+                    return p[Tidx] <= q[Tidx];
+                }
+            };
+        }
+
+        //-----------------------------------------------------------------------------
+        //! \return The element wise less than relation of two vectors.
+        //-----------------------------------------------------------------------------
+        ALPAKA_NO_HOST_ACC_WARNING
+        template<
+            typename TDim,
+            typename TSize>
+        ALPAKA_FN_HOST_ACC auto operator<=(
+            Vec<TDim, TSize> const & p,
+            Vec<TDim, TSize> const & q)
+        -> Vec<TDim, bool>
+        {
+            return
+#ifdef ALPAKA_CREATE_VEC_IN_CLASS
+                Vec<TDim, bool>::template
+#endif
+                createVecFromIndexedFn<
+#ifndef ALPAKA_CREATE_VEC_IN_CLASS
+                    TDim,
+#endif
+                    detail::CreateLessEqual>(
+                        p,
+                        q);
+        }
+
         //-----------------------------------------------------------------------------
         //! Stream out operator.
         //-----------------------------------------------------------------------------
@@ -842,7 +893,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! Specialization for selecting a sub-vector.
+            //! Cast specialization for Vec.
             //#############################################################################
             template<
                 typename TSizeNew,
@@ -853,11 +904,11 @@ namespace alpaka
                 Vec<TDim, TSize>>
             {
                 //-----------------------------------------------------------------------------
-                //! Cast constructor.
+                //!
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto cast(
-                    Vec<TDim, TSize> const & other)
+                    Vec<TDim, TSize> const & vec)
                 -> Vec<TDim, TSizeNew>
                 {
                     return
@@ -870,7 +921,29 @@ namespace alpaka
 #endif
                             vec::detail::CreateCast>(
                                 TSizeNew(),
-                                other);
+                                vec);
+                }
+            };
+
+            //#############################################################################
+            //! (Non-)Cast specialization for Vec when src and dst types are identical.
+            //#############################################################################
+            template<
+                typename TDim,
+                typename TSize>
+            struct Cast<
+                TSize,
+                Vec<TDim, TSize>>
+            {
+                //-----------------------------------------------------------------------------
+                //!
+                //-----------------------------------------------------------------------------
+                ALPAKA_NO_HOST_ACC_WARNING
+                ALPAKA_FN_HOST_ACC static auto cast(
+                    Vec<TDim, TSize> const & vec)
+                -> Vec<TDim, TSize>
+                {
+                    return vec;
                 }
             };
         }
@@ -902,7 +975,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! Specialization for selecting a sub-vector.
+            //! Reverse specialization for Vec.
             //#############################################################################
             template<
                 typename TDim,
@@ -925,6 +998,23 @@ namespace alpaka
 #endif
                             vec::detail::CreateReverse>(
                                 vec);
+                }
+            };
+
+            //#############################################################################
+            //! (Non-)Reverse specialization for 1D Vec.
+            //#############################################################################
+            template<
+                typename TSize>
+            struct Reverse<
+                Vec<dim::DimInt<1u>, TSize>>
+            {
+                ALPAKA_NO_HOST_ACC_WARNING
+                ALPAKA_FN_HOST_ACC static auto reverse(
+                    Vec<dim::DimInt<1u>, TSize> const & vec)
+                -> Vec<dim::DimInt<1u>, TSize>
+                {
+                    return vec;
                 }
             };
         }

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(
 
         static_assert(
             std::is_same<alpaka::dim::Dim<std::decay<decltype(vecConcat)>::type>, alpaka::dim::DimInt<5u>>::value,
-            "Result dimension of concatenation incorrect!");
+            "Result dimension type of concatenation incorrect!");
 
         for(typename Dim::value_type i(0); i < Dim::value; ++i)
         {
@@ -162,6 +162,32 @@ BOOST_AUTO_TEST_CASE(
         {
             BOOST_REQUIRE_EQUAL(vecConcat[Dim::value + i], vec2[i]);
         }
+    }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::Vec operator <=
+    {
+        alpaka::vec::Vec<Dim, Size> const vec3(
+            static_cast<std::size_t>(47u),
+            static_cast<std::size_t>(11u),
+            static_cast<std::size_t>(3u));
+
+        auto const vecLessEqual(vec <= vec3);
+
+        static_assert(
+            std::is_same<alpaka::dim::Dim<std::decay<decltype(vecLessEqual)>::type>, Dim>::value,
+            "Result dimension type of operator <= incorrect!");
+
+        static_assert(
+            std::is_same<alpaka::size::Size<std::decay<decltype(vecLessEqual)>::type>, bool>::value,
+            "Result size type of operator <= incorrect!");
+
+        alpaka::vec::Vec<Dim, bool> const referenceLessEqualVec(
+            true,
+            true,
+            false);
+
+        BOOST_REQUIRE_EQUAL(referenceLessEqualVec, vecLessEqual);
     }
 }
 

--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -136,6 +136,33 @@ BOOST_AUTO_TEST_CASE(
             BOOST_REQUIRE_EQUAL(vecReverse[i], vec[Dim::value - 1u - i]);
         }
     }
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::concat
+    {
+        using Dim2 = alpaka::dim::DimInt<2u>;
+        alpaka::vec::Vec<Dim2, Size> const vec2(
+            static_cast<std::size_t>(47u),
+            static_cast<std::size_t>(11u));
+
+        auto const vecConcat(
+            alpaka::vec::concat(
+                vec,
+                vec2));
+
+        static_assert(
+            std::is_same<alpaka::dim::Dim<std::decay<decltype(vecConcat)>::type>, alpaka::dim::DimInt<5u>>::value,
+            "Result dimension of concatenation incorrect!");
+
+        for(typename Dim::value_type i(0); i < Dim::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecConcat[i], vec[i]);
+        }
+        for(typename Dim2::value_type i(0); i < Dim2::value; ++i)
+        {
+            BOOST_REQUIRE_EQUAL(vecConcat[Dim::value + i], vec2[i]);
+        }
+    }
 }
 
 //#############################################################################
@@ -162,7 +189,7 @@ struct NonAlpakaVec
         for(TSize d(0); d < TDim::value; ++d)
         {
             result[TDim::value - 1 - d] = (*this)[d];
-        }    
+        }
 
         return result;
     }


### PR DESCRIPTION
* adds `alpaka::vec::concat` trait and implements it for `alpaka::vec::Vec`.
* adds `alpaka::vec::Vec<Dim, bool> alpaka::vec::Vec<Dim, Size>::operator<=`
* add specialization for reversing of one-dimensional Vec
* add specialization for casting Vec when Src and Dst types are equal

Prework for n-dimensional copy/set support (See #159 and #290).