### PR TITLE
fix CUDA_VERSION handling

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -280,6 +280,7 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
             SET(ALPAKA_ACC_GPU_CUDA_ENABLE OFF CACHE BOOL "Enable the CUDA GPU back-end" FORCE)
 
         ELSE()
+            SET(ALPAKA_CUDA_VERSION "${CUDA_VERSION}")
             SET(ALPAKA_CUDA_ARCH sm_20 CACHE STRING "GPU architecture")
             STRING(COMPARE EQUAL "${ALPAKA_CUDA_ARCH}" "sm_10" IS_CUDA_ARCH_UNSUPPORTED)
             STRING(COMPARE EQUAL "${ALPAKA_CUDA_ARCH}" "sm_11" IS_CUDA_ARCH_UNSUPPORTED)
@@ -329,11 +330,11 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
 
                 SET(CUDA_PROPAGATE_HOST_FLAGS ON)
 
-                IF(ALPAKA_CUDA_VERSION VERSION_EQUAL 8.0)
+                IF(CUDA_VERSION VERSION_EQUAL 8.0)
                     LIST(APPEND CUDA_NVCC_FLAGS "-Wno-deprecated-gpu-targets")
                 ENDIF()
 
-                IF(NOT ALPAKA_CUDA_VERSION VERSION_LESS 7.5)
+                IF(NOT CUDA_VERSION VERSION_LESS 7.5)
                     LIST(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
                 ENDIF()
 


### PR DESCRIPTION
Currently, `ALPAKA_CUDA_VERSION` can be specified to select the minimum required CUDA version and defaults to 7.0 if it is not specified. If there is no 7.0 or 7.5 installed, FIND_PACKAGE wil find the 8.0 installation.
However, we used the `ALPAKA_CUDA_VERSION` to add flags to the nvcc command line, which may not be the selected version. Correctly, we have to use `CUDA_VERSION`.