### PR TITLE
Add support for zero-dimensional Vec

### DIFF
--- a/test/unit/vec/src/VecTest.cpp
+++ b/test/unit/vec/src/VecTest.cpp
@@ -49,6 +49,15 @@ BOOST_AUTO_TEST_CASE(
         static_cast<std::size_t>(8u),
         static_cast<std::size_t>(15u));
 
+
+
+    //-----------------------------------------------------------------------------
+    // alpaka::vec::Vec zero elements
+    {
+        using Dim0 = alpaka::dim::DimInt<0u>;
+        alpaka::vec::Vec<Dim0, Size> const vec0{};
+    }
+
     //-----------------------------------------------------------------------------
     // alpaka::vec::subVecFromIndices
     {


### PR DESCRIPTION
Enables `alpaka::vec::Vec` to have zero elements. This is necessary to support some generic code.

Prework for n-dimensional copy/set support (See #159 and #290).