### PR TITLE
test event: fix broken linker step

### DIFF
--- a/test/unit/event/src/main.cpp
+++ b/test/unit/event/src/main.cpp
@@ -18,7 +18,9 @@
  * along with alpaka.
  * If not, see <http://www.gnu.org/licenses/>.
  */
-
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE event
 
 #include <boost/predef.h>   // BOOST_COMP_CLANG


### PR DESCRIPTION
fix linker error if `ALPAKA_ACC_GPU_CUDA_ENABLE` is enabled.

This bug was introduced with #396 and mentioned in post https://github.com/ComputationalRadiationPhysics/alpaka/pull/396#issuecomment-331438871, but I missed that this change is needed do to my environment was not fully clean and this patch was always used in all of my tests in #396.

```
/usr/lib/x86_64-linux-gnu/crt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status
make[2]: *** [event] Error 1
make[1]: *** [CMakeFiles/event.dir/all] Error 2
make: *** [all] Error 2
```

- [ ] do not merge this will maybe fixed with #417