### PR TITLE
fix OpenMP-4.0 test errors with clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This library uses C++11 (or newer when available).
 |Serial|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ blocks|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |OpenMP 2.0+ threads|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
-|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:x:|:x:|:x:|:x:|
+|OpenMP 4.0+ (CPU)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:x:|:x:|:white_check_mark:|:white_check_mark:|:x:|
 | std::thread |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 | Boost.Fiber |:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |TBB 2.2+|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|

--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -249,10 +249,18 @@ IF(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE OR ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE OR A
         SET(ALPAKA_ACC_CPU_BT_OMP4_ENABLE OFF CACHE BOOL "Enable the OpenMP 4.0 CPU block and thread back-end" FORCE)
 
     ELSE()
+        # clang versions beginning with 3.9 support OpenMP 4.0 but only when given the corresponding flag
+        IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            IF(ALPAKA_ACC_CPU_BT_OMP4_ENABLE)
+                LIST(APPEND OpenMP_CXX_FLAGS "-fopenmp-version=40")
+            ENDIF()
+        ENDIF()
+
         LIST(APPEND _ALPAKA_COMPILE_OPTIONS_PUBLIC ${OpenMP_CXX_FLAGS})
         IF(NOT MSVC)
             LIST(APPEND _ALPAKA_LINK_FLAGS_PUBLIC ${OpenMP_CXX_FLAGS})
         ENDIF()
+
         # CUDA requires some special handling
         IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")

--- a/include/alpaka/exec/ExecCpuOmp4.hpp
+++ b/include/alpaka/exec/ExecCpuOmp4.hpp
@@ -166,7 +166,7 @@ namespace alpaka
                 // `When an if(scalar-expression) evaluates to false, the structured block is executed on the host.`
                 #pragma omp target if(0)
                 {
-                    #pragma omp teams/* num_teams(gridBlockCount) thread_limit(blockThreadCount)*/
+                    #pragma omp teams num_teams(gridBlockCount) thread_limit(blockThreadCount)
                     {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                         // The first team does some checks ...

--- a/script/travis/before_install.sh
+++ b/script/travis/before_install.sh
@@ -51,8 +51,6 @@ then
     echo ALPAKA_CI_CLANG_VER_MINOR: "${ALPAKA_CI_CLANG_VER_MINOR}"
 
     # clang versions lower than 3.7 do not support OpenMP 2.0.
-    # clang versions lower than 3.9 do not support OpenMP 4.0
-    # OpenMP 4.0 curently leads to test errors and is therefore disabled.
     if (( (( ALPAKA_CI_CLANG_VER_MAJOR < 3 )) || ( (( ALPAKA_CI_CLANG_VER_MAJOR == 3 )) && (( ALPAKA_CI_CLANG_VER_MINOR < 7 )) ) ))
     then
         if [ "${ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE}" == "ON" ]
@@ -66,8 +64,16 @@ then
             echo ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE=${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE} because the clang version does not support it!
         fi
     fi
-    export ALPAKA_ACC_CPU_BT_OMP4_ENABLE=OFF
-    echo ALPAKA_ACC_CPU_BT_OMP4_ENABLE=${ALPAKA_ACC_CPU_BT_OMP4_ENABLE} because the clang version does not support it!
+
+    # clang versions lower than 3.9 do not support OpenMP 4.0
+    if (( (( ALPAKA_CI_CLANG_VER_MAJOR < 3 )) || ( (( ALPAKA_CI_CLANG_VER_MAJOR == 3 )) && (( ALPAKA_CI_CLANG_VER_MINOR < 9 )) ) ))
+    then
+        if [ "${ALPAKA_ACC_CPU_BT_OMP4_ENABLE}" == "ON" ]
+        then
+            export ALPAKA_ACC_CPU_BT_OMP4_ENABLE=OFF
+            echo ALPAKA_ACC_CPU_BT_OMP4_ENABLE=${ALPAKA_ACC_CPU_BT_OMP4_ENABLE} because the clang version does not support it!
+        fi
+    fi
 
     export ALPAKA_BOOST_COMPILER=-clang${ALPAKA_CI_CLANG_VER_MAJOR}${ALPAKA_CI_CLANG_VER_MINOR}
 fi

--- a/test/integ/mandelbrot/src/main.cpp
+++ b/test/integ/mandelbrot/src/main.cpp
@@ -477,7 +477,7 @@ auto main()
         // For different sizes.
         for(std::uint32_t imageSize(1u<<3u);
 #ifdef ALPAKA_CI
-            imageSize <= 1u<<8u;
+            imageSize <= 1u<<5u;
 #else
             imageSize <= 1u<<13u;
 #endif


### PR DESCRIPTION
This adds support for the OpenMP 4 backend for clang 3.9, 4 and 5.
Without the `thread_limit` annotation on the `omp teams` clause, clang did not provide enough threads to be available for the inner `omp parallel` clause. gcc did not require this but the code was already existing but commented out.
The data size of one test had to be reduced because the OpenMP 4 implementation of clang is extremely slow...