### PR TITLE
fix: crash if no available CUDA device

### DIFF
--- a/include/alpaka/pltf/PltfCudaRt.hpp
+++ b/include/alpaka/pltf/PltfCudaRt.hpp
@@ -90,7 +90,9 @@ namespace alpaka
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     int iNumDevices(0);
-                    ALPAKA_CUDA_RT_CHECK(cudaGetDeviceCount(&iNumDevices));
+                    cudaError_t error = cudaGetDeviceCount(&iNumDevices);
+                    if(error != cudaSuccess)
+                        iNumDevices = 0;
 
                     return static_cast<std::size_t>(iNumDevices);
                 }


### PR DESCRIPTION
If the CUDA backe-end is enabled and `getDevCount()` is called and there
is no CUDA device available than alpaka will exit with an error.
This is not necessary because if tehre is no device available than the number of
devices is zero.

- return zero if there is no device available