### PR TITLE
add syncBlockThreadsPredicate (count, and, or)

### DIFF
--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -53,7 +53,8 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierFiber(
                     TSize const & blockThreadCount) :
-                        m_barrier(static_cast<std::size_t>(blockThreadCount))
+                        m_barrier(static_cast<std::size_t>(blockThreadCount)),
+                        m_threadCount(blockThreadCount)
                 {}
                 //-----------------------------------------------------------------------------
                 //! Copy constructor.
@@ -77,6 +78,11 @@ namespace alpaka
                 ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~BlockSyncBarrierFiber() = default;
 
                 boost::fibers::barrier mutable m_barrier;
+
+                TSize mutable m_threadCount;
+                TSize mutable m_curThreadCount;
+                TSize mutable m_generation;
+                int mutable m_result[2u];
             };
 
             namespace traits
@@ -97,6 +103,52 @@ namespace alpaka
                     -> void
                     {
                         blockSync.m_barrier.wait();
+                    }
+                };
+
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<
+                    typename TOp,
+                    typename TSize>
+                struct SyncBlockThreadsPredicate<
+                    TOp,
+                    BlockSyncBarrierFiber<TSize>>
+                {
+                    //-----------------------------------------------------------------------------
+                    //
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                        block::sync::BlockSyncBarrierFiber<TSize> const & blockSync,
+                        int predicate)
+                    -> int
+                    {
+                        if(blockSync.m_curThreadCount == blockSync.m_threadCount)
+                        {
+                            blockSync.m_curThreadCount = 0;
+                            ++blockSync.m_generation;
+                        }
+
+                        auto const generationMod2(blockSync.m_generation % 2u);
+
+                        // The first fiber will reset the value to the initial value.
+                        if(blockSync.m_curThreadCount == 0u)
+                        {
+                            blockSync.m_result[generationMod2] = TOp::InitialValue;
+                        }
+
+                        ++blockSync.m_curThreadCount;
+
+                        // We do not have to lock because there is only ever one fiber active per block.
+                        blockSync.m_result[generationMod2] = TOp()(blockSync.m_result[generationMod2], predicate);
+
+                        // After all block threads have combined their values ...
+                        blockSync.m_barrier.wait();
+
+                        // ... the result can be returned.
+                        return blockSync.m_result[generationMod2];
                     }
                 };
             }

--- a/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
@@ -90,6 +90,66 @@ namespace alpaka
                         __syncthreads();
                     }
                 };
+
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<>
+                struct SyncBlockThreadsPredicate<
+                    block::sync::op::Count,
+                    BlockSyncCudaBuiltIn>
+                {
+                    //-----------------------------------------------------------------------------
+                    //
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                        block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
+                        int predicate)
+                    -> int
+                    {
+                        return __syncthreads_count(predicate);
+                    }
+                };
+
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<>
+                struct SyncBlockThreadsPredicate<
+                    block::sync::op::LogicalAnd,
+                    BlockSyncCudaBuiltIn>
+                {
+                    //-----------------------------------------------------------------------------
+                    //
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                        block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
+                        int predicate)
+                    -> int
+                    {
+                        return __syncthreads_and(predicate);
+                    }
+                };
+
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<>
+                struct SyncBlockThreadsPredicate<
+                    block::sync::op::LogicalOr,
+                    BlockSyncCudaBuiltIn>
+                {
+                    //-----------------------------------------------------------------------------
+                    //
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                        block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
+                        int predicate)
+                    -> int
+                    {
+                        return __syncthreads_or(predicate);
+                    }
+                };
             }
         }
     }

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -88,6 +88,29 @@ namespace alpaka
                         // Nothing to do.
                     }
                 };
+
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<
+                    typename TOp>
+                struct SyncBlockThreadsPredicate<
+                    TOp,
+                    BlockSyncNoOp>
+                {
+                    //-----------------------------------------------------------------------------
+                    //
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                        block::sync::BlockSyncNoOp const & /*blockSync*/,
+                        int predicate)
+                    -> int
+                    {
+                        //boost::ignore_unused(blockSync);
+                        return predicate;
+                    }
+                };
             }
         }
     }

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -51,6 +51,15 @@ namespace alpaka
                     typename TBlockSync,
                     typename TSfinae = void>
                 struct SyncBlockThreads;
+
+                //#############################################################################
+                //! The block synchronization and predicate operation trait.
+                //#############################################################################
+                template<
+                    typename TOp,
+                    typename TBlockSync,
+                    typename TSfinae = void>
+                struct SyncBlockThreadsPredicate;
             }
 
             //-----------------------------------------------------------------------------
@@ -99,6 +108,132 @@ namespace alpaka
                         // Delegate the call to the base class.
                         block::sync::syncBlockThreads(
                             static_cast<typename TBlockSync::BlockSyncBase const &>(blockSync));
+                    }
+                };
+            }
+
+            //-----------------------------------------------------------------------------
+            //! Defines operation functors.
+            //-----------------------------------------------------------------------------
+            namespace op
+            {
+                //#############################################################################
+                //! The addition function object.
+                //#############################################################################
+                struct Count
+                {
+                    enum { InitialValue = 0u};
+
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    template<
+                        typename T>
+                    ALPAKA_FN_HOST_ACC auto operator()(
+                        T const & currentResult,
+                        T const & value) const
+                    -> T
+                    {
+                        return currentResult + static_cast<T>(value != static_cast<T>(0));
+                    }
+                };
+                //#############################################################################
+                //! The logical and function object.
+                //#############################################################################
+                struct LogicalAnd
+                {
+                    enum { InitialValue = 1u};
+
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    template<
+                        typename T>
+                    ALPAKA_FN_HOST_ACC auto operator()(
+                        T const & currentResult,
+                        T const & value) const
+                    -> T
+                    {
+                        return static_cast<T>(currentResult && (value != static_cast<T>(0)));
+                    }
+                };
+                //#############################################################################
+                //! The logical or function object.
+                //#############################################################################
+                struct LogicalOr
+                {
+                    enum { InitialValue = 0u};
+
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    template<
+                        typename T>
+                    ALPAKA_FN_HOST_ACC auto operator()(
+                        T const & currentResult,
+                        T const & value) const
+                    -> T
+                    {
+                        return static_cast<T>(currentResult || (value != static_cast<T>(0)));
+                    }
+                };
+            }
+
+            //-----------------------------------------------------------------------------
+            //! Synchronizes all threads within the current block (independently for all blocks),
+            //! evaluates the predicate for all threads and returns the combination of all the results
+            //! computed via TOp.
+            //!
+            //! \tparam TOp The operation used to combine the predicate values of all threads.
+            //! \tparam TBlockSync The block synchronization implementation type.
+            //! \param blockSync The block synchronization implementation.
+            //! \param predicate The predicate value of the current thread.
+            //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
+            template<
+                typename TOp,
+                typename TBlockSync>
+            ALPAKA_FN_ACC auto syncBlockThreadsPredicate(
+                TBlockSync const & blockSync,
+                int predicate)
+            -> int
+            {
+                return
+                    traits::SyncBlockThreadsPredicate<
+                        TOp,
+                        TBlockSync>
+                    ::syncBlockThreadsPredicate(
+                        blockSync,
+                        predicate);
+            }
+
+            namespace traits
+            {
+                //#############################################################################
+                //! The AllocVar trait specialization for classes with BlockSyncBase member type.
+                //#############################################################################
+                template<
+                    typename TOp,
+                    typename TBlockSync>
+                struct SyncBlockThreadsPredicate<
+                    TOp,
+                    TBlockSync,
+                    typename std::enable_if<
+                        meta::IsStrictBase<
+                            typename TBlockSync::BlockSyncBase,
+                            TBlockSync
+                        >::value
+                    >::type>
+                {
+                    //-----------------------------------------------------------------------------
+                    //!
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_NO_HOST_ACC_WARNING
+                    ALPAKA_FN_ACC static auto syncBlockThreadsPredicate(
+                        TBlockSync const & blockSync,
+                        int predicate)
+                    -> int
+                    {
+                        // Delegate the call to the base class.
+                        return
+                            block::sync::syncBlockThreadsPredicate<
+                                TOp>(
+                                    static_cast<typename TBlockSync::BlockSyncBase const &>(blockSync),
+                                    predicate);
                     }
                 };
             }

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -1,0 +1,160 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/assert.hpp>                         // BOOST_VERIFY
+#include <boost/predef.h>                           // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
+
+//#############################################################################
+//!
+//#############################################################################
+class BlockSyncPredicateTestKernel
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Size = alpaka::size::Size<TAcc>;
+
+        // Get the index of the current thread within the block and the block extent and map them to 1D.
+        auto const blockThreadIdx(alpaka::idx::getIdx<alpaka::Block, alpaka::Threads>(acc));
+        auto const blockThreadExtent(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc));
+        auto const blockThreadIdx1D(alpaka::idx::mapIdx<1u>(blockThreadIdx, blockThreadExtent)[0u]);
+        auto const blockThreadExtent1D(blockThreadExtent.prod());
+
+        // syncBlockThreadsPredicate<alpaka::block::sync::op::Count>
+        {
+            Size const modulus(2u);
+            int const predicate(blockThreadIdx1D % modulus);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::Count>(acc, predicate));
+            auto const expectedResult(blockThreadExtent1D / modulus);
+            BOOST_VERIFY(expectedResult == static_cast<Size>(result));
+        }
+        {
+            Size const modulus(3u);
+            int const predicate(blockThreadIdx1D % modulus);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::Count>(acc, predicate));
+            auto const expectedResult(blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Size>(1u)) / modulus));
+            BOOST_VERIFY(expectedResult == static_cast<Size>(result));
+        }
+
+        // syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>
+        {
+            int const predicate(1);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
+            BOOST_VERIFY(result == 1);
+        }
+        {
+            int const predicate(0);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
+            BOOST_VERIFY(result == 0);
+        }
+        {
+            int const predicate(blockThreadIdx1D != 0);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
+            BOOST_VERIFY(result == 0);
+        }
+
+        // syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>
+        {
+            int const predicate(1);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
+            BOOST_VERIFY(result == 1);
+        }
+        {
+            int const predicate(0);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
+            BOOST_VERIFY(result == 0);
+        }
+        {
+            int const predicate(blockThreadIdx1D != 1);
+            auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
+            BOOST_VERIFY(result == 1);
+        }
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(blockSync)
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    synchronizePredicate,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    BlockSyncPredicateTestKernel kernel;
+
+    // 4^Dim
+    {
+        alpaka::test::KernelExecutionFixture<TAcc> fixture(
+            alpaka::vec::Vec<Dim, Size>::all(static_cast<Size>(4u)));
+
+        BOOST_REQUIRE_EQUAL(
+            true,
+            fixture(
+                kernel));
+    }
+
+    // 1^Dim
+    {
+        alpaka::test::KernelExecutionFixture<TAcc> fixture(
+            alpaka::vec::Vec<Dim, Size>::ones());
+
+        BOOST_REQUIRE_EQUAL(
+            true,
+            fixture(
+                kernel));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This implements #13.

In the current version, this adds some overhead to some accelerators in form of additional storage for member variables required per block even if the `syncBlockThreadsPredicate` method is never called.

* For `AccCpuFibers`, there are currently 5 additional variables per block which could be reduced to 2 (with some amount of work).
* For `AccCpuThreads`, there are currently 7 additional variables per block.
* For `AccCpuOmpThreads`, there are currently 2 additional int32 and 1 uint8 per block. I do not see a way to optimize this further.
