### PR TITLE
fix travis CUDA installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -290,7 +290,7 @@ before_install:
                   if [ ${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} == "ON" ]
                   ;then
                       export ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
-                      && echo ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} because nvcc does not support boost correctly!
+                      && echo ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} because nvcc does not support boost fibers correctly!
                   ;fi
               ;fi
           ;fi
@@ -304,7 +304,7 @@ before_install:
               if [ ${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} == "ON" ]
               ;then
                   export ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF
-                  && echo ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} because nvcc does not support boost correctly!
+                  && echo ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE} because clang as native CUDA compiler does not support boost fibers correctly!
               ;fi
           ;fi
       ;fi
@@ -398,6 +398,10 @@ before_install:
           ;fi
       ;fi
 
+    # Set the correct CUDA downloads
+    # NOTE: CUDA < 8.0 did not provide SHA256 in their Release files.
+    # Installing them in modern Ubunut versions is therefore not possible.
+    # We simply add those to the Release files and ignore that they can not be verified during instalation.
     - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
       ;then
           ALPAKA_CUDA_CACHE_DIR=${HOME}/cache/CUDA/CUDA-${ALPAKA_CUDA_VER}
@@ -422,6 +426,23 @@ before_install:
               && travis_retry wget -O ${ALPAKA_CUDA_CACHE_DIR}/${ALPAKA_CUDA_PKG_FILE_NAME} ${ALPAKA_CUDA_PKG_FILE_PATH}
           ;fi
           && sudo dpkg -i ${ALPAKA_CUDA_CACHE_DIR}/${ALPAKA_CUDA_PKG_FILE_NAME}
+          && if [ "${ALPAKA_CUDA_VER}" == "7.0" ]
+          ;then
+              cat /var/cuda-repo-7-0-local/Release
+              && cat /var/cuda-repo-7-0-local/Packages.gz | sha256sum
+              && gunzip -c /var/cuda-repo-7-0-local/Packages.gz | sha256sum
+              && STR=$(printf "SHA256:\n 200fb65a4c5d86b58d3303a2f53fe2a9c85bc71ecb0ad00aab6c8cf8234128b5            63833 Packages\n ffaadac7e13ebd03c9365055b50390c2cc89aaa8e127b69d94f1ad779a52b3b1            19408 Packages.gz")
+              && echo "$STR" | sudo tee -a /var/cuda-repo-7-0-local/Release
+              && cat /var/cuda-repo-7-0-local/Release
+          ;elif [ "${ALPAKA_CUDA_VER}" == "7.5" ]
+          ;then
+              cat /var/cuda-repo-7-5-local/Release
+              && cat /var/cuda-repo-7-5-local/Packages.gz | sha256sum
+              && gunzip -c /var/cuda-repo-7-5-local/Packages.gz | sha256sum
+              && STR=$(printf "SHA256:\n 3aaa653dc0280c8609643ecd3f84a82c84aa9a0508f06e1b32dc4a985018d923            76972 Packages\n da3c0819a5252eeade8219c09d6eac8840af639ccf4e5f8ba319419d897bffce            21992 Packages.gz")
+              && echo "$STR" | sudo tee -a /var/cuda-repo-7-5-local/Release
+              && cat /var/cuda-repo-7-5-local/Release
+          ;fi
       ;fi
 
     #-------------------------------------------------------------------------------
@@ -512,7 +533,7 @@ install:
     # We only install the minimal packages. Because of our manual partial installation we have to create a symlink at /usr/local/cuda
     - if [ "${ALPAKA_ACC_GPU_CUDA_ENABLE}" == "ON" ]
       ;then
-          sudo apt-get -y install cuda-core-${ALPAKA_CUDA_VER} cuda-cudart-${ALPAKA_CUDA_VER} cuda-cudart-dev-${ALPAKA_CUDA_VER} cuda-curand-${ALPAKA_CUDA_VER} cuda-curand-dev-${ALPAKA_CUDA_VER}
+          sudo apt-get -y --allow-unauthenticated install cuda-core-${ALPAKA_CUDA_VER} cuda-cudart-${ALPAKA_CUDA_VER} cuda-cudart-dev-${ALPAKA_CUDA_VER} cuda-curand-${ALPAKA_CUDA_VER} cuda-curand-dev-${ALPAKA_CUDA_VER}
           && sudo ln -s /usr/local/cuda-${ALPAKA_CUDA_VER} /usr/local/cuda
           && export PATH=/usr/local/cuda-${ALPAKA_CUDA_VER}/bin:$PATH
           && export LD_LIBRARY_PATH=/usr/local/cuda-${ALPAKA_CUDA_VER}/lib64:$LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -431,7 +431,7 @@ before_install:
               cat /var/cuda-repo-7-0-local/Release
               && cat /var/cuda-repo-7-0-local/Packages.gz | sha256sum
               && gunzip -c /var/cuda-repo-7-0-local/Packages.gz | sha256sum
-              && STR=$(printf "SHA256:\n 200fb65a4c5d86b58d3303a2f53fe2a9c85bc71ecb0ad00aab6c8cf8234128b5            63833 Packages\n ffaadac7e13ebd03c9365055b50390c2cc89aaa8e127b69d94f1ad779a52b3b1            19408 Packages.gz")
+              && STR="SHA256:"
               && echo "$STR" | sudo tee -a /var/cuda-repo-7-0-local/Release
               && cat /var/cuda-repo-7-0-local/Release
           ;elif [ "${ALPAKA_CUDA_VER}" == "7.5" ]
@@ -439,7 +439,7 @@ before_install:
               cat /var/cuda-repo-7-5-local/Release
               && cat /var/cuda-repo-7-5-local/Packages.gz | sha256sum
               && gunzip -c /var/cuda-repo-7-5-local/Packages.gz | sha256sum
-              && STR=$(printf "SHA256:\n 3aaa653dc0280c8609643ecd3f84a82c84aa9a0508f06e1b32dc4a985018d923            76972 Packages\n da3c0819a5252eeade8219c09d6eac8840af639ccf4e5f8ba319419d897bffce            21992 Packages.gz")
+              && STR="SHA256:"
               && echo "$STR" | sudo tee -a /var/cuda-repo-7-5-local/Release
               && cat /var/cuda-repo-7-5-local/Release
           ;fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -202,7 +202,8 @@ before_build:
 
 build:
     project: C:\projects\alpaka\build\alpakaAll.sln
-    parallel: true
+    # Setting parallel to true sporadically leads to "fatal error C1060: compiler is out of heap space"
+    parallel: false
     # quiet|minimal|normal|detailed
     verbosity: minimal
 


### PR DESCRIPTION
This fixes the CI that is currently broken. See #352.

Travis CI updated their Ubuntu images.
With the updates, old packages [only providing SHA1](https://wiki.debian.org/Teams/Apt/Sha1Removal) are broken and can not be installed.
```E: Failed to fetch file:/var/cuda-repo-7-5-local/Release  No Hash entry in Release file /var/lib/apt/lists/partial/_var_cuda-repo-7-5-local_Release which is considered strong enough for security purposes```

Both, CUDA 7.0 and 7.5 packages are therefore broken.
By adding the SHA256 manually before installing and ignoring that they can not be verified, the installation is successfull again (see [this stackexchange question](https://askubuntu.com/questions/760242/how-can-i-force-16-04-to-add-a-repository-even-if-it-isnt-considered-secure-eno)).
```E: There were unauthenticated packages and -y was used without --allow-unauthenticated```
