### PR TITLE
enhance CUDA error handling

### DIFF
--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -161,7 +161,7 @@ namespace alpaka
 
         //-----------------------------------------------------------------------------
         //! Resets the device.
-        //! What this method does is dependent of the accelerator.
+        //! What this method does is dependent on the accelerator.
         //-----------------------------------------------------------------------------
         template<
             typename TDev>

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -251,21 +251,12 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Query is allowed even for events on non current device.
-                    auto const ret(
-                        cudaEventQuery(
-                            event.m_spEventCudaImpl->m_CudaEvent));
-                    if(ret == cudaSuccess)
-                    {
-                        return true;
-                    }
-                    else if(ret == cudaErrorNotReady)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        throw std::runtime_error(("Unexpected return value '" + std::string(cudaGetErrorString(ret)) + "'from cudaEventQuery!"));
-                    }
+                    cudaError_t ret = cudaSuccess;
+                    ALPAKA_CUDA_RT_CHECK_IGNORE(
+                        ret = cudaEventQuery(
+                            event.m_spEventCudaImpl->m_CudaEvent),
+                        cudaErrorNotReady);
+                    return (ret == cudaSuccess);
                 }
             };
         }

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -286,7 +286,7 @@ namespace alpaka
         namespace traits
         {
             //#############################################################################
-            //! The CUDA async device stream 1D copy enqueue trait specialization.
+            //! The CUDA asynchronous kernel enqueue trait specialization.
             //#############################################################################
             template<
                 typename TDim,
@@ -418,19 +418,13 @@ namespace alpaka
                     // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom error message.
                     cudaStreamSynchronize(
                         stream.m_spStreamCudaRtAsyncImpl->m_CudaStream);
-                    cudaError_t const error(cudaGetLastError());
-                    if(error != cudaSuccess)
-                    {
-                        std::string const sError("The execution of kernel '" + std::string(typeid(TKernelFnObj).name()) + "' failed with error: '" + std::string(cudaGetErrorString(error)) + "'");
-                        std::cerr << sError << std::endl;
-                        ALPAKA_DEBUG_BREAK;
-                        throw std::runtime_error(sError);
-                    }
+                    std::string const kernelName("'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
+                    ::alpaka::cuda::detail::cudaRtCheckLastError(kernelName.c_str(), __FILE__, __LINE__);
 #endif
                 }
             };
             //#############################################################################
-            //! The CUDA sync device stream 1D copy enqueue trait specialization.
+            //! The CUDA synchronous kernel enqueue trait specialization.
             //#############################################################################
             template<
                 typename TDim,
@@ -559,14 +553,8 @@ namespace alpaka
                     cudaStreamSynchronize(
                         stream.m_spStreamCudaRtSyncImpl->m_CudaStream);
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                    cudaError_t const error(cudaGetLastError());
-                    if(error != cudaSuccess)
-                    {
-                        std::string const sError("The execution of kernel '" + std::string(typeid(TKernelFnObj).name()) + "' failed with error: '" + std::string(cudaGetErrorString(error)) + "'");
-                        std::cerr << sError << std::endl;
-                        ALPAKA_DEBUG_BREAK;
-                        throw std::runtime_error(sError);
-                    }
+                    std::string const kernelName("'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
+                    ::alpaka::cuda::detail::cudaRtCheckLastError(kernelName.c_str(), __FILE__, __LINE__);
 #endif
                 }
             };

--- a/include/alpaka/stream/StreamCudaRtAsync.hpp
+++ b/include/alpaka/stream/StreamCudaRtAsync.hpp
@@ -254,21 +254,12 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Query is allowed even for streams on non current device.
-                    auto const ret(
-                        cudaStreamQuery(
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
-                    if(ret == cudaSuccess)
-                    {
-                        return true;
-                    }
-                    else if(ret == cudaErrorNotReady)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        throw std::runtime_error(("Unexpected return value '" + std::string(cudaGetErrorString(ret)) + "' from cudaStreamQuery!"));
-                    }
+                    cudaError_t ret = cudaSuccess;
+                    ALPAKA_CUDA_RT_CHECK_IGNORE(
+                        ret = cudaStreamQuery(
+                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream),
+                        cudaErrorNotReady);
+                    return (ret == cudaSuccess);
                 }
             };
         }

--- a/include/alpaka/stream/StreamCudaRtSync.hpp
+++ b/include/alpaka/stream/StreamCudaRtSync.hpp
@@ -254,21 +254,12 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     // Query is allowed even for streams on non current device.
-                    auto const ret(
-                        cudaStreamQuery(
-                            stream.m_spStreamCudaRtSyncImpl->m_CudaStream));
-                    if(ret == cudaSuccess)
-                    {
-                        return true;
-                    }
-                    else if(ret == cudaErrorNotReady)
-                    {
-                        return false;
-                    }
-                    else
-                    {
-                        throw std::runtime_error(("Unexpected return value '" + std::string(cudaGetErrorString(ret)) + "' from cudaStreamQuery!"));
-                    }
+                    cudaError_t ret = cudaSuccess;
+                    ALPAKA_CUDA_RT_CHECK_IGNORE(
+                        ret = cudaStreamQuery(
+                            stream.m_spStreamCudaRtSyncImpl->m_CudaStream),
+                        cudaErrorNotReady);
+                    return (ret == cudaSuccess);
                 }
             };
         }


### PR DESCRIPTION
* unify the error message generation within `cudaRtCheckLastError` and `cudaRtCheckIgnore` by factoring out the `cudaRtCheck` function
* replaces manual error checking after kernel execution (only done when `ALPAKA_DEBUG  >= ALPAKA_DEBUG_MINIMAL`) with `cudaRtCheckLastError` leading to consistent error messages
* replaces manual error checking around `cudaEventQuery`and `cudaStreamQuery` with the corresponding macros leading to consistent error messages