### PR TITLE
Tests: Fix Undefined Define

### DIFF
--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -314,14 +314,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     alpaka::test::acc::TestAccs)
 {
     // This test exceeds the maximum compilation time.
-#if !ALPAKA_CI
+#if !defined(ALPAKA_CI)
     TestAtomicOperations<TAcc, std::int8_t>::testAtomicOperations();
     TestAtomicOperations<TAcc, std::uint8_t>::testAtomicOperations();
     TestAtomicOperations<TAcc, std::int16_t>::testAtomicOperations();
     TestAtomicOperations<TAcc, std::uint16_t>::testAtomicOperations();
 #endif
     TestAtomicOperations<TAcc, std::int32_t>::testAtomicOperations();
-#if !ALPAKA_CI
+#if !defined(ALPAKA_CI)
     TestAtomicOperations<TAcc, std::uint32_t>::testAtomicOperations();
     TestAtomicOperations<TAcc, std::int64_t>::testAtomicOperations();
     TestAtomicOperations<TAcc, std::uint64_t>::testAtomicOperations();

--- a/test/unit/kernel/src/KernelLambda.cpp
+++ b/test/unit/kernel/src/KernelLambda.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_SUITE(kernel)
 // So with nvcc 7.5 this only works in CUDA only mode or by using ALPAKA_FN_ACC_CUDA_ONLY instead of ALPAKA_FN_ACC
 #if !BOOST_COMP_NVCC || BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(8, 0, 0) || defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE)
 
-#if !ALPAKA_CI
+#if !defined(ALPAKA_CI)
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE(
     lambdaKernelIsWorking,
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
 // Generic lambdas are a C++14 feature.
 #if !defined(BOOST_NO_CXX14_GENERIC_LAMBDAS)
-#if !ALPAKA_CI
+#if !defined(ALPAKA_CI)
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE(
     genericLambdaKernelIsWorking,


### PR DESCRIPTION
`ALPAKA_CI` is undefined in regular environments which crashes the build during compile.