### PR TITLE
add missing static_cast to get matching types

### DIFF
--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -193,7 +193,7 @@ namespace alpaka
                 -> vec::Vec<dim::DimInt<1u>, TElem>
                 {
                     return {
-                        idx[0u] * extent[1u] + idx[1u]};
+                        static_cast<TElem>(idx[0u] * extent[1u] + idx[1u])};
                 }
             };
             //#############################################################################
@@ -219,7 +219,7 @@ namespace alpaka
                 -> vec::Vec<dim::DimInt<1u>, TElem>
                 {
                     return {
-                        (idx[0u] * extent[1u] + idx[1u]) * extent[2u] + idx[2u]};
+                        static_cast<TElem>((idx[0u] * extent[1u] + idx[1u]) * extent[2u] + idx[2u])};
                 }
             };
             //#############################################################################
@@ -245,7 +245,7 @@ namespace alpaka
                 -> vec::Vec<dim::DimInt<1u>, TElem>
                 {
                     return {
-                        ((idx[0u] * extent[1u] + idx[1u]) * extent[2u] + idx[2u]) * extent[3u] + idx[3u]};
+                        static_cast<TElem>(((idx[0u] * extent[1u] + idx[1u]) * extent[2u] + idx[2u]) * extent[3u] + idx[3u])};
                 }
             };
         }


### PR DESCRIPTION
The `static_cast`s had already been added to the non-1-dimensional cases but are also required here to fix compilation when `TElem` is one of the types for which the result of a mathematical operation between two same typed variables results in a different type.