### PR TITLE
add more tests for events

### DIFF
--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -62,7 +62,7 @@ namespace alpaka
                         dev::DevCpu const & dev) :
                             m_uuid(boost::uuids::random_generator()()),
                             m_dev(dev),
-                            m_Mutex(),
+                            m_mutex(),
                             m_enqueueCount(0u),
                             m_canceledEnqueueCount(0u),
                             m_bIsReady(true),
@@ -101,9 +101,9 @@ namespace alpaka
                     boost::uuids::uuid const m_uuid;                        //!< The unique ID.
                     dev::DevCpu const m_dev;                                //!< The device this event is bound to.
 
-                    std::mutex mutable m_Mutex;                             //!< The mutex used to synchronize access to the event.
+                    std::mutex mutable m_mutex;                             //!< The mutex used to synchronize access to the event.
 
-                    std::condition_variable mutable m_ConditionVariable;    //!< The condition signaling the event completion.
+                    std::condition_variable mutable m_conditionVariable;    //!< The condition signaling the event completion.
                     std::size_t m_enqueueCount;                             //!< The number of times this event has been enqueued.
                     std::size_t m_canceledEnqueueCount;                     //!< The number of successive re-enqueues while it was already in the queue. Reset on completion.
                     bool m_bIsReady;                                        //!< If the event is not waiting within a stream (not enqueued or already completed).
@@ -124,7 +124,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST EventCpu(
                 dev::DevCpu const & dev) :
-                    m_spEventCpuImpl(std::make_shared<cpu::detail::EventCpuImpl>(dev))
+                    m_spEventImpl(std::make_shared<cpu::detail::EventCpuImpl>(dev))
             {}
             //-----------------------------------------------------------------------------
             //! Copy constructor.
@@ -148,7 +148,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(EventCpu const & rhs) const
             -> bool
             {
-                return (m_spEventCpuImpl->m_uuid == rhs.m_spEventCpuImpl->m_uuid);
+                return (m_spEventImpl->m_uuid == rhs.m_spEventImpl->m_uuid);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.
@@ -160,7 +160,7 @@ namespace alpaka
             }
 
         public:
-            std::shared_ptr<cpu::detail::EventCpuImpl> m_spEventCpuImpl;
+            std::shared_ptr<cpu::detail::EventCpuImpl> m_spEventImpl;
         };
     }
 
@@ -182,7 +182,7 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> dev::DevCpu
                 {
-                    return event.m_spEventCpuImpl->m_dev;
+                    return event.m_spEventImpl->m_dev;
                 }
             };
         }
@@ -191,33 +191,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
-            //! The CPU device event event type trait specialization.
-            //#############################################################################
-            template<>
-            struct EventType<
-                event::EventCpu>
-            {
-                using type = event::EventCpu;
-            };
-            //#############################################################################
-            //! The CPU device event create trait specialization.
-            //#############################################################################
-            template<>
-            struct Create<
-                event::EventCpu,
-                dev::DevCpu>
-            {
-                //-----------------------------------------------------------------------------
-                //!
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto create(
-                    dev::DevCpu const & dev)
-                -> event::EventCpu
-                {
-                    return event::EventCpu(dev);
-                }
-            };
             //#############################################################################
             //! The CPU device event test trait specialization.
             //#############################################################################
@@ -232,9 +205,9 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> bool
                 {
-                    std::lock_guard<std::mutex> lk(event.m_spEventCpuImpl->m_Mutex);
+                    std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
 
-                    return event.m_spEventCpuImpl->m_bIsReady;
+                    return event.m_spEventImpl->m_bIsReady;
                 }
             };
         }
@@ -263,21 +236,23 @@ namespace alpaka
                     event::EventCpu & event)
                 -> void
                 {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
                     // Copy the shared pointer of the event implementation.
                     // This is forwarded to the lambda that is enqueued into the stream to ensure that the event implementation is alive as long as it is enqueued.
-                    auto spEventCpuImpl(event.m_spEventCpuImpl);
+                    auto spEventImpl(event.m_spEventImpl);
 
                     // Setting the event state and enqueuing it has to be atomic.
-                    std::lock_guard<std::mutex> lk(spEventCpuImpl->m_Mutex);
+                    std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
                     // This is a invariant: If the event is ready (not enqueued) there can not be anybody waiting for it.
-                    assert(!(spEventCpuImpl->m_bIsReady && spEventCpuImpl->m_bIsWaitedFor));
+                    assert(!(spEventImpl->m_bIsReady && spEventImpl->m_bIsWaitedFor));
 
                     // If it is enqueued ...
-                    if(!spEventCpuImpl->m_bIsReady)
+                    if(!spEventImpl->m_bIsReady)
                     {
                         // ... and somebody is waiting for it, it can NOT be re-enqueued.
-                        if(spEventCpuImpl->m_bIsWaitedFor)
+                        if(spEventImpl->m_bIsWaitedFor)
                         {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                             std::cout << BOOST_CURRENT_FUNCTION << "WARNING: The event to enqueue is already enqueued AND waited on. It can NOT be re-enqueued!" << std::endl;
@@ -287,17 +262,17 @@ namespace alpaka
                         // ... and nobody is waiting for it, increment the cancel counter.
                         else
                         {
-                            ++spEventCpuImpl->m_canceledEnqueueCount;
+                            ++spEventImpl->m_canceledEnqueueCount;
                         }
                     }
                     // If it is not enqueued, set its state to enqueued.
                     else
                     {
-                        spEventCpuImpl->m_bIsReady = false;
+                        spEventImpl->m_bIsReady = false;
                     }
 
                     // Increment the enqueue counter. This is used to skip waits for events that had already been finished and re-enqueued which would lead to deadlocks.
-                    ++spEventCpuImpl->m_enqueueCount;
+                    ++spEventImpl->m_enqueueCount;
 
                     // We can not unlock the mutex here, because the order of events enqueued has to be identical to the call order.
                     // Unlocking here would allow a later enqueue call to complete before this event is enqueued.
@@ -305,23 +280,23 @@ namespace alpaka
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
                     // Enqueue a task that only resets the events flag if it is completed.
                     spStreamImpl->m_workerThread.enqueueTask(
-                        [spEventCpuImpl]()
+                        [spEventImpl]()
                         {
                             {
-                                std::lock_guard<std::mutex> lk2(spEventCpuImpl->m_Mutex);
+                                std::lock_guard<std::mutex> lk2(spEventImpl->m_mutex);
                                 // Nothing to do if it has been re-enqueued to a later position in the queue.
-                                if(spEventCpuImpl->m_canceledEnqueueCount > 0)
+                                if(spEventImpl->m_canceledEnqueueCount > 0)
                                 {
-                                    --spEventCpuImpl->m_canceledEnqueueCount;
+                                    --spEventImpl->m_canceledEnqueueCount;
                                     return;
                                 }
                                 else
                                 {
-                                    spEventCpuImpl->m_bIsWaitedFor = false;
-                                    spEventCpuImpl->m_bIsReady = true;
+                                    spEventImpl->m_bIsWaitedFor = false;
+                                    spEventImpl->m_bIsReady = true;
                                 }
                             }
-                            spEventCpuImpl->m_ConditionVariable.notify_all();
+                            spEventImpl->m_conditionVariable.notify_all();
                         });
 #endif
                 }
@@ -342,6 +317,8 @@ namespace alpaka
                     event::EventCpu & event)
                 -> void
                 {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
                     stream::enqueue(stream.m_spAsyncStreamCpu, event);
                 }
             };
@@ -361,24 +338,26 @@ namespace alpaka
                     event::EventCpu & event)
                 -> void
                 {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
                     boost::ignore_unused(spStreamImpl);
 
                     {
                         // Copy the shared pointer of the event implementation.
                         // This is forwarded to the lambda that is enqueued into the stream to ensure that the event implementation is alive as long as it is enqueued.
-                        auto spEventCpuImpl(event.m_spEventCpuImpl);
+                        auto spEventImpl(event.m_spEventImpl);
 
                         // Setting the event state and enqueuing it has to be atomic.
-                        std::lock_guard<std::mutex> lk(spEventCpuImpl->m_Mutex);
+                        std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
                         // This is a invariant: If the event is ready (not enqueued) there can not be anybody waiting for it.
-                        assert(!(spEventCpuImpl->m_bIsReady && spEventCpuImpl->m_bIsWaitedFor));
+                        assert(!(spEventImpl->m_bIsReady && spEventImpl->m_bIsWaitedFor));
 
                         // If it is enqueued ...
-                        if(!spEventCpuImpl->m_bIsReady)
+                        if(!spEventImpl->m_bIsReady)
                         {
                             // ... and somebody is waiting for it, it can NOT be re-enqueued.
-                            if(spEventCpuImpl->m_bIsWaitedFor)
+                            if(spEventImpl->m_bIsWaitedFor)
                             {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                                 std::cout << BOOST_CURRENT_FUNCTION << "WARNING: The event to enqueue is already enqueued AND waited on. It can NOT be re-enqueued!" << std::endl;
@@ -388,33 +367,33 @@ namespace alpaka
                             // ... and nobody is waiting for it, increment the cancel counter.
                             else
                             {
-                                ++spEventCpuImpl->m_canceledEnqueueCount;
+                                ++spEventImpl->m_canceledEnqueueCount;
                             }
                         }
                         // If it is not enqueued, set its state to enqueued.
                         else
                         {
-                            spEventCpuImpl->m_bIsReady = false;
+                            spEventImpl->m_bIsReady = false;
                         }
 
                         // Increment the enqueue counter. This is used to skip waits for events that had already been finished and re-enqueued which would lead to deadlocks.
-                        ++spEventCpuImpl->m_enqueueCount;
+                        ++spEventImpl->m_enqueueCount;
 
                         // NOTE: Difference to async version: directly reset the event flag instead of enqueuing.
 
                         // Nothing to do if it has been re-enqueued to a later position in any queue.
-                        if(spEventCpuImpl->m_canceledEnqueueCount > 0)
+                        if(spEventImpl->m_canceledEnqueueCount > 0)
                         {
-                            --spEventCpuImpl->m_canceledEnqueueCount;
+                            --spEventImpl->m_canceledEnqueueCount;
                             return;
                         }
                         else
                         {
-                            spEventCpuImpl->m_bIsWaitedFor = false;
-                            spEventCpuImpl->m_bIsReady = true;
+                            spEventImpl->m_bIsWaitedFor = false;
+                            spEventImpl->m_bIsReady = true;
                         }
                     }
-                    event.m_spEventCpuImpl->m_ConditionVariable.notify_all();
+                    event.m_spEventImpl->m_conditionVariable.notify_all();
                 }
             };
             //#############################################################################
@@ -433,6 +412,8 @@ namespace alpaka
                     event::EventCpu & event)
                 -> void
                 {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
                     stream::enqueue(stream.m_spSyncStreamCpu, event);
                 }
             };
@@ -448,15 +429,15 @@ namespace alpaka
                 //
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto currentThreadWaitForEventNoLock(
-                    std::shared_ptr<event::cpu::detail::EventCpuImpl> const & spEventCpuImpl, std::unique_lock<std::mutex> & lk)
+                    std::shared_ptr<event::cpu::detail::EventCpuImpl> const & spEventImpl, std::unique_lock<std::mutex> & lk)
                 -> void
                 {
-                    if(!spEventCpuImpl->m_bIsReady)
+                    if(!spEventImpl->m_bIsReady)
                     {
-                        spEventCpuImpl->m_bIsWaitedFor = true;
-                        spEventCpuImpl->m_ConditionVariable.wait(
+                        spEventImpl->m_bIsWaitedFor = true;
+                        spEventImpl->m_conditionVariable.wait(
                             lk,
-                            [spEventCpuImpl]{return spEventCpuImpl->m_bIsReady;});
+                            [spEventImpl]{return spEventImpl->m_bIsReady;});
                     }
                 }
             }
@@ -478,7 +459,7 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> void
                 {
-                    wait::wait(event.m_spEventCpuImpl);
+                    wait::wait(event.m_spEventImpl);
                 }
             };
             //#############################################################################
@@ -497,12 +478,12 @@ namespace alpaka
                 //
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto currentThreadWaitFor(
-                    std::shared_ptr<event::cpu::detail::EventCpuImpl> const & spEventCpuImpl)
+                    std::shared_ptr<event::cpu::detail::EventCpuImpl> const & spEventImpl)
                 -> void
                 {
-                    std::unique_lock<std::mutex> lk(spEventCpuImpl->m_Mutex);
+                    std::unique_lock<std::mutex> lk(spEventImpl->m_mutex);
 
-                    detail::currentThreadWaitForEventNoLock(spEventCpuImpl, lk);
+                    detail::currentThreadWaitForEventNoLock(spEventImpl, lk);
                 }
             };
             //#############################################################################
@@ -527,27 +508,27 @@ namespace alpaka
                 {
                     // Copy the shared pointer of the event implementation.
                     // This is forwarded to the lambda that is enqueued into the stream to ensure that the event implementation is alive as long as it is enqueued.
-                    auto spEventCpuImpl(event.m_spEventCpuImpl);
+                    auto spEventImpl(event.m_spEventImpl);
 
-                    std::lock_guard<std::mutex> lk(spEventCpuImpl->m_Mutex);
+                    std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
-                    if(!spEventCpuImpl->m_bIsReady)
+                    if(!spEventImpl->m_bIsReady)
                     {
-                        spEventCpuImpl->m_bIsWaitedFor = true;
+                        spEventImpl->m_bIsWaitedFor = true;
 
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
-                        auto const enqueueCount = spEventCpuImpl->m_enqueueCount;
+                        auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                         // Enqueue a task that waits for the given event.
                         spStreamImpl->m_workerThread.enqueueTask(
-                            [spEventCpuImpl, enqueueCount]()
+                            [spEventImpl, enqueueCount]()
                             {
-                                std::unique_lock<std::mutex> lk2(spEventCpuImpl->m_Mutex);
+                                std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
 
-                                if(enqueueCount == spEventCpuImpl->m_enqueueCount)
+                                if(enqueueCount == spEventImpl->m_enqueueCount)
                                 {
-                                    detail::currentThreadWaitForEventNoLock(spEventCpuImpl, lk2);
+                                    detail::currentThreadWaitForEventNoLock(spEventImpl, lk2);
                                 }
                             });
 #endif
@@ -593,9 +574,9 @@ namespace alpaka
 
                     // Copy the shared pointer of the event implementation.
                     // This is forwarded to the lambda that is enqueued into the stream to ensure that the event implementation is alive as long as it is enqueued.
-                    auto spEventCpuImpl(event.m_spEventCpuImpl);
+                    auto spEventImpl(event.m_spEventImpl);
                     // NOTE: Difference to async version: directly wait for event.
-                    wait::wait(spEventCpuImpl);
+                    wait::wait(spEventImpl);
                 }
             };
             //#############################################################################

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -134,7 +134,7 @@ namespace alpaka
             ALPAKA_FN_HOST EventCudaRt(
                 dev::DevCudaRt const & dev,
                 bool bBusyWait = true) :
-                    m_spEventCudaImpl(std::make_shared<cuda::detail::EventCudaImpl>(dev, bBusyWait))
+                    m_spEventImpl(std::make_shared<cuda::detail::EventCudaImpl>(dev, bBusyWait))
             {
                 ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
             }
@@ -160,7 +160,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(EventCudaRt const & rhs) const
             -> bool
             {
-                return (m_spEventCudaImpl->m_CudaEvent == rhs.m_spEventCudaImpl->m_CudaEvent);
+                return (m_spEventImpl->m_CudaEvent == rhs.m_spEventImpl->m_CudaEvent);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.
@@ -176,7 +176,7 @@ namespace alpaka
             ALPAKA_FN_HOST ~EventCudaRt() = default;
 
         public:
-            std::shared_ptr<cuda::detail::EventCudaImpl> m_spEventCudaImpl;
+            std::shared_ptr<cuda::detail::EventCudaImpl> m_spEventImpl;
         };
     }
 
@@ -198,7 +198,7 @@ namespace alpaka
                     event::EventCudaRt const & event)
                 -> dev::DevCudaRt
                 {
-                    return event.m_spEventCudaImpl->m_dev;
+                    return event.m_spEventImpl->m_dev;
                 }
             };
         }
@@ -207,33 +207,6 @@ namespace alpaka
     {
         namespace traits
         {
-            //#############################################################################
-            //! The CUDA RT device event event type trait specialization.
-            //#############################################################################
-            template<>
-            struct EventType<
-                event::EventCudaRt>
-            {
-                using type = event::EventCudaRt;
-            };
-            //#############################################################################
-            //! The CPU device event create trait specialization.
-            //#############################################################################
-            template<>
-            struct Create<
-                event::EventCudaRt,
-                dev::DevCudaRt>
-            {
-                //-----------------------------------------------------------------------------
-                //!
-                //-----------------------------------------------------------------------------
-                ALPAKA_FN_HOST static auto create(
-                    dev::DevCudaRt const & dev)
-                -> event::EventCudaRt
-                {
-                    return event::EventCudaRt(dev);
-                }
-            };
             //#############################################################################
             //! The CUDA RT device event test trait specialization.
             //#############################################################################
@@ -254,7 +227,7 @@ namespace alpaka
                     cudaError_t ret = cudaSuccess;
                     ALPAKA_CUDA_RT_CHECK_IGNORE(
                         ret = cudaEventQuery(
-                            event.m_spEventCudaImpl->m_CudaEvent),
+                            event.m_spEventImpl->m_CudaEvent),
                         cudaErrorNotReady);
                     return (ret == cudaSuccess);
                 }
@@ -284,7 +257,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     ALPAKA_CUDA_RT_CHECK(cudaEventRecord(
-                        event.m_spEventCudaImpl->m_CudaEvent,
+                        event.m_spEventImpl->m_CudaEvent,
                         stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
                 }
             };
@@ -307,7 +280,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     ALPAKA_CUDA_RT_CHECK(cudaEventRecord(
-                        event.m_spEventCudaImpl->m_CudaEvent,
+                        event.m_spEventImpl->m_CudaEvent,
                         stream.m_spStreamCudaRtSyncImpl->m_CudaStream));
                 }
             };
@@ -338,7 +311,7 @@ namespace alpaka
 
                     // Sync is allowed even for events on non current device.
                     ALPAKA_CUDA_RT_CHECK(cudaEventSynchronize(
-                        event.m_spEventCudaImpl->m_CudaEvent));
+                        event.m_spEventImpl->m_CudaEvent));
                 }
             };
             //#############################################################################
@@ -361,7 +334,7 @@ namespace alpaka
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamWaitEvent(
                         stream.m_spStreamCudaRtAsyncImpl->m_CudaStream,
-                        event.m_spEventCudaImpl->m_CudaEvent,
+                        event.m_spEventImpl->m_CudaEvent,
                         0));
                 }
             };
@@ -385,7 +358,7 @@ namespace alpaka
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamWaitEvent(
                         stream.m_spStreamCudaRtSyncImpl->m_CudaStream,
-                        event.m_spEventCudaImpl->m_CudaEvent,
+                        event.m_spEventImpl->m_CudaEvent,
                         0));
                 }
             };
@@ -416,7 +389,7 @@ namespace alpaka
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamWaitEvent(
                         0,
-                        event.m_spEventCudaImpl->m_CudaEvent,
+                        event.m_spEventImpl->m_CudaEvent,
                         0));
                 }
             };

--- a/include/alpaka/event/Traits.hpp
+++ b/include/alpaka/event/Traits.hpp
@@ -46,15 +46,6 @@ namespace alpaka
             struct EventType;
 
             //#############################################################################
-            //! The event creator trait.
-            //#############################################################################
-            template<
-                typename TEvent,
-                typename TDev,
-                typename TSfinae = void>
-            struct Create;
-
-            //#############################################################################
             //! The event tester trait.
             //#############################################################################
             template<
@@ -69,24 +60,6 @@ namespace alpaka
         template<
             typename T>
         using Event = typename traits::EventType<T>::type;
-
-        //-----------------------------------------------------------------------------
-        //! Creates an event on a device.
-        //-----------------------------------------------------------------------------
-        template<
-            typename TEvent,
-            typename TDev>
-        ALPAKA_FN_HOST auto create(
-            TDev const & dev)
-        -> TEvent
-        {
-            return
-                traits::Create<
-                    TEvent,
-                    TDev>
-                ::create(
-                    dev);
-        }
 
         //-----------------------------------------------------------------------------
         //! Tests if the given event has already been completed.

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -1,0 +1,345 @@
+/**
+* \file
+* Copyright 2017 Benjamin Worpitz
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+
+#include <mutex>                        // std::mutex
+#include <condition_variable>           // std::condition_variable
+
+namespace alpaka
+{
+    //-----------------------------------------------------------------------------
+    //! The test specifics.
+    //-----------------------------------------------------------------------------
+    namespace test
+    {
+        //-----------------------------------------------------------------------------
+        //! The test event specifics.
+        //-----------------------------------------------------------------------------
+        namespace event
+        {
+            namespace traits
+            {
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<
+                    typename TDev>
+                struct EventHostManualTriggerType;
+            }
+
+            //#############################################################################
+            //! The event type trait alias template to remove the ::type.
+            //#############################################################################
+            template<
+                typename TDev>
+            using EventHostManualTrigger = typename traits::EventHostManualTriggerType<TDev>::type;
+
+            namespace cpu
+            {
+                namespace detail
+                {
+                    //#############################################################################
+                    //! Event that can be enqueued into a stream and can be triggered by the Host.
+                    //#############################################################################
+                    class EventHostManualTriggerCpuImpl
+                    {
+                    public:
+                        //-----------------------------------------------------------------------------
+                        //! Constructor.
+                        //-----------------------------------------------------------------------------
+                        ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(
+                            dev::DevCpu const & dev) :
+                                m_dev(dev),
+                                m_mutex(),
+                                m_enqueueCount(0u),
+                                m_bIsReady(true)
+                    {}
+                        //-----------------------------------------------------------------------------
+                        //! Copy constructor.
+                        //-----------------------------------------------------------------------------
+                        ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl const & other) = delete;
+                        //-----------------------------------------------------------------------------
+                        //! Move constructor.
+                        //-----------------------------------------------------------------------------
+                        ALPAKA_FN_HOST EventHostManualTriggerCpuImpl(EventHostManualTriggerCpuImpl &&) = default;
+                        //-----------------------------------------------------------------------------
+                        //! Copy assignment operator.
+                        //-----------------------------------------------------------------------------
+                        ALPAKA_FN_HOST auto operator=(EventHostManualTriggerCpuImpl const &) -> EventHostManualTriggerCpuImpl & = delete;
+                        //-----------------------------------------------------------------------------
+                        //! Move assignment operator.
+                        //-----------------------------------------------------------------------------
+                        ALPAKA_FN_HOST auto operator=(EventHostManualTriggerCpuImpl &&) -> EventHostManualTriggerCpuImpl & = default;
+
+                        //-----------------------------------------------------------------------------
+                        //!
+                        //-----------------------------------------------------------------------------
+                        void trigger()
+                        {
+                            {
+                                std::unique_lock<std::mutex> lock(m_mutex);
+                                m_bIsReady = true;
+                            }
+                            m_conditionVariable.notify_one();
+                        }
+
+                    public:
+                        dev::DevCpu const m_dev;                                //!< The device this event is bound to.
+
+                        mutable std::mutex m_mutex;                             //!< The mutex used to synchronize access to the event.
+
+                        mutable std::condition_variable m_conditionVariable;    //!< The condition signaling the event completion.
+                        std::size_t m_enqueueCount;                             //!< The number of times this event has been enqueued.
+
+                        bool m_bIsReady;                                        //!< If the event is not waiting within a stream (not enqueued or already completed).
+                    };
+                }
+            }
+
+            //#############################################################################
+            //! Event that can be enqueued into a stream and can be triggered by the Host.
+            //#############################################################################
+            class EventHostManualTriggerCpu
+            {
+            public:
+                //-----------------------------------------------------------------------------
+                //! Constructor.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST EventHostManualTriggerCpu(
+                    dev::DevCpu const & dev) :
+                        m_spEventImpl(std::make_shared<cpu::detail::EventHostManualTriggerCpuImpl>(dev))
+                {}
+                //-----------------------------------------------------------------------------
+                //! Copy constructor.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST EventHostManualTriggerCpu(EventHostManualTriggerCpu const &) = default;
+                //-----------------------------------------------------------------------------
+                //! Move constructor.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST EventHostManualTriggerCpu(EventHostManualTriggerCpu &&) = default;
+                //-----------------------------------------------------------------------------
+                //! Copy assignment operator.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST auto operator=(EventHostManualTriggerCpu const &) -> EventHostManualTriggerCpu & = default;
+                //-----------------------------------------------------------------------------
+                //! Move assignment operator.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST auto operator=(EventHostManualTriggerCpu &&) -> EventHostManualTriggerCpu & = default;
+                //-----------------------------------------------------------------------------
+                //! Equality comparison operator.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST auto operator==(EventHostManualTriggerCpu const & rhs) const
+                -> bool
+                {
+                    return (m_spEventImpl == rhs.m_spEventImpl);
+                }
+                //-----------------------------------------------------------------------------
+                //! Inequality comparison operator.
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST auto operator!=(EventHostManualTriggerCpu const & rhs) const
+                -> bool
+                {
+                    return !((*this) == rhs);
+                }
+
+                //-----------------------------------------------------------------------------
+                //!
+                //-----------------------------------------------------------------------------
+                void trigger()
+                {
+                    m_spEventImpl->trigger();
+                }
+
+            public:
+                std::shared_ptr<cpu::detail::EventHostManualTriggerCpuImpl> m_spEventImpl;
+            };
+
+            namespace traits
+            {
+                //#############################################################################
+                //!
+                //#############################################################################
+                template<>
+                struct EventHostManualTriggerType<
+                    alpaka::dev::DevCpu>
+                {
+                    using type = alpaka::test::event::EventHostManualTriggerCpu;
+                };
+            }
+        }
+    }
+    namespace dev
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU device event device get trait specialization.
+            //#############################################################################
+            template<>
+            struct GetDev<
+                test::event::EventHostManualTriggerCpu>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto getDev(
+                    test::event::EventHostManualTriggerCpu const & event)
+                -> dev::DevCpu
+                {
+                    return event.m_spEventImpl->m_dev;
+                }
+            };
+        }
+    }
+    namespace event
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //! The CPU device event test trait specialization.
+            //#############################################################################
+            template<>
+            struct Test<
+                test::event::EventHostManualTriggerCpu>
+            {
+                //-----------------------------------------------------------------------------
+                //! \return If the event is not waiting within a stream (not enqueued or already handled).
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto test(
+                    test::event::EventHostManualTriggerCpu const & event)
+                -> bool
+                {
+                    std::lock_guard<std::mutex> lk(event.m_spEventImpl->m_mutex);
+
+                    return event.m_spEventImpl->m_bIsReady;
+                }
+            };
+        }
+    }
+    namespace stream
+    {
+        namespace traits
+        {
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<>
+            struct Enqueue<
+                stream::StreamCpuAsync,
+                test::event::EventHostManualTriggerCpu>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
+                    stream::StreamCpuAsync & stream,
+#else
+                    stream::StreamCpuAsync &,
+#endif
+                    test::event::EventHostManualTriggerCpu & event)
+                -> void
+                {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                    // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+                    auto spEventImpl(event.m_spEventImpl);
+
+                    // Setting the event state and enqueuing it has to be atomic.
+                    std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
+
+                    // The event should not yet be enqueued.
+                    assert(spEventImpl->m_bIsReady);
+
+                    // Set its state to enqueued.
+                    spEventImpl->m_bIsReady = false;
+
+                    // Increment the enqueue counter. This is used to skip waits for events that had already been finished and re-enqueued which would lead to deadlocks.
+                    ++spEventImpl->m_enqueueCount;
+
+                    // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
+#if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
+                    auto const enqueueCount = spEventImpl->m_enqueueCount;
+
+                    // Enqueue a task that only resets the events flag if it is completed.
+                    stream.m_spAsyncStreamCpu->m_workerThread.enqueueTask(
+                        [spEventImpl, enqueueCount]()
+                        {
+                            std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);
+                            spEventImpl->m_conditionVariable.wait(
+                                lk2,
+                                [spEventImpl, enqueueCount]
+                                {
+                                    return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady;
+                                });
+                        });
+#endif
+                }
+            };
+            //#############################################################################
+            //!
+            //#############################################################################
+            template<>
+            struct Enqueue<
+                stream::StreamCpuSync,
+                test::event::EventHostManualTriggerCpu>
+            {
+                //-----------------------------------------------------------------------------
+                //
+                //-----------------------------------------------------------------------------
+                ALPAKA_FN_HOST static auto enqueue(
+                    stream::StreamCpuSync &,
+                    test::event::EventHostManualTriggerCpu & event)
+                -> void
+                {
+                    ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                    // Copy the shared pointer to ensure that the event implementation is alive as long as it is enqueued.
+                    auto spEventImpl(event.m_spEventImpl);
+
+                    // Setting the event state and enqueuing it has to be atomic.
+                    std::unique_lock<std::mutex> lk(spEventImpl->m_mutex);
+
+                    // The event should not yet be enqueued.
+                    assert(spEventImpl->m_bIsReady);
+
+                    // Set its state to enqueued.
+                    spEventImpl->m_bIsReady = false;
+
+                    // Increment the enqueue counter. This is used to skip waits for events that had already been finished and re-enqueued which would lead to deadlocks.
+                    ++spEventImpl->m_enqueueCount;
+
+                    auto const enqueueCount = spEventImpl->m_enqueueCount;
+
+                    spEventImpl->m_conditionVariable.wait(
+                        lk,
+                        [spEventImpl, enqueueCount]
+                        {
+                            return (enqueueCount != spEventImpl->m_enqueueCount) || spEventImpl->m_bIsReady;
+                        });
+                }
+            };
+        }
+    }
+}

--- a/test/common/include/alpaka/test/stream/Stream.hpp
+++ b/test/common/include/alpaka/test/stream/Stream.hpp
@@ -149,7 +149,6 @@ namespace alpaka
                 typename TStream>
             using IsSyncStream = traits::IsSyncStream<TStream>;
 
-
             //#############################################################################
             //! A std::tuple holding tuples of devices and corresponding stream types.
             //#############################################################################
@@ -162,6 +161,15 @@ namespace alpaka
                     std::tuple<alpaka::dev::DevCudaRt, alpaka::stream::StreamCudaRtSync>,
                     std::tuple<alpaka::dev::DevCudaRt, alpaka::stream::StreamCudaRtAsync>
 #endif
+                >;
+
+            //#############################################################################
+            //! A std::tuple holding tuples of devices and corresponding stream types.
+            //#############################################################################
+            using TestStreamsCpu =
+                std::tuple<
+                    std::tuple<alpaka::dev::DevCpu, alpaka::stream::StreamCpuSync>,
+                    std::tuple<alpaka::dev::DevCpu, alpaka::stream::StreamCpuAsync>
                 >;
         }
     }


### PR DESCRIPTION
* some renamings of event interna (wrong capilatization, some shortening)
* removes the useless reflexive specializations of `EventType` for the event types themselves
* removes the `event::create` method and the corresponding trait as it always only called the constructor
* adds code for a manually host side triggered event (`EventHostManualTrigger`) that streams can wait on (currently only for CPU streams). This is currently only test code and not part of alpaka itself.
* currently only tests CPU streams/event (CUDA stream testing will be added later)