### PR TITLE
fix mandelbrot file writing

### DIFF
--- a/test/integ/mandelbrot/src/main.cpp
+++ b/test/integ/mandelbrot/src/main.cpp
@@ -327,7 +327,7 @@ auto writeTgaColorImage(
     {
         ofs.write(
             pData,
-            static_cast<std::streamsize>(bufWidthColors*bufHeightColors));
+            static_cast<std::streamsize>(bufWidthBytes*bufHeightColors));
     }
     // ... else we have to write row by row.
     else
@@ -336,7 +336,7 @@ auto writeTgaColorImage(
         {
             ofs.write(
                 pData + bufPitchBytes*row,
-                static_cast<std::streamsize>(bufWidthColors));
+                static_cast<std::streamsize>(bufWidthBytes));
         }
     }
 }


### PR DESCRIPTION
The tga files are not valid because the number of elements in a row is used instead of the correct number of bytes in a row (RGBA has 4 bytes per pixel)