### PR TITLE
make Common.hpp include comments more general

### DIFF
--- a/include/alpaka/acc/AccDevProps.hpp
+++ b/include/alpaka/acc/AccDevProps.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <alpaka/vec/Vec.hpp>       // Vec
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 #include <vector>                   // std::vector
 #include <string>                   // std::string

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>                   // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>                   // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/acc/Traits.hpp
+++ b/include/alpaka/acc/Traits.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <alpaka/acc/AccDevProps.hpp>   // AccDevProps
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <string>                       // std::string
 #include <typeinfo>                     // typeid

--- a/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/atomic/Traits.hpp
+++ b/include/alpaka/atomic/Traits.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
 #include <alpaka/core/Positioning.hpp>
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/core/Vectorize.hpp>            // defaultAlignment
 #include <alpaka/block/shared/dyn/Traits.hpp>   // AllocVar
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*
 
 #include <boost/align.hpp>                      // boost::aligned_alloc
 

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/block/shared/dyn/Traits.hpp
+++ b/include/alpaka/block/shared/dyn/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/core/Vectorize.hpp>        // defaultAlignment
 #include <alpaka/block/shared/st/Traits.hpp>// AllocVar
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <boost/align.hpp>                  // boost::aligned_alloc
 

--- a/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/core/Vectorize.hpp>        // defaultAlignment
 #include <alpaka/block/shared/st/Traits.hpp>// AllocVar
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <boost/align.hpp>                  // boost::aligned_alloc
 

--- a/include/alpaka/block/shared/st/Traits.hpp
+++ b/include/alpaka/block/shared/st/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/core/Fibers.hpp>       // boost::fibers::barrier
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <mutex>                        // std::mutex
 #include <map>                          // std::map

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/block/sync/Traits.hpp> // SyncBlockThreads
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/core/BarrierThread.hpp>// BarrierThread
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <thread>                       // std::thread
 #include <mutex>                        // std::mutex

--- a/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/block/sync/Traits.hpp> // SyncBlockThreads
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/block/sync/Traits.hpp
+++ b/include/alpaka/block/sync/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -24,7 +24,7 @@
 // Uncomment this to disable the standard spinlock behaviour of the threads
 //#define ALPAKA_THREAD_BARRIER_DISABLE_SPINLOCK
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_NO_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 #include <alpaka/block/sync/Traits.hpp> // block::sync::op::LogicalOr, LogicalAnd, Count
 
 #include <mutex>                        // std::mutex

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/core/OpenMp.hpp
+++ b/include/alpaka/core/OpenMp.hpp
@@ -23,7 +23,7 @@
 
 #ifdef _OPENMP
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 #include <omp.h>
 

--- a/include/alpaka/core/Unroll.hpp
+++ b/include/alpaka/core/Unroll.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 //-----------------------------------------------------------------------------
 //! Suggests unrolling of the directly following loop to the compiler.

--- a/include/alpaka/core/Vectorize.hpp
+++ b/include/alpaka/core/Vectorize.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 #include <cstddef>                  // std::size_t
 #include <cstdint>                  // std::int32_t, ...

--- a/include/alpaka/dev/DevCudaRt.hpp
+++ b/include/alpaka/dev/DevCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/dev/Traits.hpp
+++ b/include/alpaka/dev/Traits.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/event/Traits.hpp
+++ b/include/alpaka/event/Traits.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 #include <alpaka/dev/Traits.hpp>    // dev::getDev
 

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/exec/Traits.hpp
+++ b/include/alpaka/exec/Traits.hpp
@@ -29,7 +29,7 @@
     #include <alpaka/workdiv/Traits.hpp>    // workdiv::getWorkDiv
 #endif
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <type_traits>                      // std::decay
 

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <alpaka/meta/IntegerSequence.hpp>  // IntegerSequence
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 #include <alpaka/meta/Fold.hpp>             // meta::foldr
 #include <alpaka/size/Traits.hpp>           // size::Size
 #include <alpaka/dim/DimIntegralConst.hpp>  // dim::DimInt

--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <alpaka/vec/Vec.hpp>               // Vec
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #if !BOOST_ARCH_CUDA_DEVICE
     #include <boost/core/ignore_unused.hpp> // boost::ignore_unused

--- a/include/alpaka/idx/Traits.hpp
+++ b/include/alpaka/idx/Traits.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/meta/IsStrictBase.hpp>     // meta::IsStrictBase
 
 #include <alpaka/core/Positioning.hpp>      // origin::Grid/Blocks, unit::Blocks, unit::Threads
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <alpaka/vec/Vec.hpp>               // Vec<N>
 

--- a/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -22,7 +22,7 @@
 #pragma once
 
 #include <alpaka/vec/Vec.hpp>               // Vec
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <boost/predef.h>                   // BOOST_COMP_CLANG
 #if !BOOST_ARCH_CUDA_DEVICE

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/abs/Traits.hpp
+++ b/include/alpaka/math/abs/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/acos/Traits.hpp
+++ b/include/alpaka/math/acos/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/asin/Traits.hpp
+++ b/include/alpaka/math/asin/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/atan/Traits.hpp
+++ b/include/alpaka/math/atan/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/atan2/Traits.hpp
+++ b/include/alpaka/math/atan2/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/cbrt/Traits.hpp
+++ b/include/alpaka/math/cbrt/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/ceil/Traits.hpp
+++ b/include/alpaka/math/ceil/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/cos/Traits.hpp
+++ b/include/alpaka/math/cos/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/erf/Traits.hpp
+++ b/include/alpaka/math/erf/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/exp/Traits.hpp
+++ b/include/alpaka/math/exp/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/floor/Traits.hpp
+++ b/include/alpaka/math/floor/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/fmod/Traits.hpp
+++ b/include/alpaka/math/fmod/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/log/Traits.hpp
+++ b/include/alpaka/math/log/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/max/Traits.hpp
+++ b/include/alpaka/math/max/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/min/Traits.hpp
+++ b/include/alpaka/math/min/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/pow/Traits.hpp
+++ b/include/alpaka/math/pow/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/remainder/Traits.hpp
+++ b/include/alpaka/math/remainder/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/round/Traits.hpp
+++ b/include/alpaka/math/round/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/rsqrt/Traits.hpp
+++ b/include/alpaka/math/rsqrt/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/sin/Traits.hpp
+++ b/include/alpaka/math/sin/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/sqrt/Traits.hpp
+++ b/include/alpaka/math/sqrt/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/math/tan/Traits.hpp
+++ b/include/alpaka/math/tan/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/trunc/Traits.hpp
+++ b/include/alpaka/math/trunc/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/mem/alloc/Traits.hpp>  // mem::alloc::Alloc, mem::alloc::Free
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/align.hpp>              // boost::aligned_alloc
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused

--- a/include/alpaka/mem/alloc/AllocCpuNew.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuNew.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/mem/alloc/Traits.hpp>  // mem::alloc::Alloc, mem::alloc::Free
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/mem/alloc/Traits.hpp
+++ b/include/alpaka/mem/alloc/Traits.hpp
@@ -25,7 +25,7 @@
 #include <alpaka/dim/Traits.hpp>        // dim::DimType
 #include <alpaka/extent/Traits.hpp>     // extent::GetExtent
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 namespace alpaka
 {

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/mem/view/Traits.hpp>   // base concept
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -30,7 +30,7 @@
 
 #include <alpaka/vec/Vec.hpp>           // Vec
 #include <alpaka/meta/Fold.hpp>         // meta::foldr
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused

--- a/include/alpaka/mem/view/ViewStdContainers.hpp
+++ b/include/alpaka/mem/view/ViewStdContainers.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/dev/DevCpu.hpp>        // dev::DevCpu
 #include <alpaka/mem/buf/Traits.hpp>    // dev::traits::DevType, DimType, GetExtent,Copy, GetOffset, ...
 #include <alpaka/pltf/PltfCpu.hpp>      // pltf::getDevByIndex
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 #include <boost/predef.h>               // workarounds

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -30,7 +30,7 @@
 
 #include <alpaka/mem/view/ViewPlainPtr.hpp>         // ViewPlainPtr
 #include <alpaka/vec/Vec.hpp>                       // Vec
-#include <alpaka/core/Common.hpp>                   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>                   // ALPAKA_FN_*
 
 #include <type_traits>                              // std::conditional, ...
 

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <alpaka/meta/IntegerSequence.hpp>
 

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/meta/ForEachType.hpp
+++ b/include/alpaka/meta/ForEachType.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/predef.h>               // Workarounds.
 #if !BOOST_ARCH_CUDA_DEVICE

--- a/include/alpaka/meta/IntegerSequence.hpp
+++ b/include/alpaka/meta/IntegerSequence.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 #include <alpaka/meta/Set.hpp>      // core::IsSet
 
 #include <boost/predef.h>           // workarounds

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/vec/Vec.hpp>               // Vec
 #include <alpaka/dim/Traits.hpp>            // Dim
 #include <alpaka/meta/IntegerSequence.hpp>  // meta::IndexSequence
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #if !BOOST_ARCH_CUDA_DEVICE
     #include <boost/core/ignore_unused.hpp> // boost::ignore_unused

--- a/include/alpaka/offset/Traits.hpp
+++ b/include/alpaka/offset/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/dim/DimIntegralConst.hpp>  // dim::DimInt
 #include <alpaka/size/Traits.hpp>           // Size
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <type_traits>                      // std::enable_if
 

--- a/include/alpaka/pltf/PltfCudaRt.hpp
+++ b/include/alpaka/pltf/PltfCudaRt.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/pltf/Traits.hpp
+++ b/include/alpaka/pltf/Traits.hpp
@@ -20,7 +20,7 @@
 */
 
 #pragma once
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 #include <alpaka/dev/Traits.hpp>    // dev::Dev
 
 #include <boost/config.hpp>         // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION

--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/rand/RandStl.hpp
+++ b/include/alpaka/rand/RandStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/rand/Traits.hpp>       // CreateNormalReal, ...
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/rand/Traits.hpp
+++ b/include/alpaka/rand/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/stream/StreamCudaRtAsync.hpp
+++ b/include/alpaka/stream/StreamCudaRtAsync.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/stream/StreamCudaRtSync.hpp
+++ b/include/alpaka/stream/StreamCudaRtSync.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/stream/Traits.hpp
+++ b/include/alpaka/stream/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/wait/Traits.hpp>   // CurrentThreadWaitFor, WaiterWaitFor
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 #include <type_traits>              // std::decay
 #include <utility>                  // std::forward

--- a/include/alpaka/time/TimeCudaBuiltIn.hpp
+++ b/include/alpaka/time/TimeCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/time/Traits.hpp>       // time::Clock
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/time/TimeStl.hpp
+++ b/include/alpaka/time/TimeStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/time/Traits.hpp>       // time::Clock
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_ACC_CUDA_ONLY
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/core/ignore_unused.hpp> // boost::ignore_unused
 

--- a/include/alpaka/time/Traits.hpp
+++ b/include/alpaka/time/Traits.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/meta/IsStrictBase.hpp> // meta::IsStrictBase
 
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <type_traits>                  // std::enable_if
 

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -32,7 +32,7 @@
 #include <alpaka/meta/Fold.hpp>             // meta::foldr
 #include <alpaka/core/Align.hpp>            // ALPAKA_OPTIMAL_ALIGNMENT_SIZE
 #include <alpaka/core/Assert.hpp>           // assertValueUnsigned
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*
 
 #include <boost/predef.h>                   // workarounds
 #include <boost/config.hpp>                 // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION

--- a/include/alpaka/wait/Traits.hpp
+++ b/include/alpaka/wait/Traits.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <alpaka/core/Common.hpp>   // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>   // ALPAKA_FN_*
 
 namespace alpaka
 {

--- a/include/alpaka/workdiv/Traits.hpp
+++ b/include/alpaka/workdiv/Traits.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/vec/Vec.hpp>           // Vec<N>
 #include <alpaka/core/Positioning.hpp>  // origin::Grid/Blocks, unit::Blocks, unit::Threads
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST_ACC
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <boost/config.hpp>             // BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
 

--- a/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
@@ -23,7 +23,7 @@
 
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
-#include <alpaka/core/Common.hpp>           // ALPAKA_FN_ACC_CUDA_ONLY, BOOST_LANG_CUDA
+#include <alpaka/core/Common.hpp>           // ALPAKA_FN_*, BOOST_LANG_CUDA
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -29,7 +29,7 @@
 #include <alpaka/vec/Vec.hpp>                   // Vec
 
 #include <alpaka/core/Assert.hpp>               // assertValueUnsigned
-#include <alpaka/core/Common.hpp>               // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>               // ALPAKA_FN_*
 
 #include <cassert>                              // assert
 #include <cmath>                                // std::ceil

--- a/include/alpaka/workdiv/WorkDivMembers.hpp
+++ b/include/alpaka/workdiv/WorkDivMembers.hpp
@@ -25,7 +25,7 @@
 #include <alpaka/size/Traits.hpp>       // size::Size
 
 #include <alpaka/vec/Vec.hpp>           // Vec
-#include <alpaka/core/Common.hpp>       // ALPAKA_FN_HOST
+#include <alpaka/core/Common.hpp>       // ALPAKA_FN_*
 
 #include <iosfwd>                       // std::ostream
 


### PR DESCRIPTION
The comments aout why the `<alpaka/core/Common.hpp>` header is included are not correct in many cases. Most of the time all the different versions of the `ALPAKA_FN_*` macros are used. Therefore, this changes all such comments to a more generic version.
This should reduce the necessary changes and the chance for comments getting out of sync in future changes (e.g. clang 4.0 support).