### PR TITLE
CMake: Root Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,26 @@
 #
 
 ################################################################################
-# Required CMake version.
+# Required CMake version
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.7.0)
 
-PROJECT("alpakaAll")
+project("alpakaAll")
+
+################################################################################
+# Options and Variants
+
+option(alpaka_BUILD_EXAMPLES "Build the examples" ON)
+
+include(CTest)
+# automatically defines: BUILD_TESTING, default is ON
 
 ################################################################################
 # Add subdirectories.
 
-ADD_SUBDIRECTORY("example/")
-ADD_SUBDIRECTORY("test/")
+if(alpaka_BUILD_EXAMPLES)
+    add_subdirectory("example/")
+endif()
+if(BUILD_TESTING)
+    add_subdirectory("test/")
+endif()

--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -106,5 +106,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(headerCheck PROPERTIES FOLDER "test/analysis")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/integ/cudaOnly/CMakeLists.txt
+++ b/test/integ/cudaOnly/CMakeLists.txt
@@ -81,5 +81,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/integ")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/acc/CMakeLists.txt
+++ b/test/unit/acc/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/atomic/CMakeLists.txt
+++ b/test/unit/atomic/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/block/shared/CMakeLists.txt
+++ b/test/unit/block/shared/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/block/sync/CMakeLists.txt
+++ b/test/unit/block/sync/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/event/CMakeLists.txt
+++ b/test/unit/event/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/idx/CMakeLists.txt
+++ b/test/unit/idx/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/kernel/CMakeLists.txt
+++ b/test/unit/kernel/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/mem/buf/CMakeLists.txt
+++ b/test/unit/mem/buf/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/mem/view/CMakeLists.txt
+++ b/test/unit/mem/view/CMakeLists.txt
@@ -88,5 +88,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/meta/CMakeLists.txt
+++ b/test/unit/meta/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/queue/CMakeLists.txt
+++ b/test/unit/queue/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/rand/CMakeLists.txt
+++ b/test/unit/rand/CMakeLists.txt
@@ -87,5 +87,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/time/CMakeLists.txt
+++ b/test/unit/time/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/vec/CMakeLists.txt
+++ b/test/unit/vec/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})


### PR DESCRIPTION
Add options to control tests `BUILD_TESTING` (CMake-standardized) and examples `alpaka_BUILD_EXAMPLES` (project-specific).

Preparation for install #366 