### PR TITLE
CUDA: Missing Initializer Warning

### DIFF
--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -114,22 +114,9 @@ namespace alpaka
             {
                 if(error != cudaSuccess)
                 {
-                    // Disable the incorrect warning see: http://stackoverflow.com/questions/13905200/is-it-wise-to-ignore-gcc-clangs-wmissing-braces-warning
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wmissing-braces"
-#endif
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
-                    std::array<cudaError_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{std::forward<TErrors>(ignoredErrorCodes)...};
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic pop
-#endif
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic pop
-#endif
+                    // https://stackoverflow.com/questions/18792731/can-we-omit-the-double-braces-for-stdarray-in-c14/18792782#18792782
+                    std::array<cudaError_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{{ignoredErrorCodes...}};
+
                     // If the error code is not one of the ignored ones.
                     if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error) == aIgnoredErrorCodes.cend())
                     {

--- a/include/alpaka/core/Cuda.hpp
+++ b/include/alpaka/core/Cuda.hpp
@@ -119,9 +119,16 @@ namespace alpaka
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wmissing-braces"
 #endif
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
                     std::array<cudaError_t, sizeof...(ignoredErrorCodes)> const aIgnoredErrorCodes{std::forward<TErrors>(ignoredErrorCodes)...};
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic pop
+#endif
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
 #endif
                     // If the error code is not one of the ignored ones.
                     if(std::find(aIgnoredErrorCodes.cbegin(), aIgnoredErrorCodes.cend(), error) == aIgnoredErrorCodes.cend())


### PR DESCRIPTION
The original removed warning was about `-Wmissing-braces` in clang.
I am not sure if it's a good idea to remove `-Wmissing-field-initializers` for this, following this SO post: http://stackoverflow.com/questions/13905200/is-it-wise-to-ignore-gcc-clangs-wmissing-braces-warning

~~Nevertheless, here is a disable for the warning in case you are 100% sure everything is ok at this location.~~ Close #377 

Refactored following this SO posts:
- https://stackoverflow.com/questions/18792731/can-we-omit-the-double-braces-for-stdarray-in-c14/18792782#18792782
- https://stackoverflow.com/questions/28845419/variadic-template-for-forward-list-initialization-of-stdarray/28845794#28845794