### PR TITLE
add clang declval implementation

### DIFF
--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -98,6 +98,7 @@
 #include <alpaka/core/OpenMp.hpp>
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Unroll.hpp>
+#include <alpaka/core/Utility.hpp>
 #include <alpaka/core/Vectorize.hpp>
 
 //-----------------------------------------------------------------------------

--- a/include/alpaka/core/Utility.hpp
+++ b/include/alpaka/core/Utility.hpp
@@ -1,0 +1,53 @@
+/**
+* \file
+* Copyright 2017 Rene Widera
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA
+#   include <type_traits> // std::add_rvalue_reference
+#else
+#   include <utility> // std::declval
+#endif
+
+
+namespace alpaka
+{
+    namespace core
+    {
+        //-----------------------------------------------------------------------------
+        //! convert any type to a reverence type
+        //
+        // This function is equivalent to std::declval() but can be used
+        // within an alpaka accelerator kernel too.
+        // This function can be used only within std::decltype().
+        //-----------------------------------------------------------------------------
+#if BOOST_LANG_CUDA && BOOST_COMP_CLANG_CUDA
+        template< class T >
+        ALPAKA_FN_HOST_ACC
+        typename std::add_rvalue_reference<T>::type
+        declval();
+#else
+        using std::declval;
+#endif
+    }
+}


### PR DESCRIPTION
- add for clang CUDA compiler a `declval` implementation (can be used on host and device)
- fallback to `sdt::declval` for non clang compiler

Note: We need this function within PIConGPU but this is a so fundamental method that alpaka is the right place to hold the implementation.

std::declval can not be used on the device if CUDA code is compiled with clang
```
c++/5.3.0/type_traits:2202:5: note: candidate function not viable: call to __host__ 
function from __device__ function
    declval() noexcept
```