### PR TITLE
implement IsIntegralSuperset

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -185,14 +185,18 @@
 //-----------------------------------------------------------------------------
 #include <alpaka/meta/Apply.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
-#include <alpaka/meta/Concatenate.hpp>
 #include <alpaka/meta/CartesianProduct.hpp>
+#include <alpaka/meta/Concatenate.hpp>
 #include <alpaka/meta/DependentFalseType.hpp>
 #include <alpaka/meta/Filter.hpp>
 #include <alpaka/meta/Fold.hpp>
 #include <alpaka/meta/ForEachType.hpp>
+#include <alpaka/meta/IntegerSequence.hpp>
+#include <alpaka/meta/IsIntegralSuperset.hpp>
+#include <alpaka/meta/IsStrictBase.hpp>
 #include <alpaka/meta/Metafunctions.hpp>
 #include <alpaka/meta/NdLoop.hpp>
+#include <alpaka/meta/Set.hpp>
 #include <alpaka/meta/StdTupleAsMplSequence.hpp>
 #include <alpaka/meta/Transform.hpp>
 

--- a/include/alpaka/meta/IsIntegralSuperset.hpp
+++ b/include/alpaka/meta/IsIntegralSuperset.hpp
@@ -1,0 +1,47 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <type_traits>  // std::is_unsigned, std::is_integral
+
+namespace alpaka
+{
+    namespace meta
+    {
+        //#############################################################################
+        //! The trait is true if all values of TSubset are contained in TSuperset.
+        //#############################################################################
+        template<
+            typename TSuperset,
+            typename TSubset>
+        using IsIntegralSuperset =
+            std::integral_constant<
+                bool,
+                std::is_integral<TSuperset>::value && std::is_integral<TSubset>::value
+                && (
+                    // If the signdness is equal, the sizes have to be greater or equal to be a superset.
+                    ((std::is_unsigned<TSuperset>::value == std::is_unsigned<TSubset>::value) && (sizeof(TSuperset) >= sizeof(TSubset)))
+                    // If the signdness is non-equal, the superset has to have at least one bit more.
+                    || ((std::is_unsigned<TSuperset>::value != std::is_unsigned<TSubset>::value) && (sizeof(TSuperset) > sizeof(TSubset)))
+                )>;
+    }
+}

--- a/test/unit/meta/src/IsIntegralSupersetTest.cpp
+++ b/test/unit/meta/src/IsIntegralSupersetTest.cpp
@@ -1,0 +1,291 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+
+#include <boost/predef.h>               // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
+
+#include <type_traits>                  // std::is_same, std::is_integral
+
+BOOST_AUTO_TEST_SUITE(meta)
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isIntegralSupersetTrue)
+{
+    // unsigned - unsigned
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint32_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint32_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint32_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint16_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint16_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint8_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // signed - signed
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int32_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int32_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int32_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int16_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int16_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int8_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // unsigned - signed
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint64_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint32_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint32_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::uint16_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // signed - unsigned
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int64_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int32_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int32_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        alpaka::meta::IsIntegralSuperset<std::int16_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isIntegralSupersetNoIntegral)
+{
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<float, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint64_t, double>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+}
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(isIntegralSupersetFalse)
+{
+    // unsigned - unsigned
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint16_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint16_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint32_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // signed - signed
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int16_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int16_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int32_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // unsigned - signed
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint64_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint32_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint32_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint16_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint16_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint16_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::int64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::int32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::int16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::uint8_t, std::int8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    // signed - unsigned
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int64_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int32_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int32_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int16_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int16_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int16_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::uint64_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::uint32_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::uint16_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+    static_assert(
+        !alpaka::meta::IsIntegralSuperset<std::int8_t, std::uint8_t>::value,
+        "alpaka::meta::IsIntegralSuperset failed!");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
`alpaka::meta::IsIntegralSuperset` tests if an integral type is a superset of another integral type.

Prework for n-dimensional copy/set support (See #159 and #290).