### PR TITLE
AtomicStlLock: increase perfromance

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -84,9 +84,9 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtRefFiberIdMap<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock, // grid atomics
-                atomic::AtomicStlLock, // block atomics
-                atomic::AtomicNoOp     // thread atomics
+                atomic::AtomicStlLock<16>, // grid atomics
+                atomic::AtomicStlLock<16>, // block atomics
+                atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
@@ -117,9 +117,9 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefFiberIdMap<TDim, TSize>(m_fibersToIndices),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock, // atomics between grids
-                        atomic::AtomicStlLock, // atomics between blocks
-                        atomic::AtomicNoOp     // atomics between threads
+                        atomic::AtomicStlLock<16>, // atomics between grids
+                        atomic::AtomicStlLock<16>, // atomics between blocks
+                        atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -87,7 +87,7 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicStlLock<16>,   // grid atomics
                 atomic::AtomicOmpCritSec,    // block atomics
                 atomic::AtomicNoOp           // thread atomics
             >,
@@ -120,7 +120,7 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicStlLock<16>,// atomics between grids
                         atomic::AtomicOmpCritSec, // atomics between blocks
                         atomic::AtomicNoOp        // atomics between threads
                     >(),

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -85,7 +85,7 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtOmp<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicStlLock<16>,   // grid atomics
                 atomic::AtomicOmpCritSec,    // block atomics
                 atomic::AtomicOmpCritSec     // thread atomics
             >,
@@ -118,7 +118,7 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicStlLock<16>,// atomics between grids
                         atomic::AtomicOmpCritSec, // atomics between blocks
                         atomic::AtomicOmpCritSec  // atomics between threads
                     >(),

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -85,7 +85,7 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtOmp<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock,       // grid atomics
+                atomic::AtomicStlLock<16>,   // grid atomics
                 atomic::AtomicOmpCritSec,    // block atomics
                 atomic::AtomicOmpCritSec     // thread atomics
             >,
@@ -118,7 +118,7 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtOmp<TDim, TSize>(),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock,    // atomics between grids
+                        atomic::AtomicStlLock<16>,// atomics between grids
                         atomic::AtomicOmpCritSec, // atomics between blocks
                         atomic::AtomicOmpCritSec  // atomics between threads
                     >(),

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -79,9 +79,9 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock, // grid atomics
-                atomic::AtomicNoOp,    // block atomics
-                atomic::AtomicNoOp     // thread atomics
+                atomic::AtomicStlLock<16>, // grid atomics
+                atomic::AtomicNoOp,        // block atomics
+                atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
@@ -112,9 +112,9 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock, // atomics between grids
-                        atomic::AtomicNoOp,    // atomics between blocks
-                        atomic::AtomicNoOp     // atomics between threads
+                        atomic::AtomicStlLock<16>, // atomics between grids
+                        atomic::AtomicNoOp,        // atomics between blocks
+                        atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -77,9 +77,9 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtZero<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock, // grid atomics
-                atomic::AtomicStlLock, // block atomics
-                atomic::AtomicNoOp     // thread atomics
+                atomic::AtomicStlLock<16>, // grid atomics
+                atomic::AtomicStlLock<16>, // block atomics
+                atomic::AtomicNoOp         // thread atomics
             >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
@@ -110,9 +110,9 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtZero<TDim, TSize>(),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock, // atomics between grids
-                        atomic::AtomicStlLock, // atomics between blocks
-                        atomic::AtomicNoOp     // atomics between threads
+                        atomic::AtomicStlLock<16>, // atomics between grids
+                        atomic::AtomicStlLock<16>, // atomics between blocks
+                        atomic::AtomicNoOp         // atomics between threads
                     >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -80,9 +80,9 @@ namespace alpaka
             public idx::gb::IdxGbRef<TDim, TSize>,
             public idx::bt::IdxBtRefThreadIdMap<TDim, TSize>,
             public atomic::AtomicHierarchy<
-                atomic::AtomicStlLock, // grid atomics
-                atomic::AtomicStlLock, // block atomics
-                atomic::AtomicStlLock  // thread atomics
+                atomic::AtomicStlLock<16>, // grid atomics
+                atomic::AtomicStlLock<16>, // block atomics
+                atomic::AtomicStlLock<16>  // thread atomics
             >,
             public math::MathStl,
             public block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc,
@@ -113,9 +113,9 @@ namespace alpaka
                     idx::gb::IdxGbRef<TDim, TSize>(m_gridBlockIdx),
                     idx::bt::IdxBtRefThreadIdMap<TDim, TSize>(m_threadToIndexMap),
                     atomic::AtomicHierarchy<
-                        atomic::AtomicStlLock, // atomics between grids
-                        atomic::AtomicStlLock, // atomics between blocks
-                        atomic::AtomicStlLock  // atomics between threads
+                        atomic::AtomicStlLock<16>, // atomics between grids
+                        atomic::AtomicStlLock<16>, // atomics between blocks
+                        atomic::AtomicStlLock<16>  // atomics between threads
                     >(),
                     math::MathStl(),
                     block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc(static_cast<std::size_t>(blockSharedMemDynSizeBytes)),

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -24,6 +24,7 @@
 #include <alpaka/atomic/Traits.hpp>                 // AtomicOp
 
 #include <mutex>                                    // std::mutex, std::lock_guard
+#include <array>
 
 namespace alpaka
 {
@@ -34,7 +35,11 @@ namespace alpaka
         //
         //  Atomics can be used in the grids, blocks and threads hierarchy levels.
         //  Atomics are not guaranteed to be save between devices.
+        //
+        // \tparam THashTableSize size of the hash table to allow concurrency between
+        //                        atomics to different addresses
         //#############################################################################
+        template<size_t THashTableSize>
         class AtomicStlLock
         {
         public:
@@ -45,6 +50,34 @@ namespace alpaka
                 typename THierarchy,
                 typename TSfinae>
             friend struct atomic::traits::AtomicOp;
+
+            static constexpr size_t nextPowerOf2(size_t const value, size_t const bit = 0)
+            {
+                return value <= (1u << bit) ? (1u << bit) : nextPowerOf2(value, bit + 1u);
+            }
+
+            //-----------------------------------------------------------------------------
+            //! get a hash value of the pointer
+            //
+            // This is no perfect hash, there will be collisions if the size of pointer type
+            // is not a power of two.
+            //-----------------------------------------------------------------------------
+            template<typename TPtr>
+            static size_t hash(TPtr const * const ptr)
+            {
+                size_t const ptrAddr = reinterpret_cast< size_t >( ptr );
+                // using power of two for the next division will increase the performance
+                constexpr size_t typeSizePowerOf2 = nextPowerOf2(sizeof(TPtr));
+                // division removes the stride between indices
+                return (ptrAddr / typeSizePowerOf2);
+            }
+
+            //-----------------------------------------------------------------------------
+            //! get the size of the hash table
+            //
+            // The size is at least 1 or THashTableSize rounded up to the next power of 2
+            //-----------------------------------------------------------------------------
+            static constexpr size_t hashTableSize = THashTableSize == 0 ? 1u : nextPowerOf2(THashTableSize);
 
             //-----------------------------------------------------------------------------
             //! Default constructor.
@@ -71,10 +104,14 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_ACC_NO_CUDA /*virtual*/ ~AtomicStlLock() = default;
 
-            std::mutex & getMutex() const
+            template<typename TPtr>
+            std::mutex & getMutex(TPtr const * const ptr) const
             {
-                static std::mutex m_mtxAtomic; //!< The mutex protecting access for a atomic operation.
-                return m_mtxAtomic;
+                size_t const hashedAddr = hash(ptr) & (hashTableSize - 1u);
+                static std::array<
+                    std::mutex,
+                    hashTableSize> m_mtxAtomic; //!< The mutex protecting access for a atomic operation.
+                return m_mtxAtomic[hashedAddr];
             }
         };
 
@@ -86,10 +123,11 @@ namespace alpaka
             template<
                 typename TOp,
                 typename T,
-                typename THierarchy>
+                typename THierarchy,
+                size_t THashTableSize>
             struct AtomicOp<
                 TOp,
-                atomic::AtomicStlLock,
+                atomic::AtomicStlLock<THashTableSize>,
                 T,
                 THierarchy>
             {
@@ -97,29 +135,25 @@ namespace alpaka
                 //
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
-                    atomic::AtomicStlLock const & atomic,
+                    atomic::AtomicStlLock<THashTableSize> const & atomic,
                     T * const addr,
                     T const & value)
                 -> T
                 {
-                    // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
-                    // We could use a list of mutexes and lock the mutex depending on the target memory location to allow multiple atomic ops on different targets concurrently.
-                    std::lock_guard<std::mutex> lock(atomic.getMutex());
+                    std::lock_guard<std::mutex> lock(atomic.getMutex(addr));
                     return TOp()(addr, value);
                 }
                 //-----------------------------------------------------------------------------
                 //
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
-                    atomic::AtomicStlLock const & atomic,
+                    atomic::AtomicStlLock<THashTableSize> const & atomic,
                     T * const addr,
                     T const & compare,
                     T const & value)
                 -> T
                 {
-                    // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
-                    // We could use a list of mutexes and lock the mutex depending on the target memory location to allow multiple atomic ops on different targets concurrently.
-                    std::lock_guard<std::mutex> lock(atomic.getMutex());
+                    std::lock_guard<std::mutex> lock(atomic.getMutex(addr));
                     return TOp()(addr, compare, value);
                 }
             };

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -51,9 +51,10 @@ namespace alpaka
                 typename TSfinae>
             friend struct atomic::traits::AtomicOp;
 
-            static constexpr size_t nextPowerOf2(size_t const value, size_t const bit = 0)
+            static constexpr size_t nextPowerOf2(size_t const value, size_t const bit = 0u)
             {
-                return value <= (1u << bit) ? (1u << bit) : nextPowerOf2(value, bit + 1u);
+                return value <= (static_cast<size_t>(1u) << bit) ?
+                    (static_cast<size_t>(1u) << bit) : nextPowerOf2(value, bit + 1u);
             }
 
             //-----------------------------------------------------------------------------
@@ -71,13 +72,6 @@ namespace alpaka
                 // division removes the stride between indices
                 return (ptrAddr / typeSizePowerOf2);
             }
-
-            //-----------------------------------------------------------------------------
-            //! get the size of the hash table
-            //
-            // The size is at least 1 or THashTableSize rounded up to the next power of 2
-            //-----------------------------------------------------------------------------
-            static constexpr size_t hashTableSize = THashTableSize == 0 ? 1u : nextPowerOf2(THashTableSize);
 
             //-----------------------------------------------------------------------------
             //! Default constructor.
@@ -107,10 +101,17 @@ namespace alpaka
             template<typename TPtr>
             std::mutex & getMutex(TPtr const * const ptr) const
             {
+                //-----------------------------------------------------------------------------
+                //! get the size of the hash table
+                //
+                // The size is at least 1 or THashTableSize rounded up to the next power of 2
+                //-----------------------------------------------------------------------------
+                constexpr size_t hashTableSize = THashTableSize == 0u ? 1u : nextPowerOf2(THashTableSize);
+
                 size_t const hashedAddr = hash(ptr) & (hashTableSize - 1u);
                 static std::array<
                     std::mutex,
-                    hashTableSize> m_mtxAtomic; //!< The mutex protecting access for a atomic operation.
+                    hashTableSize> m_mtxAtomic; //!< The mutex protecting access for an atomic operation.
                 return m_mtxAtomic[hashedAddr];
             }
         };


### PR DESCRIPTION
This pull requests adds a table of mutex to AtomicStlLock to increase the concurrency. The size of teh table can be changed and is currently set to the magic number 16. 16 is a trait of between concurrency and size of used cache for the mutex array. 16 mutex each 40 bytes is 640 byte which will not eat the L1 but provide a good performance.

- use an array of mutex to increase concurrency
- add static hash method (non collision less)
- add documentation
- use AtomicStlLock with hash table size `16`

# Performance

I used PIConGPU with the KelvinHelmholtz example and the alpaka backend `AccCpuOmp2Threads`   on a 4 socket `AMD Opteron(TM) Processor 6276` (64 cores in total). I changed the atomic operation used on the block and threads level for the tests. The test will use many concurrent atomic operation between a group of 256 openMP threads.  I will show the total time used to performe 10 time steps.

| atomic | time [s] |
|:---:|:---:|
|AtomicOmpCritSec | 353 |
| AtomicStlLock(unchanged) | 303 |
| AtomicStlLock<4> | 239 |
| AtomicStlLock<8> | 225 |
| AtomicStlLock<16> | 194 |
| AtomicStlLock<32> | 197 |

# Why not using std::atomic<T>

To use std atomic the type must be defined as std::atomic. It is not allowed to cast a type e.g. `float` to `std::atomic<float>`. Therefore the usage for arbitrary data is not possible.

# Why is an own hash function used and not std::hash<Ptr*>

I checked the implementation of the std hash function and the implementation for a pointer is only a `reinterpret_cast`. This will produce strides between the hash indices and if we map than the hash to a element within the mutex array we will not use each element in the array which reduce the efficiency.
The hash function is not collision free for pointer where the type is not a power of two. This will be no problem for the usage but guarantee that we can always use all elements of the mutex array.
Du to the special type of hashing function I have not moved the implementation to the core of alpaka.

# Note

If have not removed the usage of `AtomicOmpCritSec` because I will add new openMP atomics without a critical section to give the openMP implementation the possibility to choose the best fitting atomic operation for the used architecture.