### PR TITLE
Doc: No __CUDA_VER__

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -68,7 +68,7 @@
 // nvcc CUDA compiler detection
 //-----------------------------------------------------------------------------
 #if defined(__CUDACC__) && defined(__NVCC__)
-    // The __CUDACC_VER__, __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__ and __CUDACC_VER_BUILD__
+    // The __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__ and __CUDACC_VER_BUILD__
     // have been added with nvcc 7.5 and have not been available before.
     #if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__) || !defined(__CUDACC_VER_BUILD__)
         #define BOOST_COMP_NVCC BOOST_VERSION_NUMBER_AVAILABLE


### PR DESCRIPTION
The `__CUDA_VER__` define only existed between CUDA 7.5 and 8.0.
Let us not mention it, so nobody gets the idea to use it.