### PR TITLE
Explicitly define the fiber stack size

### DIFF
--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -300,8 +300,11 @@ namespace alpaka
                 //!    The guaranteed number of concurrent executors used in the pool.
                 //!    This is also the maximum number of tasks worked on concurrently.
                 //-----------------------------------------------------------------------------
+                template<
+                    typename... TArgs>
                 ConcurrentExecPool(
-                    TSize concurrentExecutionCount) :
+                    TSize concurrentExecutionCount,
+                    TArgs... args) :
                     m_vConcurrentExecs(),
                     m_qTasks(),
                     m_bShutdownFlag(false)
@@ -316,7 +319,10 @@ namespace alpaka
                     // Create all concurrent executors.
                     for(TSize concurrentExec(0u); concurrentExec < concurrentExecutionCount; ++concurrentExec)
                     {
-                        m_vConcurrentExecs.emplace_back(std::bind(&ConcurrentExecPool::concurrentExecFn, this));
+                        m_vConcurrentExecs.emplace_back(
+                            std::tuple_cat(
+                                std::make_tuple(args...),
+                                std::make_tuple(std::bind(&ConcurrentExecPool::concurrentExecFn, this))));
                     }
                 }
                 //-----------------------------------------------------------------------------
@@ -505,8 +511,11 @@ namespace alpaka
                 //!    The guaranteed number of concurrent executors used in the pool.
                 //!    This is also the maximum number of tasks worked on concurrently.
                 //-----------------------------------------------------------------------------
+                template<
+                    typename... TArgs>
                 ConcurrentExecPool(
-                    TSize concurrentExecutionCount) :
+                    TSize concurrentExecutionCount,
+                    TArgs ... args) :
                     m_vConcurrentExecs(),
                     m_qTasks(),
                     m_mtxWakeup(),
@@ -523,7 +532,10 @@ namespace alpaka
                     // Create all concurrent executors.
                     for(TSize concurrentExec(0u); concurrentExec < concurrentExecutionCount; ++concurrentExec)
                     {
-                        m_vConcurrentExecs.emplace_back(std::bind(&ConcurrentExecPool::concurrentExecFn, this));
+                        m_vConcurrentExecs.emplace_back(
+                            std::tuple_cat(
+                                std::make_tuple(args...),
+                                std::make_tuple(std::bind(&ConcurrentExecPool::concurrentExecFn, this))));
                     }
                 }
                 //-----------------------------------------------------------------------------

--- a/include/alpaka/exec/ExecCpuFibers.hpp
+++ b/include/alpaka/exec/ExecCpuFibers.hpp
@@ -174,11 +174,15 @@ namespace alpaka
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                 std::cout << BOOST_CURRENT_FUNCTION
-                    << " Fiber stack size: " << boost::fibers::fixedsize_stack::traits_type::default_size() << " B" << std::endl;
+                    << " Fiber stack size: " << m_perFiberStackSizeInByte << " B"
+                    << ", default fiber stack size: " << boost::fibers::fixedsize_stack::traits_type::default_size() << " B" << std::endl;
 #endif
 
                 auto const blockThreadCount(blockThreadExtent.prod());
-                FiberPool fiberPool(blockThreadCount);
+                FiberPool fiberPool(
+                    blockThreadCount,
+                    std::allocator_arg,
+                    boost::fibers::fixedsize_stack(m_perFiberStackSizeInByte));
 
                 auto const boundGridBlockExecHost(
                     meta::apply(
@@ -216,7 +220,7 @@ namespace alpaka
                 TArgs const & ... args)
             -> void
             {
-                    // The futures of the threads in the current block.
+                // The futures of the threads in the current block.
                 std::vector<boost::fibers::future<void>> futuresInBlock;
 
                 // Set the index of the current block
@@ -318,6 +322,7 @@ namespace alpaka
                 syncBlockThreads(acc);
             }
 
+            static std::size_t const m_perFiberStackSizeInByte = 64u * 1024u;
             TKernelFnObj m_kernelFnObj;
             std::tuple<TArgs...> m_args;
         };


### PR DESCRIPTION
... to reduce the memory being allocated per fiber.
The 64 KiB used is close to the stack size available per CUDA thread on current GPUs. 