### PR TITLE
host `constexpr` within device code

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -350,6 +350,10 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
 
                 IF(NOT CUDA_VERSION VERSION_LESS 7.5)
                     LIST(APPEND CUDA_NVCC_FLAGS "--expt-extended-lambda")
+                    LIST(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+                ELSE()
+                    # CUDA 7.0
+                    LIST(APPEND CUDA_NVCC_FLAGS "--relaxed-constexpr")
                 ENDIF()
 
                 FOREACH(_CUDA_ARCH_ELEM ${ALPAKA_CUDA_ARCH})

--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -369,10 +369,10 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
                 IF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
                     LIST(APPEND CUDA_NVCC_FLAGS "-g")
                     # https://github.com/ComputationalRadiationPhysics/alpaka/issues/428
-                    IF(CMAKE_COMPILER_IS_GNUCXX AND
-                       CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0 AND
-                       CUDA_VERSION VERSION_EQUAL 8.0)
-                        MESSAGE(WARNING "GCC 4.9 does not support -G with CUDA8! "
+                    IF(((CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0) OR
+                        (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)) AND
+                        CUDA_VERSION VERSION_LESS 9.0)
+                        MESSAGE(WARNING "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} not support -G with CUDA <= 8! "
                                         "Device debug symbols NOT added.")
                     ELSE()
                         LIST(APPEND CUDA_NVCC_FLAGS "-G")

--- a/test/unit/kernel/src/KernelWithHostConstexpr.cpp
+++ b/test/unit/kernel/src/KernelWithHostConstexpr.cpp
@@ -1,0 +1,99 @@
+/**
+ * \file
+ * Copyright 2017 Rene Widera, Benjamin Worpitz
+ *
+ * This file is part of alpaka.
+ *
+ * alpaka is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * alpaka is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with alpaka.
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// \Hack: Boost.MPL defines BOOST_MPL_CFG_GPU_ENABLED to __host__ __device__ if nvcc is used.
+// BOOST_AUTO_TEST_CASE_TEMPLATE and its internals are not GPU enabled but is using boost::mpl::for_each internally.
+// For each template parameter this leads to:
+// /home/travis/build/boost/boost/mpl/for_each.hpp(78): warning: calling a __host__ function from a __host__ __device__ function is not allowed
+// because boost::mpl::for_each has the BOOST_MPL_CFG_GPU_ENABLED attribute but the test internals are pure host methods.
+// Because we do not use MPL within GPU code here, we can disable the MPL GPU support.
+#define BOOST_MPL_CFG_GPU_ENABLED
+
+#include <alpaka/alpaka.hpp>
+#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
+#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+
+#include <boost/predef.h>                           // BOOST_COMP_CLANG
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wunused-parameter"
+#endif
+#include <boost/test/unit_test.hpp>
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
+
+#include <limits>
+
+BOOST_AUTO_TEST_SUITE(kernel)
+
+//#############################################################################
+//!
+//#############################################################################
+class KernelWithHostConstexpr
+{
+public:
+    //-----------------------------------------------------------------------------
+    //!
+    //-----------------------------------------------------------------------------
+    ALPAKA_NO_HOST_ACC_WARNING
+    template<typename TAcc>
+    ALPAKA_FN_ACC auto operator()(
+        TAcc const & acc) const
+    -> void
+    {
+        // Do something useless on the accelerator.
+        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        
+        constexpr double epsilon = std::numeric_limits< double >::epsilon();
+        this->ignoreUnused(epsilon);
+    }
+private:
+    //! ignore unused variables
+    template<typename T>
+    ALPAKA_FN_ACC auto ignoreUnused(T const &) const
+    -> void
+    {}
+};
+
+//-----------------------------------------------------------------------------
+//
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    kernelWithHostConstexpr,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Size = alpaka::size::Size<TAcc>;
+
+    alpaka::test::KernelExecutionFixture<TAcc> fixture(
+        alpaka::vec::Vec<Dim, Size>::ones());
+
+    KernelWithHostConstexpr kernel;
+
+    BOOST_REQUIRE_EQUAL(
+        true,
+        fixture(
+            kernel));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- add nvcc compiler flag to allow usage of host constexpr functions within device code
- add test case to validate host constexpr usage within the device

# Note
The clang cuda compiler support this feature by default (tested with clang 4.0)

- [ ] do not merge (I added a test commit to disable `-G`)