### PR TITLE
fix comparison warning in `Vec.hpp`

### DIFF
--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -361,7 +361,7 @@ namespace alpaka
             {
                 core::assertValueUnsigned(iIdx);
                 auto const idx(static_cast<typename TDim::value_type>(iIdx));
-                assert(idx<TDim::value);
+                assert(TDim::value > 0u && idx<TDim::value);
                 return m_data[idx];
             }
 
@@ -380,7 +380,7 @@ namespace alpaka
             {
                 core::assertValueUnsigned(iIdx);
                 auto const idx(static_cast<typename TDim::value_type>(iIdx));
-                assert(idx<TDim::value);
+                assert(TDim::value > 0u && idx<TDim::value);
                 return m_data[idx];
             }
 


### PR DESCRIPTION
fix warning:
```
alpaka/include/alpaka/vec/Vec.hpp(383): warning: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "auto alpaka::vec::Vec<TDim, TSize>::operator[](TIdx) const->TSize [with TDim=alpaka::dim::DimInt<0UL>, TSize=uint16_t, TIdx=std::size_t, <unnamed>=void]"
```