### PR TITLE
remove uuid and clean up

### DIFF
--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -315,7 +315,7 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    stream::enqueue(stream.m_spAsyncStreamCpu, event);
+                    stream::enqueue(stream.m_spStreamImpl, event);
                 }
             };
             //#############################################################################
@@ -410,7 +410,7 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    stream::enqueue(stream.m_spSyncStreamCpu, event);
+                    stream::enqueue(stream.m_spStreamImpl, event);
                 }
             };
         }
@@ -547,7 +547,7 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> void
                 {
-                    wait::wait(stream.m_spAsyncStreamCpu, event);
+                    wait::wait(stream.m_spStreamImpl, event);
                 }
             };
             //#############################################################################
@@ -591,7 +591,7 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> void
                 {
-                    wait::wait(stream.m_spSyncStreamCpu, event);
+                    wait::wait(stream.m_spStreamImpl, event);
                 }
             };
             //#############################################################################

--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -30,8 +30,6 @@
 #include <alpaka/wait/Traits.hpp>           // CurrentThreadWaitFor
 #include <alpaka/dev/Traits.hpp>            // GetDev
 
-#include <boost/uuid/uuid.hpp>              // boost::uuids::uuid
-#include <boost/uuid/uuid_generators.hpp>   // boost::uuids::random_generator
 #include <boost/core/ignore_unused.hpp>     // boost::ignore_unused
 
 #include <cassert>                          // assert
@@ -60,7 +58,6 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST EventCpuImpl(
                         dev::DevCpu const & dev) :
-                            m_uuid(boost::uuids::random_generator()()),
                             m_dev(dev),
                             m_mutex(),
                             m_enqueueCount(0u),
@@ -98,7 +95,6 @@ namespace alpaka
                     = default;
 #endif
                 public:
-                    boost::uuids::uuid const m_uuid;                        //!< The unique ID.
                     dev::DevCpu const m_dev;                                //!< The device this event is bound to.
 
                     std::mutex mutable m_mutex;                             //!< The mutex used to synchronize access to the event.
@@ -148,7 +144,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(EventCpu const & rhs) const
             -> bool
             {
-                return (m_spEventImpl->m_uuid == rhs.m_spEventImpl->m_uuid);
+                return (m_spEventImpl == rhs.m_spEventImpl);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -258,7 +258,7 @@ namespace alpaka
 
                     ALPAKA_CUDA_RT_CHECK(cudaEventRecord(
                         event.m_spEventImpl->m_CudaEvent,
-                        stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                        stream.m_spStreamImpl->m_CudaStream));
                 }
             };
             //#############################################################################
@@ -281,7 +281,7 @@ namespace alpaka
 
                     ALPAKA_CUDA_RT_CHECK(cudaEventRecord(
                         event.m_spEventImpl->m_CudaEvent,
-                        stream.m_spStreamCudaRtSyncImpl->m_CudaStream));
+                        stream.m_spStreamImpl->m_CudaStream));
                 }
             };
         }
@@ -333,7 +333,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamWaitEvent(
-                        stream.m_spStreamCudaRtAsyncImpl->m_CudaStream,
+                        stream.m_spStreamImpl->m_CudaStream,
                         event.m_spEventImpl->m_CudaEvent,
                         0));
                 }
@@ -357,7 +357,7 @@ namespace alpaka
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamWaitEvent(
-                        stream.m_spStreamCudaRtSyncImpl->m_CudaStream,
+                        stream.m_spStreamImpl->m_CudaStream,
                         event.m_spEventImpl->m_CudaEvent,
                         0));
                 }

--- a/include/alpaka/event/EventCudaRt.hpp
+++ b/include/alpaka/event/EventCudaRt.hpp
@@ -160,7 +160,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(EventCudaRt const & rhs) const
             -> bool
             {
-                return (m_spEventImpl->m_CudaEvent == rhs.m_spEventImpl->m_CudaEvent);
+                return (m_spEventImpl == rhs.m_spEventImpl);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.

--- a/include/alpaka/exec/ExecGpuCudaRt.hpp
+++ b/include/alpaka/exec/ExecGpuCudaRt.hpp
@@ -395,7 +395,7 @@ namespace alpaka
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
-                            stream.m_spStreamCudaRtAsyncImpl->m_dev.m_iDevice));
+                            stream.m_spStreamImpl->m_dev.m_iDevice));
                     // Enqueue the kernel execution.
                     // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch language extension expects the arguments by value.
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
@@ -407,7 +407,7 @@ namespace alpaka
                                 gridDim,
                                 blockDim,
                                 static_cast<std::size_t>(blockSharedMemDynSizeBytes),
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream>>>(
+                                stream.m_spStreamImpl->m_CudaStream>>>(
                                     threadElemExtent,
                                     task.m_kernelFnObj,
                                     args...);
@@ -418,7 +418,7 @@ namespace alpaka
                     // Wait for the kernel execution to finish but do not check error return of this call.
                     // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom error message.
                     cudaStreamSynchronize(
-                        stream.m_spStreamCudaRtAsyncImpl->m_CudaStream);
+                        stream.m_spStreamImpl->m_CudaStream);
                     std::string const kernelName("'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                     ::alpaka::cuda::detail::cudaRtCheckLastError(kernelName.c_str(), __FILE__, __LINE__);
 #endif
@@ -530,7 +530,7 @@ namespace alpaka
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
-                            stream.m_spStreamCudaRtSyncImpl->m_dev.m_iDevice));
+                            stream.m_spStreamImpl->m_dev.m_iDevice));
                     // Enqueue the kernel execution.
                     // \NOTE: No const reference (const &) is allowed as the parameter type because the kernel launch language extension expects the arguments by value.
                     // This forces the type of a float argument given with std::forward to this function to be of type float instead of e.g. "float const & __ptr64" (MSVC).
@@ -542,7 +542,7 @@ namespace alpaka
                                 gridDim,
                                 blockDim,
                                 blockSharedMemDynSizeBytes,
-                                stream.m_spStreamCudaRtSyncImpl->m_CudaStream>>>(
+                                stream.m_spStreamImpl->m_CudaStream>>>(
                                     threadElemExtent,
                                     task.m_kernelFnObj,
                                     args...);
@@ -552,7 +552,7 @@ namespace alpaka
                     // Wait for the kernel execution to finish but do not check error return of this call.
                     // Do not use the alpaka::wait method because it checks the error itself but we want to give a custom error message.
                     cudaStreamSynchronize(
-                        stream.m_spStreamCudaRtSyncImpl->m_CudaStream);
+                        stream.m_spStreamImpl->m_CudaStream);
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                     std::string const kernelName("'execution of kernel: '" + std::string(typeid(TKernelFnObj).name()) + "' failed with");
                     ::alpaka::cuda::detail::cudaRtCheckLastError(kernelName.c_str(), __FILE__, __LINE__);

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -780,7 +780,7 @@ namespace alpaka
                                 srcNativePtr,
                                 static_cast<std::size_t>(extentWidthBytes),
                                 cudaMemCpyKind,
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                     else
                     {
@@ -792,7 +792,7 @@ namespace alpaka
                                 srcNativePtr,
                                 iSrcDev,
                                 static_cast<std::size_t>(extentWidthBytes),
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                 }
             };
@@ -911,7 +911,7 @@ namespace alpaka
                                 static_cast<std::size_t>(extentWidthBytes),
                                 static_cast<std::size_t>(extentHeight),
                                 cudaMemCpyKind,
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                     else
                     {
@@ -924,7 +924,7 @@ namespace alpaka
                         ALPAKA_CUDA_RT_CHECK(
                             cudaMemcpy3DPeerAsync(
                                 &cudaMemCpy3DPeerParms,
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                 }
             };
@@ -1038,7 +1038,7 @@ namespace alpaka
                         ALPAKA_CUDA_RT_CHECK(
                             cudaMemcpy3DAsync(
                                 &cudaMemCpy3DParms,
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                     else
                     {
@@ -1050,7 +1050,7 @@ namespace alpaka
                         ALPAKA_CUDA_RT_CHECK(
                             cudaMemcpy3DPeerAsync(
                                 &cudaMemCpy3DPeerParms,
-                                stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                                stream.m_spStreamImpl->m_CudaStream));
                     }
                 }
             };

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -191,7 +191,7 @@ namespace alpaka
                             dstNativePtr,
                             static_cast<int>(byte),
                             static_cast<size_t>(extentWidthBytes),
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                            stream.m_spStreamImpl->m_CudaStream));
                 }
             };
             //#############################################################################
@@ -306,7 +306,7 @@ namespace alpaka
                             static_cast<int>(byte),
                             static_cast<size_t>(extentWidthBytes),
                             static_cast<size_t>(extentHeight),
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                            stream.m_spStreamImpl->m_CudaStream));
                 }
             };
             //#############################################################################
@@ -443,7 +443,7 @@ namespace alpaka
                             cudaPitchedPtrVal,
                             static_cast<int>(byte),
                             cudaExtentVal,
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                            stream.m_spStreamImpl->m_CudaStream));
                 }
             };
             //#############################################################################

--- a/include/alpaka/stream/StreamCpuAsync.hpp
+++ b/include/alpaka/stream/StreamCpuAsync.hpp
@@ -119,9 +119,9 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST StreamCpuAsync(
                 dev::DevCpu const & dev) :
-                    m_spAsyncStreamCpu(std::make_shared<cpu::detail::StreamCpuAsyncImpl>(dev))
+                    m_spStreamImpl(std::make_shared<cpu::detail::StreamCpuAsyncImpl>(dev))
             {
-                dev.m_spDevCpuImpl->RegisterAsyncStream(m_spAsyncStreamCpu);
+                dev.m_spDevCpuImpl->RegisterAsyncStream(m_spStreamImpl);
             }
             //-----------------------------------------------------------------------------
             //! Copy constructor.
@@ -145,7 +145,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCpuAsync const & rhs) const
             -> bool
             {
-                return (m_spAsyncStreamCpu == rhs.m_spAsyncStreamCpu);
+                return (m_spStreamImpl == rhs.m_spStreamImpl);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.
@@ -161,7 +161,7 @@ namespace alpaka
             ALPAKA_FN_HOST ~StreamCpuAsync() = default;
 
         public:
-            std::shared_ptr<cpu::detail::StreamCpuAsyncImpl> m_spAsyncStreamCpu;
+            std::shared_ptr<cpu::detail::StreamCpuAsyncImpl> m_spStreamImpl;
         };
     }
 
@@ -192,7 +192,7 @@ namespace alpaka
                     stream::StreamCpuAsync const & stream)
                 -> dev::DevCpu
                 {
-                    return stream.m_spAsyncStreamCpu->m_dev;
+                    return stream.m_spStreamImpl->m_dev;
                 }
             };
         }
@@ -241,7 +241,7 @@ namespace alpaka
                 {
 // Workaround: Clang can not support this when natively compiling device code. See ConcurrentExecPool.hpp.
 #if !(BOOST_COMP_CLANG_CUDA && BOOST_ARCH_CUDA_DEVICE)
-                    stream.m_spAsyncStreamCpu->m_workerThread.enqueueTask(
+                    stream.m_spStreamImpl->m_workerThread.enqueueTask(
                         task);
 #endif
                 }
@@ -260,7 +260,7 @@ namespace alpaka
                     stream::StreamCpuAsync const & stream)
                 -> bool
                 {
-                    return stream.m_spAsyncStreamCpu->m_workerThread.isQueueEmpty();
+                    return stream.m_spStreamImpl->m_workerThread.isQueueEmpty();
                 }
             };
         }

--- a/include/alpaka/stream/StreamCpuAsync.hpp
+++ b/include/alpaka/stream/StreamCpuAsync.hpp
@@ -30,9 +30,6 @@
 
 #include <alpaka/core/ConcurrentExecPool.hpp>   // core::ConcurrentExecPool
 
-#include <boost/uuid/uuid.hpp>                  // boost::uuids::uuid
-#include <boost/uuid/uuid_generators.hpp>       // boost::uuids::random_generator
-
 #include <type_traits>                          // std::is_base
 #include <thread>                               // std::thread
 #include <mutex>                                // std::mutex
@@ -77,7 +74,6 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST StreamCpuAsyncImpl(
                         dev::DevCpu const & dev) :
-                            m_uuid(boost::uuids::random_generator()()),
                             m_dev(dev),
                             m_workerThread(1u)
                     {}
@@ -105,7 +101,6 @@ namespace alpaka
                         m_dev.m_spDevCpuImpl->UnregisterAsyncStream(this);
                     }
                 public:
-                    boost::uuids::uuid const m_uuid;    //!< The unique ID.
                     dev::DevCpu const m_dev;            //!< The device this stream is bound to.
 
                     ThreadPool m_workerThread;
@@ -150,7 +145,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCpuAsync const & rhs) const
             -> bool
             {
-                return (m_spAsyncStreamCpu->m_uuid == rhs.m_spAsyncStreamCpu->m_uuid);
+                return (m_spAsyncStreamCpu == rhs.m_spAsyncStreamCpu);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.

--- a/include/alpaka/stream/StreamCpuSync.hpp
+++ b/include/alpaka/stream/StreamCpuSync.hpp
@@ -29,8 +29,6 @@
 #include <alpaka/wait/Traits.hpp>               // CurrentThreadWaitFor, WaiterWaitFor
 
 #include <boost/core/ignore_unused.hpp>         // boost::ignore_unused
-#include <boost/uuid/uuid.hpp>                  // boost::uuids::uuid
-#include <boost/uuid/uuid_generators.hpp>       // boost::uuids::random_generator
 
 namespace alpaka
 {
@@ -59,7 +57,6 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST StreamCpuSyncImpl(
                         dev::DevCpu const & dev) :
-                            m_uuid(boost::uuids::random_generator()()),
                             m_dev(dev)
                     {}
                     //-----------------------------------------------------------------------------
@@ -84,7 +81,6 @@ namespace alpaka
                     ALPAKA_FN_HOST ~StreamCpuSyncImpl() = default;
 
                 public:
-                    boost::uuids::uuid const m_uuid;    //!< The unique ID.
                     dev::DevCpu const m_dev;            //!< The device this stream is bound to.
                 };
             }
@@ -125,7 +121,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCpuSync const & rhs) const
             -> bool
             {
-                return (m_spSyncStreamCpu->m_uuid == rhs.m_spSyncStreamCpu->m_uuid);
+                return (m_spSyncStreamCpu == rhs.m_spSyncStreamCpu);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.

--- a/include/alpaka/stream/StreamCpuSync.hpp
+++ b/include/alpaka/stream/StreamCpuSync.hpp
@@ -97,7 +97,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST StreamCpuSync(
                 dev::DevCpu const & dev) :
-                    m_spSyncStreamCpu(std::make_shared<cpu::detail::StreamCpuSyncImpl>(dev))
+                    m_spStreamImpl(std::make_shared<cpu::detail::StreamCpuSyncImpl>(dev))
             {}
             //-----------------------------------------------------------------------------
             //! Copy constructor.
@@ -121,7 +121,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCpuSync const & rhs) const
             -> bool
             {
-                return (m_spSyncStreamCpu == rhs.m_spSyncStreamCpu);
+                return (m_spStreamImpl == rhs.m_spStreamImpl);
             }
             //-----------------------------------------------------------------------------
             //! Inequality comparison operator.
@@ -137,7 +137,7 @@ namespace alpaka
             ALPAKA_FN_HOST ~StreamCpuSync() = default;
 
         public:
-            std::shared_ptr<cpu::detail::StreamCpuSyncImpl> m_spSyncStreamCpu;
+            std::shared_ptr<cpu::detail::StreamCpuSyncImpl> m_spStreamImpl;
         };
     }
 
@@ -168,7 +168,7 @@ namespace alpaka
                     stream::StreamCpuSync const & stream)
                 -> dev::DevCpu
                 {
-                    return stream.m_spSyncStreamCpu->m_dev;
+                    return stream.m_spStreamImpl->m_dev;
                 }
             };
         }

--- a/include/alpaka/stream/StreamCudaRtAsync.hpp
+++ b/include/alpaka/stream/StreamCudaRtAsync.hpp
@@ -166,7 +166,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCudaRtAsync const & rhs) const
             -> bool
             {
-                return (m_spStreamCudaRtAsyncImpl->m_CudaStream == rhs.m_spStreamCudaRtAsyncImpl->m_CudaStream);
+                return (m_spStreamCudaRtAsyncImpl == rhs.m_spStreamCudaRtAsyncImpl);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.

--- a/include/alpaka/stream/StreamCudaRtAsync.hpp
+++ b/include/alpaka/stream/StreamCudaRtAsync.hpp
@@ -142,7 +142,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST StreamCudaRtAsync(
                 dev::DevCudaRt const & dev) :
-                m_spStreamCudaRtAsyncImpl(std::make_shared<cuda::detail::StreamCudaRtAsyncImpl>(dev))
+                m_spStreamImpl(std::make_shared<cuda::detail::StreamCudaRtAsyncImpl>(dev))
             {}
             //-----------------------------------------------------------------------------
             //! Copy constructor.
@@ -166,7 +166,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCudaRtAsync const & rhs) const
             -> bool
             {
-                return (m_spStreamCudaRtAsyncImpl == rhs.m_spStreamCudaRtAsyncImpl);
+                return (m_spStreamImpl == rhs.m_spStreamImpl);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.
@@ -182,7 +182,7 @@ namespace alpaka
             ALPAKA_FN_HOST ~StreamCudaRtAsync() = default;
 
         public:
-            std::shared_ptr<cuda::detail::StreamCudaRtAsyncImpl> m_spStreamCudaRtAsyncImpl;
+            std::shared_ptr<cuda::detail::StreamCudaRtAsyncImpl> m_spStreamImpl;
         };
     }
 
@@ -213,7 +213,7 @@ namespace alpaka
                     stream::StreamCudaRtAsync const & stream)
                 -> dev::DevCudaRt
                 {
-                    return stream.m_spStreamCudaRtAsyncImpl->m_dev;
+                    return stream.m_spStreamImpl->m_dev;
                 }
             };
         }
@@ -282,7 +282,7 @@ namespace alpaka
                     auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamAddCallback(
-                        stream.m_spStreamCudaRtAsyncImpl->m_CudaStream,
+                        stream.m_spStreamImpl->m_CudaStream,
                         cudaRtCallback,
                         pCallbackSynchronizationData.get(),
                         0u));
@@ -329,7 +329,7 @@ namespace alpaka
                     cudaError_t ret = cudaSuccess;
                     ALPAKA_CUDA_RT_CHECK_IGNORE(
                         ret = cudaStreamQuery(
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream),
+                            stream.m_spStreamImpl->m_CudaStream),
                         cudaErrorNotReady);
                     return (ret == cudaSuccess);
                 }
@@ -361,7 +361,7 @@ namespace alpaka
                     // Sync is allowed even for streams on non current device.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaStreamSynchronize(
-                            stream.m_spStreamCudaRtAsyncImpl->m_CudaStream));
+                            stream.m_spStreamImpl->m_CudaStream));
                 }
             };
         }

--- a/include/alpaka/stream/StreamCudaRtSync.hpp
+++ b/include/alpaka/stream/StreamCudaRtSync.hpp
@@ -166,7 +166,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCudaRtSync const & rhs) const
             -> bool
             {
-                return (m_spStreamCudaRtSyncImpl->m_CudaStream == rhs.m_spStreamCudaRtSyncImpl->m_CudaStream);
+                return (m_spStreamCudaRtSyncImpl == rhs.m_spStreamCudaRtSyncImpl);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.

--- a/include/alpaka/stream/StreamCudaRtSync.hpp
+++ b/include/alpaka/stream/StreamCudaRtSync.hpp
@@ -142,7 +142,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST StreamCudaRtSync(
                 dev::DevCudaRt const & dev) :
-                m_spStreamCudaRtSyncImpl(std::make_shared<cuda::detail::StreamCudaRtSyncImpl>(dev))
+                m_spStreamImpl(std::make_shared<cuda::detail::StreamCudaRtSyncImpl>(dev))
             {}
             //-----------------------------------------------------------------------------
             //! Copy constructor.
@@ -166,7 +166,7 @@ namespace alpaka
             ALPAKA_FN_HOST auto operator==(StreamCudaRtSync const & rhs) const
             -> bool
             {
-                return (m_spStreamCudaRtSyncImpl == rhs.m_spStreamCudaRtSyncImpl);
+                return (m_spStreamImpl == rhs.m_spStreamImpl);
             }
             //-----------------------------------------------------------------------------
             //! Equality comparison operator.
@@ -182,7 +182,7 @@ namespace alpaka
             ALPAKA_FN_HOST ~StreamCudaRtSync() = default;
 
         public:
-            std::shared_ptr<cuda::detail::StreamCudaRtSyncImpl> m_spStreamCudaRtSyncImpl;
+            std::shared_ptr<cuda::detail::StreamCudaRtSyncImpl> m_spStreamImpl;
         };
     }
 
@@ -213,7 +213,7 @@ namespace alpaka
                     stream::StreamCudaRtSync const & stream)
                 -> dev::DevCudaRt
                 {
-                    return stream.m_spStreamCudaRtSyncImpl->m_dev;
+                    return stream.m_spStreamImpl->m_dev;
                 }
             };
         }
@@ -282,7 +282,7 @@ namespace alpaka
                     auto pCallbackSynchronizationData = std::make_shared<CallbackSynchronizationData>();
 
                     ALPAKA_CUDA_RT_CHECK(cudaStreamAddCallback(
-                        stream.m_spStreamCudaRtSyncImpl->m_CudaStream,
+                        stream.m_spStreamImpl->m_CudaStream,
                         cudaRtCallback,
                         pCallbackSynchronizationData.get(),
                         0u));
@@ -322,7 +322,7 @@ namespace alpaka
                     cudaError_t ret = cudaSuccess;
                     ALPAKA_CUDA_RT_CHECK_IGNORE(
                         ret = cudaStreamQuery(
-                            stream.m_spStreamCudaRtSyncImpl->m_CudaStream),
+                            stream.m_spStreamImpl->m_CudaStream),
                         cudaErrorNotReady);
                     return (ret == cudaSuccess);
                 }
@@ -353,7 +353,7 @@ namespace alpaka
 
                     // Sync is allowed even for streams on non current device.
                     ALPAKA_CUDA_RT_CHECK(cudaStreamSynchronize(
-                        stream.m_spStreamCudaRtSyncImpl->m_CudaStream));
+                        stream.m_spStreamImpl->m_CudaStream));
                 }
             };
         }

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -283,7 +283,7 @@ namespace alpaka
                     auto const enqueueCount = spEventImpl->m_enqueueCount;
 
                     // Enqueue a task that only resets the events flag if it is completed.
-                    stream.m_spAsyncStreamCpu->m_workerThread.enqueueTask(
+                    stream.m_spStreamImpl->m_workerThread.enqueueTask(
                         [spEventImpl, enqueueCount]()
                         {
                             std::unique_lock<std::mutex> lk2(spEventImpl->m_mutex);

--- a/test/sanitizer_ubsan_blacklist.txt
+++ b/test/sanitizer_ubsan_blacklist.txt
@@ -1,7 +1,5 @@
 # boost/random/mersenne_twister.hpp:152:23: runtime error: unsigned integer overflow: 1812433253 * 5489 cannot be represented in type 'unsigned int'
 src:*/boost/random/mersenne_twister.hpp
-# boost/uuid/sha1.hpp:171:43: runtime error: unsigned integer overflow: 3903086636 + 2562383102 cannot be represented in type 'unsigned int'
-src:*/boost/uuid/sha1.hpp
 # /usr/include/tbb/task.h:705:30: runtime error: member call on address 0x7ff8ceee3200 which does not point to an object of type 'tbb::internal::scheduler'
 src:*/tbb/task.h
 # /usr/lib/gcc/x86_64-linux-gnu/5.4.1/../../../../include/c++/5.4.1/memory:118:54: runtime error: negation of 64 cannot be represented in type 'size_t' (aka 'unsigned long')


### PR DESCRIPTION
* remove uuid from CPU event and streams because it is unused. It was used in a very old version when the event implementations themselves had not been shared_ptr`s.
* replace comparison of underlying CUDA event/stream with comparison of impl shared_ptr (one less indirection and a raw pointer comparison instead of an unknown `operator==`) -> now identical to CPU
* rename all stream impl members to shorter and identical names for clearness. The same has already been done for the event impls

This is best reviewed commit by commit but everything belongs thematically together.