### PR TITLE
fix appveyor curl not available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -169,10 +169,12 @@ before_build:
     #-------------------------------------------------------------------------------
     # Install TBB
     - cmd: set TBB_ARCHIVE_VER=tbb44_20160526oss
+    - cmd: set TBB_DOWNLOAD_URL=https://www.threadingbuildingblocks.org/sites/default/files/software_releases/windows/%TBB_ARCHIVE_VER%_win_0.zip
     - cmd: set TBB_ROOT_DIR=C:\projects\tbb
+    - cmd: set TBB_DST_PATH=%TBB_ROOT_DIR%\tbb.zip
     - cmd: mkdir %TBB_ROOT_DIR%
-    - cmd: curl https://www.threadingbuildingblocks.org/sites/default/files/software_releases/windows/%TBB_ARCHIVE_VER%_win_0.zip > %TBB_ROOT_DIR%\tbb.zip
-    - cmd: 7z x %TBB_ROOT_DIR%\tbb.zip -o%TBB_ROOT_DIR% -y
+    - ps: Invoke-WebRequest $env:TBB_DOWNLOAD_URL -OutFile $env:TBB_DST_PATH
+    - cmd: 7z x %TBB_DST_PATH% -o%TBB_ROOT_DIR% -y
     - cmd: set TBB_ROOT_DIR=%TBB_ROOT_DIR%\%TBB_ARCHIVE_VER%
     - cmd: if "%PLATFORM%"=="Win32" set ALPAKA_TBB_BIN_DIR=%TBB_ROOT_DIR%\bin\ia32\vc14
     - cmd: if "%PLATFORM%"=="x64" set ALPAKA_TBB_BIN_DIR=%TBB_ROOT_DIR%\bin\intel64\vc14


### PR DESCRIPTION
Appveyor does not provide curl in the windows image anymore, so the CI builds are currently failing.
Replacing it with a PowerShell download command fixes it.