### PR TITLE
add unit tests for events and rand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -707,10 +707,13 @@ script:
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/acc/" ./acc ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/atomic/" ./atomic ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/block/shared/" ./blockShared ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/event/" ./event ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/idx/" ./idx ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/kernel/" ./kernel ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/mem/buf/" ./memBuf ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/mem/view/" ./memView ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/meta/" ./meta ;fi
+    - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/rand/" ./rand ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/stream/" ./stream ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/time/" ./time ;fi
     - if [ "${ALPAKA_CI_ANALYSIS}" == "OFF" ] ;then ./travis/compileExec.sh "test/unit/vec/" ./vec ;fi

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ This library uses C++11 (or newer when available).
 |TBB 2.2+|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |CUDA 7.0+|:white_check_mark: (nvcc 7.0+)|:white_check_mark: (nvcc 8.0+)|:x:|:x:|:x:|:white_check_mark: (native/nvcc 8.0+)|:white_check_mark: (native)|:x:|:x:|
 
+*NOTE*: When natively compiling CUDA code with clang-3.8, the random functionality is not available.
+
 
 Dependencies
 ------------

--- a/doc/markdown/user/implementation/mapping/CUDA.md
+++ b/doc/markdown/user/implementation/mapping/CUDA.md
@@ -122,7 +122,7 @@ The following tables list the functions available in the [CUDA Runtime API](http
 
 |CUDA|alpaka|
 |---|---|
-|cudaEventCreate|alpaka::event::Event< TAcc > event(device);|
+|cudaEventCreate|alpaka::event::Event< TStream > event(dev);|
 |cudaEventCreateWithFlags|-|
 |cudaEventDestroy|n/a (Destructor)|
 |cudaEventElapsedTime|-|

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -91,8 +91,8 @@ namespace alpaka
             public block::shared::dyn::BlockSharedMemDynCudaBuiltIn,
             public block::shared::st::BlockSharedMemStCudaBuiltIn,
             public block::sync::BlockSyncCudaBuiltIn,
-// This is not currently supported by the clang native CUDA compiler.
-#if !BOOST_COMP_CLANG_CUDA
+// This is not supported by older clang native CUDA compilers.
+#if !BOOST_COMP_CLANG_CUDA || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(3,9,0))
             public rand::RandCuRand,
 #endif
             public time::TimeCudaBuiltIn
@@ -115,8 +115,8 @@ namespace alpaka
                     block::shared::dyn::BlockSharedMemDynCudaBuiltIn(),
                     block::shared::st::BlockSharedMemStCudaBuiltIn(),
                     block::sync::BlockSyncCudaBuiltIn(),
-// This is not currently supported by the clang native CUDA compiler.
-#if !BOOST_COMP_CLANG_CUDA
+// This is not supported by older clang native CUDA compilers.
+#if !BOOST_COMP_CLANG_CUDA || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(3,9,0))
                     rand::RandCuRand(),
 #endif
                     time::TimeCudaBuiltIn()

--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -29,8 +29,8 @@
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
-// This is not currently supported by the clang native CUDA compiler.
-#if !BOOST_COMP_CLANG_CUDA
+// This is not supported by older clang native CUDA compilers.
+#if !BOOST_COMP_CLANG_CUDA || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(3,9,0))
 
 #include <alpaka/rand/Traits.hpp>       // CreateNormalReal, ...
 
@@ -218,7 +218,7 @@ namespace alpaka
                         double const fUniformRand(curand_uniform_double(&generator.m_State));
                         // NOTE: (1.0f - curand_uniform_double) does not work, because curand_uniform_double seems to return denormalized floats around 0.f.
                         // [0.f, 1.0f)
-                        return fUniformRand * static_cast<double>( fUniformRand != 1.0f );
+                        return fUniformRand * static_cast<double>( fUniformRand != 1.0 );
                     }
                 };
 

--- a/test/common/include/alpaka/test/stream/StreamTestFixture.hpp
+++ b/test/common/include/alpaka/test/stream/StreamTestFixture.hpp
@@ -1,0 +1,56 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <alpaka/alpaka.hpp>
+
+namespace alpaka
+{
+    namespace test
+    {
+        namespace stream
+        {
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<
+                typename TDevStream>
+            struct StreamTestFixture
+            {
+                using Dev = typename std::tuple_element<0, TDevStream>::type;
+                using Stream = typename std::tuple_element<1, TDevStream>::type;
+
+                using Pltf = alpaka::pltf::Pltf<Dev>;
+
+                //-----------------------------------------------------------------------------
+                //!
+                //-----------------------------------------------------------------------------
+                StreamTestFixture() :
+                    m_dev(alpaka::pltf::getDevByIdx<Pltf>(0u)),
+                    m_stream(m_dev)
+                {
+                }
+
+                Dev m_dev;
+                Stream m_stream;
+            };
+        }
+    }
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Benjamin Worpitz
+# Copyright 2015-2017 Benjamin Worpitz
 #
 # This file is part of alpaka.
 #
@@ -34,11 +34,13 @@ ADD_SUBDIRECTORY("acc/")
 ADD_SUBDIRECTORY("atomic/")
 ADD_SUBDIRECTORY("block/shared/")
 ADD_SUBDIRECTORY("block/sync/")
+ADD_SUBDIRECTORY("event/")
 ADD_SUBDIRECTORY("idx/")
 ADD_SUBDIRECTORY("kernel/")
 ADD_SUBDIRECTORY("mem/buf/")
 ADD_SUBDIRECTORY("mem/view/")
 ADD_SUBDIRECTORY("meta/")
+ADD_SUBDIRECTORY("rand/")
 ADD_SUBDIRECTORY("stream/")
 ADD_SUBDIRECTORY("time/")
 ADD_SUBDIRECTORY("vec/")

--- a/test/unit/event/CMakeLists.txt
+++ b/test/unit/event/CMakeLists.txt
@@ -1,0 +1,82 @@
+#
+# Copyright 2017 Benjamin Worpitz
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required CMake version.
+################################################################################
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
+
+SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+################################################################################
+
+SET(_TARGET_NAME "event")
+
+PROJECT(${_TARGET_NAME})
+
+#-------------------------------------------------------------------------------
+# Find alpaka test common.
+#-------------------------------------------------------------------------------
+
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../common/" CACHE STRING  "The location of the alpaka test common library")
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE(common REQUIRED)
+
+#-------------------------------------------------------------------------------
+# Boost.Test.
+#-------------------------------------------------------------------------------
+FIND_PACKAGE(Boost QUIET COMPONENTS unit_test_framework)
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+
+ELSE()
+    IF(NOT Boost_USE_STATIC_LIBS)
+        LIST(APPEND _DEFINITIONS_PRIVATE "-DBOOST_TEST_DYN_LINK")
+    ENDIF()
+ENDIF()
+
+#-------------------------------------------------------------------------------
+# Add executable.
+#-------------------------------------------------------------------------------
+
+SET(_SOURCE_DIR "src/")
+
+# Add all the source files in all recursive subdirectories and group them accordingly.
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "${_SOURCE_DIR}" "cpp" _FILES_SOURCE)
+
+# Always add all files to the target executable build call to add them to the build project.
+ALPAKA_ADD_EXECUTABLE(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+TARGET_COMPILE_OPTIONS(
+    ${_TARGET_NAME}
+    PRIVATE ${_DEFINITIONS_PRIVATE})
+TARGET_LINK_LIBRARIES(
+    ${_TARGET_NAME}
+    PUBLIC common Boost::unit_test_framework)
+
+# Group the targets into subfolders for IDEs supporting this.
+SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+ENABLE_TESTING()
+ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/event/src/main.cpp
+++ b/test/unit/event/src/main.cpp
@@ -1,0 +1,32 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE event
+
+#include <boost/predef.h>   // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif

--- a/test/unit/rand/CMakeLists.txt
+++ b/test/unit/rand/CMakeLists.txt
@@ -1,0 +1,82 @@
+#
+# Copyright 2017 Benjamin Worpitz
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+################################################################################
+# Required CMake version.
+################################################################################
+
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
+
+SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
+
+################################################################################
+# Project.
+################################################################################
+
+SET(_TARGET_NAME "rand")
+
+PROJECT(${_TARGET_NAME})
+
+#-------------------------------------------------------------------------------
+# Find alpaka test common.
+#-------------------------------------------------------------------------------
+
+SET(COMMON_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../common/" CACHE STRING  "The location of the alpaka test common library")
+LIST(APPEND CMAKE_MODULE_PATH "${COMMON_ROOT}")
+FIND_PACKAGE(common REQUIRED)
+
+#-------------------------------------------------------------------------------
+# Boost.Test.
+#-------------------------------------------------------------------------------
+FIND_PACKAGE(Boost QUIET COMPONENTS unit_test_framework)
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_FOUND)
+    MESSAGE(FATAL_ERROR "Required alpaka dependency Boost.Test could not be found!")
+
+ELSE()
+    IF(NOT Boost_USE_STATIC_LIBS)
+        LIST(APPEND _DEFINITIONS_PRIVATE "-DBOOST_TEST_DYN_LINK")
+    ENDIF()
+ENDIF()
+
+#-------------------------------------------------------------------------------
+# Add executable.
+#-------------------------------------------------------------------------------
+
+SET(_SOURCE_DIR "src/")
+
+# Add all the source files in all recursive subdirectories and group them accordingly.
+append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "${_SOURCE_DIR}" "cpp" _FILES_SOURCE)
+
+# Always add all files to the target executable build call to add them to the build project.
+ALPAKA_ADD_EXECUTABLE(
+    ${_TARGET_NAME}
+    ${_FILES_SOURCE})
+TARGET_COMPILE_OPTIONS(
+    ${_TARGET_NAME}
+    PRIVATE ${_DEFINITIONS_PRIVATE})
+TARGET_LINK_LIBRARIES(
+    ${_TARGET_NAME}
+    PUBLIC common Boost::unit_test_framework)
+
+# Group the targets into subfolders for IDEs supporting this.
+SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
+
+ENABLE_TESTING()
+ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -1,0 +1,142 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/assert.hpp>                         // BOOST_VERIFY
+#include <boost/predef.h>                           // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
+
+BOOST_AUTO_TEST_SUITE(rand_)
+
+// This is not supported by older clang native CUDA compilers.
+#if !BOOST_COMP_CLANG_CUDA || (BOOST_COMP_CLANG_CUDA >= BOOST_VERSION_NUMBER(3,9,0))
+
+//#############################################################################
+//!
+//#############################################################################
+class RandTestKernel
+{
+public:
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-variable"
+#endif
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<
+        typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        auto gen(alpaka::rand::generator::createDefault(acc, 12345u, 6789u));
+
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-variable"
+#endif
+        {
+            auto dist(alpaka::rand::distribution::createNormalReal<float>(acc));
+            auto const r = dist(gen);
+#if !BOOST_ARCH_CUDA_DEVICE
+            BOOST_VERIFY(std::isfinite(r));
+#endif
+        }
+
+        {
+            auto dist(alpaka::rand::distribution::createNormalReal<double>(acc));
+            auto const r = dist(gen);
+#if !BOOST_ARCH_CUDA_DEVICE
+            BOOST_VERIFY(std::isfinite(r));
+#endif
+        }
+
+        {
+            auto dist(alpaka::rand::distribution::createUniformReal<float>(acc));
+            auto const r = dist(gen);
+            BOOST_VERIFY(0.0f <= r);
+            BOOST_VERIFY(1.0f > r);
+        }
+
+        {
+            auto dist(alpaka::rand::distribution::createUniformReal<double>(acc));
+            auto const r = dist(gen);
+            BOOST_VERIFY(0.0 <= r);
+            BOOST_VERIFY(1.0 > r);
+        }
+
+        {
+            auto dist(alpaka::rand::distribution::createUniformUint<std::uint32_t>(acc));
+            auto const r = dist(gen);
+        }
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
+    }
+#if BOOST_COMP_GNUC
+    #pragma GCC diagnostic pop
+#endif
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    defaultRandomGeneratorIsWorking,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::vec::Vec<Dim, Size>::ones());
+
+    RandTestKernel kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/rand/src/main.cpp
+++ b/test/unit/rand/src/main.cpp
@@ -1,0 +1,32 @@
+/**
+ * \file
+ * Copyright 2017 Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE rand
+
+#include <boost/predef.h>   // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
This adds unit tests for `event` and `rand` functionality. The `event` unit tests are only basic ones. They will be extended but this requires some more work that will be added in a future Pull Request.
Note: The random functionality is not available when natively compiling CUDA with clang-3.8. It has now been enabled for clang-3.9.
Furthermore, this adds the missing `idx` unit test to the CI.