### PR TITLE
CMake: Unify Requirement of 3.7.0+

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -18,8 +18,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# CUDA_SOURCE_PROPERTY_FORMAT is only supported starting from 3.3.0.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 #------------------------------------------------------------------------------
 # Calls CUDA_ADD_EXECUTABLE or ADD_EXECUTABLE depending on the enabled alpaka accelerators.

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -18,8 +18,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# CUDA_SOURCE_PROPERTY_FORMAT is only supported starting from 3.3.0.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 #------------------------------------------------------------------------------
 # Calls CUDA_ADD_LIBRARY or ADD_LIBRARY depending on the enabled alpaka

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaExamples")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaTest")
 

--- a/test/analysis/CMakeLists.txt
+++ b/test/analysis/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaAnalysisTest")
 

--- a/test/integ/CMakeLists.txt
+++ b/test/integ/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaIntegTest")
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaUnitTest")
 


### PR DESCRIPTION
Use proper CMake 3.7+ requirement in all CMake files.
Gets rid of warnings with older policies with upcoming changes for install #366 