### PR TITLE
support clang 4.0 - native CUDA still not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ compiler:
 # CXX                                           : {g++, clang++}
 #   [g++] ALPAKA_GCC_VER                        : {4.9, 5, 6, 7}
 #   [clang++] ALPAKA_CLANG_LIBSTDCPP_VERSION    : {5}
-#   [clang++] ALPAKA_CLANG_VER                  : {3.5.2, 3.6.2, 3.7.1, 3.8.1, 3.9.0}
+#   [clang++] ALPAKA_CLANG_VER                  : {3.5.2, 3.6.2, 3.7.1, 3.8.1, 3.9.0, 4.0.0}
 # CMAKE_BUILD_TYPE                              : {Debug, Release}
 # ALPAKA_CI                                     : {ON}
 # ALPAKA_CI_BOOST_BRANCH                        : {boost-1.62.0, boost-1.63.0, boost-1.64.0}
@@ -86,14 +86,14 @@ env:
 
     matrix:
         # Analysis builds
-        - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.9.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.62.0 ALPAKA_CI_CMAKE_VER=3.8.2 ALPAKA_CI_SANITIZERS=                ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=8.0 ALPAKA_CUDA_COMPILER=clang
-        - ALPAKA_GCC_VER=7   ALPAKA_CLANG_VER=3.9.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.64.0 ALPAKA_CI_CMAKE_VER=3.7.2 ALPAKA_CI_SANITIZERS=                ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2
+        - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.9.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.62.0 ALPAKA_CI_CMAKE_VER=3.8.2 ALPAKA_CI_SANITIZERS=                ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=7.5 ALPAKA_CUDA_COMPILER=clang
+        - ALPAKA_GCC_VER=7   ALPAKA_CLANG_VER=4.0.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.64.0 ALPAKA_CI_CMAKE_VER=3.7.2 ALPAKA_CI_SANITIZERS=                ALPAKA_CI_ANALYSIS=ON  ALPAKA_DEBUG=2
 
         # Debug builds
         - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.8.1 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.63.0 ALPAKA_CI_CMAKE_VER=3.8.2 ALPAKA_CI_SANITIZERS=                ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=7.5 ALPAKA_CUDA_COMPILER=clang ALPAKA_ACC_GPU_CUDA_ONLY_MODE=ON ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE=OFF ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE=OFF ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=OFF ALPAKA_ACC_CPU_BT_OMP4_ENABLE=OFF ALPAKA_ACC_CPU_BT_OPENACC2_ENABLE=OFF
         - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.7.1 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.62.0 ALPAKA_CI_CMAKE_VER=3.7.2 ALPAKA_CI_SANITIZERS=TSan+UBSan+ESan OMP_NUM_THREADS=3 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=8.0 ALPAKA_CUDA_COMPILER=nvcc
         - ALPAKA_GCC_VER=5   ALPAKA_CLANG_VER=3.8.1 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.64.0 ALPAKA_CI_CMAKE_VER=3.8.2 ALPAKA_CI_SANITIZERS=ASan+UBSan+ESan OMP_NUM_THREADS=2 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=8.0 ALPAKA_CUDA_COMPILER=nvcc
-        - ALPAKA_GCC_VER=6   ALPAKA_CLANG_VER=3.9.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.63.0 ALPAKA_CI_CMAKE_VER=3.7.2 ALPAKA_CI_SANITIZERS=TSan+UBSan+ESan OMP_NUM_THREADS=4
+        - ALPAKA_GCC_VER=6   ALPAKA_CLANG_VER=4.0.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.63.0 ALPAKA_CI_CMAKE_VER=3.7.2 ALPAKA_CI_SANITIZERS=TSan+UBSan+ESan OMP_NUM_THREADS=4
 
         # Release builds
         - ALPAKA_GCC_VER=4.9 ALPAKA_CLANG_VER=3.9.0 CMAKE_BUILD_TYPE=Release ALPAKA_CI_BOOST_BRANCH=boost-1.64.0 ALPAKA_CI_CMAKE_VER=3.8.2 ALPAKA_CI_SANITIZERS=ASan+UBSan+ESan OMP_NUM_THREADS=4 ALPAKA_ACC_GPU_CUDA_ENABLE=ON  ALPAKA_CUDA_VER=7.0 ALPAKA_CUDA_COMPILER=clang
@@ -204,10 +204,13 @@ before_install:
       ;then
           if [ "${ALPAKA_CUDA_COMPILER}" == "clang" ]
           ;then
-              if [ "${ALPAKA_CUDA_VER}" == "8.0" ]
+              if (( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} <= 9 )) ))
               ;then
-                  export ALPAKA_CUDA_VER=7.5
-                  && echo ALPAKA_CUDA_VER=${ALPAKA_CUDA_VER} because the clang version does not support CUDA 8.0!
+                  if [ "${ALPAKA_CUDA_VER}" == "8.0" ]
+                  ;then
+                      echo clang ${ALPAKA_CLANG_VER} used as CUDA compiler does not support CUDA 8.0!
+                      && exit 1
+                  ;fi
               ;fi
           ;fi
       ;fi
@@ -349,7 +352,7 @@ before_install:
       ;fi
 
     # clang versions lower than 3.7 do not support OpenMP 2.0.
-    # clang versions lower than 4.0 do not support OpenMP 4.0.
+    # clang versions lower than 5.0 do not support OpenMP 4.0.
     - if [ "${CXX}" == "clang++" ]
       ;then
           if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 3 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 3 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 7 )) ) ))
@@ -365,7 +368,7 @@ before_install:
                   && echo ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE} because the clang version does not support it!
               ;fi
           ;fi
-          && if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 4 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 4 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 0 )) ) ))
+          && if (( (( ${ALPAKA_CLANG_VER_MAJOR} < 5 )) || ( (( ${ALPAKA_CLANG_VER_MAJOR} == 5 )) && (( ${ALPAKA_CLANG_VER_MINOR} < 0 )) ) ))
           ;then
               if [ "${ALPAKA_ACC_CPU_BT_OMP4_ENABLE}" == "ON" ]
               ;then

--- a/README.md
+++ b/README.md
@@ -63,16 +63,16 @@ Supported Compilers
 
 This library uses C++11 (or newer when available).
 
-|Accelerator Back-end|gcc 4.9.2|gcc 5.4|gcc 6.3/7.1|clang 3.5/3.6|clang 3.7|clang 3.8|clang 3.9|MSVC 2015.3/2017|
-|---|---|---|---|---|---|---|---|---|
-|Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 2.0+ threads|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|:x:|:x:|
-| std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-| Boost.Fiber |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|TBB 2.2+|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|CUDA 7.0+|:white_check_mark: (nvcc 7.0+)|:white_check_mark: (nvcc 8.0+)|:x:|:x:|:x:|:white_check_mark: (native/nvcc 8.0+)|:white_check_mark: (native)|:x:|
+|Accelerator Back-end|gcc 4.9.2|gcc 5.4|gcc 6.2/7.1|clang 3.5/3.6|clang 3.7|clang 3.8|clang 3.9|clang 4.0|MSVC 2015.3/2017|
+|---|---|---|---|---|---|---|---|---|---|
+|Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|OpenMP 2.0+ threads|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|:x:|:x:|:x:|
+| std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+| Boost.Fiber |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|TBB 2.2+|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+|CUDA 7.0+|:white_check_mark: (nvcc 7.0+)|:white_check_mark: (nvcc 8.0+)|:x:|:x:|:x:|:white_check_mark: (native/nvcc 8.0+)|:white_check_mark: (native)|:x:|:x:|
 
 
 Dependencies

--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2014-2015 Erik Zenker
+ * Copyright 2014-2017 Erik Zenker, Benjamin Worpitz
  *
  * This file is part of alpaka.
  *
@@ -50,7 +50,8 @@ struct PrintBufferKernel
 
         for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
         {
-            std::cout << buffer[i] << " ";
+            // NOTE: hard-coded for unsigned int
+            printf("%u ", buffer[i]);
         }
     }
 };

--- a/include/alpaka/acc/AccDevProps.hpp
+++ b/include/alpaka/acc/AccDevProps.hpp
@@ -46,7 +46,6 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! Default-constructor
             //-----------------------------------------------------------------------------
-            ALPAKA_NO_HOST_ACC_WARNING
             ALPAKA_FN_HOST AccDevProps(
                 TSize const & multiProcessorCount,
                 vec::Vec<TDim, TSize> const & gridBlockExtentMax,

--- a/include/alpaka/exec/ExecCpuFibers.hpp
+++ b/include/alpaka/exec/ExecCpuFibers.hpp
@@ -258,9 +258,15 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST static auto blockThreadExecHost(
                 acc::AccCpuFibers<TDim, TSize> & acc,
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
                 std::vector<boost::fibers::future<void>> & futuresInBlock,
                 vec::Vec<TDim, TSize> const & blockThreadIdx,
                 FiberPool & fiberPool,
+#else
+                std::vector<boost::fibers::future<void>> &,
+                vec::Vec<TDim, TSize> const & blockThreadIdx,
+                FiberPool &,
+#endif
                 TKernelFnObj const & kernelFnObj,
                 TArgs const & ... args)
             -> void
@@ -282,6 +288,8 @@ namespace alpaka
                 futuresInBlock.emplace_back(
                     fiberPool.enqueueTask(
                         boundBlockThreadExecAcc));
+#else
+                (void)boundBlockThreadExecAcc;
 #endif
             }
             //-----------------------------------------------------------------------------

--- a/include/alpaka/exec/ExecCpuThreads.hpp
+++ b/include/alpaka/exec/ExecCpuThreads.hpp
@@ -283,6 +283,8 @@ namespace alpaka
                 futuresInBlock.emplace_back(
                     threadPool.enqueueTask(
                         boundBlockThreadExecAcc));
+#else
+                (void)boundBlockThreadExecAcc;
 #endif
             }
             //-----------------------------------------------------------------------------

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -466,8 +466,8 @@ namespace alpaka
                     // \FIXME: CUDA currently supports a maximum of 3 dimensions!
                     for(auto i(static_cast<typename TDim::value_type>(0)); i<std::min(static_cast<typename TDim::value_type>(3), TDim::value); ++i)
                     {
-                        reinterpret_cast<unsigned int *>(&gridDim)[i] = gridBlockExtent[TDim::value-1u-i];
-                        reinterpret_cast<unsigned int *>(&blockDim)[i] = blockThreadExtent[TDim::value-1u-i];
+                        reinterpret_cast<unsigned int *>(&gridDim)[i] = static_cast<unsigned int>(gridBlockExtent[TDim::value-1u-i]);
+                        reinterpret_cast<unsigned int *>(&blockDim)[i] = static_cast<unsigned int>(blockThreadExtent[TDim::value-1u-i]);
                     }
                     // Assert that all extent of the higher dimensions are 1!
                     for(auto i(std::min(static_cast<typename TDim::value_type>(3), TDim::value)); i<TDim::value; ++i)

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -581,10 +581,9 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     //!
                     //-----------------------------------------------------------------------------
-                    ALPAKA_NO_HOST_ACC_WARNING
                     template<
                         typename TPitch>
-                    ALPAKA_FN_HOST_ACC static auto create(
+                    ALPAKA_FN_HOST static auto create(
                         TPitch const & pitch)
                     -> size::Size<TPitch>
                     {
@@ -595,10 +594,9 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! \return The pitch vector.
             //-----------------------------------------------------------------------------
-            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TPitch>
-            ALPAKA_FN_HOST_ACC auto getPitchBytesVec(
+            ALPAKA_FN_HOST auto getPitchBytesVec(
                 TPitch const & pitch = TPitch())
             -> vec::Vec<dim::Dim<TPitch>, size::Size<TPitch>>
             {
@@ -612,11 +610,10 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! \return The pitch but only the last N elements.
             //-----------------------------------------------------------------------------
-            ALPAKA_NO_HOST_ACC_WARNING
             template<
                 typename TDim,
                 typename TPitch>
-            ALPAKA_FN_HOST_ACC auto getPitchBytesVecEnd(
+            ALPAKA_FN_HOST auto getPitchBytesVecEnd(
                 TPitch const & pitch = TPitch())
             -> vec::Vec<TDim, size::Size<TPitch>>
             {

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -293,8 +293,7 @@ namespace alpaka
                     mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize>,
                     typename std::enable_if<TIdx::value < TDim::value>::type>
                 {
-                    ALPAKA_NO_HOST_ACC_WARNING
-                    ALPAKA_FN_HOST_ACC static auto getPitchBytes(
+                    ALPAKA_FN_HOST static auto getPitchBytes(
                         mem::view::ViewPlainPtr<TDev, TElem, TDim, TSize> const & view)
                     -> TSize
                     {

--- a/test/common/include/alpaka/test/acc/Acc.hpp
+++ b/test/common/include/alpaka/test/acc/Acc.hpp
@@ -30,7 +30,7 @@
 // When compiling the tests with CUDA enabled (nvcc or native clang) on the CI infrastructure
 // we have to dramatically reduce the number of tested combinations.
 // Else the log length would be exceeded.
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA && ALPAKA_CI
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA && defined(ALPAKA_CI)
     #define ALPAKA_CUDA_CI
 #endif
 

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -178,7 +178,11 @@ namespace alpaka
                             // [py, px, ElemSize] [z, y, x] -> [py*z, px*y, ElemSize*x]
                             auto const dimensionalOffsetsInByte(currentIdxDimx * dstPitchBytes);
                             // sum{[py*z, px*y, ElemSize*x]} -> offset in byte
-                            auto const offsetInByte(dimensionalOffsetsInByte.foldrAll(std::plus<Size>()));
+                            auto const offsetInByte(dimensionalOffsetsInByte.foldrAll(
+                                [](Size a, Size b)
+                                {
+                                    return static_cast<Size>(a + b);
+                                }));
 
                             using Byte = typename MimicConst<std::uint8_t, Elem>::type;
                             Byte* ptr(reinterpret_cast<Byte*>(m_nativePtr) + offsetInByte);


### PR DESCRIPTION
This adds support for clang 4.0 compilation and fixes some warnings as well as some wrong function attributes.
This does still not provide support for compiling CUDA. This is still under investigation.