### PR TITLE
Do not add -G on Debug when using gcc 4.9 and CUDA 8

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -366,8 +366,17 @@ IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
 
                 SET(CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
 
-                if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-                    LIST(APPEND CUDA_NVCC_FLAGS "-g" "-G")
+                IF(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+                    LIST(APPEND CUDA_NVCC_FLAGS "-g")
+                    # https://github.com/ComputationalRadiationPhysics/alpaka/issues/428
+                    IF(CMAKE_COMPILER_IS_GNUCXX AND
+                       CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0 AND
+                       CUDA_VERSION VERSION_EQUAL 8.0)
+                        MESSAGE(WARNING "GCC 4.9 does not support -G with CUDA8! "
+                                        "Device debug symbols NOT added.")
+                    ELSE()
+                        LIST(APPEND CUDA_NVCC_FLAGS "-G")
+                    ENDIF()
                 ENDIF()
 
                 IF(ALPAKA_CUDA_FAST_MATH)


### PR DESCRIPTION
For alpaka supported GCC versions less then 5.X, do not automatically add device debug symbols with `-G`.

This also warns the user verbosely when tried. See report in #428.