### PR TITLE
[WIP] Installer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,25 @@
 #
 
 ################################################################################
-# Required CMake version
+# Preamble
 
 cmake_minimum_required(VERSION 3.7.0)
 
-project("alpakaAll")
+project(alpaka VERSION 0.3.0
+) # LANGUAGES CXX
+
+################################################################################
+# Project Structure
+
+# install directories
+set(CMAKE_INSTALL_BINDIR bin)
+set(CMAKE_INSTALL_LIBDIR lib)
+set(CMAKE_INSTALL_INCLUDEDIR include)
+if(WIN32)
+    set(CMAKE_INSTALL_CMAKEDIR)
+else()
+    set(CMAKE_INSTALL_CMAKEDIR)# lib/cmake/alpaka
+endif()
 
 ################################################################################
 # Options and Variants
@@ -34,7 +48,7 @@ include(CTest)
 # automatically defines: BUILD_TESTING, default is ON
 
 ################################################################################
-# Add subdirectories.
+# Tests and Examples
 
 if(alpaka_BUILD_EXAMPLES)
     add_subdirectory("example/")
@@ -42,3 +56,72 @@ endif()
 if(BUILD_TESTING)
     add_subdirectory("test/")
 endif()
+
+################################################################################
+# Generate Files with Configuration Options
+
+#configure_file(
+#    ${alpaka_SOURCE_DIR}/alpakaConfig.cmake.in
+#    ${alpaka_BINARY_DIR}/alpakaConfig.cmake
+#    @ONLY
+#)
+file(COPY
+    ${alpaka_SOURCE_DIR}/alpakaConfig.cmake
+    DESTINATION ${alpaka_BINARY_DIR}
+)
+
+include(CMakePackageConfigHelpers)
+
+# alpaka is a header-only library and thus independ on the architecture.
+# This removes the 32/64bit version specifier from the installed cmake package,
+# allowing to use a 32bit install on a 64bit machine and vice versa.
+set(_alpaka_CMAKE_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
+unset(CMAKE_SIZEOF_VOID_P)
+write_basic_package_version_file("alpakaConfigVersion.cmake"
+    VERSION ${alpaka_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+set(CMAKE_SIZEOF_VOID_P ${_alpaka_CMAKE_SIZEOF_VOID_P})
+
+################################################################################
+# Installs
+
+# headers
+install(DIRECTORY "${alpaka_SOURCE_DIR}/include"
+    DESTINATION include
+)
+
+# CMake package file for find_package(alpaka::alpaka) in depending projects
+#install(EXPORT alpakaTargets
+#    FILE alpakaTargets.cmake
+#    NAMESPACE alpaka::
+#    DESTINATION lib/cmake/alpaka
+#)
+install(
+    FILES
+        ${alpaka_BINARY_DIR}/alpakaConfig.cmake
+        ${alpaka_BINARY_DIR}/alpakaConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_CMAKEDIR}
+)
+
+################################################################################
+# Status Message for Build Options
+
+message("")
+message("alpaka build configuration:")
+message("  library Version: ${alpaka_VERSION}")
+message("  C++ Compiler: ${CMAKE_CXX_COMPILER_ID} "
+                        "${CMAKE_CXX_COMPILER_VERSION} "
+                        "${CMAKE_CXX_COMPILER_WRAPPER}")
+message("    ${CMAKE_CXX_COMPILER}")
+message("")
+message("  Installation prefix: ${CMAKE_INSTALL_PREFIX}")
+message("        bin: ${CMAKE_INSTALL_BINDIR}")
+message("        lib: ${CMAKE_INSTALL_LIBDIR}")
+message("    include: ${CMAKE_INSTALL_INCLUDEDIR}")
+message("      cmake: ${CMAKE_INSTALL_CMAKEDIR}")
+message("")
+message("  Build Type: ${CMAKE_BUILD_TYPE}")
+message("  Testing: ${BUILD_TESTING}")
+message("  Examples: ${alpaka_BUILD_EXAMPLES}")
+message("")

--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -542,7 +542,8 @@ SET_SOURCE_FILES_PROPERTIES(${_ALPAKA_FILES_OTHER} PROPERTIES HEADER_FILE_ONLY T
 #-------------------------------------------------------------------------------
 # Target.
 IF(NOT TARGET "alpaka")
-    ADD_LIBRARY("alpaka" INTERFACE)
+    ADD_LIBRARY(alpaka INTERFACE)
+    ADD_LIBRARY(${PROJECT_NAME}::alpaka ALIAS alpaka)
 
     # HACK: Workaround for the limitation that files added to INTERFACE targets (target_sources) can not be marked as PUBLIC or PRIVATE but only as INTERFACE.
     # Therefore those files will be added to projects "linking" to the INTERFACE library, but are not added to the project itself within an IDE.

--- a/newVersion.sh
+++ b/newVersion.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017-2018 Axel Huebl
+#
+# This file is part of alpaka.
+#
+# alpaka is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# alpaka is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with alpaka.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+set -o pipefail
+
+# This file is a maintainer tool to bump the versions inside Alpaka's
+# source directory at all places where necessary.
+
+# Maintainer Inputs ###########################################################
+
+echo "Hi there, this is a Alpaka maintainer tool to update the source"
+echo "code of Alpaka to a new version number on all places where"
+echo "necessary."
+echo "For it to work, you need write access on the source directory and"
+echo "you should be working in a clean git branch without ongoing"
+echo "rebase/merge/conflict resolves and without unstaged changes."
+
+# check source dir
+REPO_DIR=$(cd $(dirname $BASH_SOURCE) && pwd)
+echo
+echo "Your current source directory is: $REPO_DIR"
+echo
+
+read -p "Are you sure you want to continue? [y/N] " -r
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "You did not confirm with 'y', aborting."
+    exit 1
+fi
+
+echo "We will now run a few sed commands on your source directory."
+echo "Please answer the following questions about the version number"
+echo "you want to set first:"
+echo
+
+read -p "MAJOR version? (e.g. 1) " -r
+MAJOR=$REPLY
+echo
+read -p "MINOR version? (e.g. 2) " -r
+MINOR=$REPLY
+echo
+read -p "PATCH version? (e.g. 3) " -r
+PATCH=$REPLY
+echo
+#read -p "SUFFIX? (e.g. rc2, dev, ... or empty) " -r
+SUFFIX=""
+#SUFFIX=$REPLY
+#echo
+
+if [[ -n "$SUFFIX" ]]
+then
+    SUFFIX_STR="-$SUFFIX"
+fi
+
+VERSION_STR="$MAJOR.$MINOR.$PATCH$SUFFIX_STR"
+
+echo
+echo "Your new version is: $VERSION_STR"
+echo
+
+read -p "Is this information correct? Will now start updating! [y/N] " -r
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    echo "You did not confirm with 'y', aborting."
+    exit 1
+fi
+
+
+# Updates #####################################################################
+
+# Alpaka version.hpp
+#   include/alpaka/version.hpp
+sed -i 's/'\
+'[[:blank:]]*#[[:blank:]]*define[[:blank:]]\+ALPAKA_VERSION_MAJOR[[:blank:]]\+.*/'\
+'#define ALPAKA_VERSION_MAJOR '$MAJOR'/g' \
+    $REPO_DIR/include/alpaka/version.hpp
+sed -i 's/'\
+'[[:blank:]]*#[[:blank:]]*define[[:blank:]]\+ALPAKA_VERSION_MINOR[[:blank:]]\+.*/'\
+'#define ALPAKA_VERSION_MINOR '$MINOR'/g' \
+    $REPO_DIR/include/alpaka/version.hpp
+sed -i 's/'\
+'[[:blank:]]*#[[:blank:]]*define[[:blank:]]\+ALPAKA_VERSION_PATCH[[:blank:]]\+.*/'\
+'#define ALPAKA_VERSION_PATCH '$PATCH'/g' \
+    $REPO_DIR/include/alpaka/version.hpp
+#sed -i 's/'\
+#'[[:blank:]]*#[[:blank:]]*define[[:blank:]]\+ALPAKA_VERSION_LABEL[[:blank:]]\+.*/'\
+#'#define ALPAKA_VERSION_LABEL "'$SUFFIX'"/g' \
+#    $REPO_DIR/include/alpaka/version.hpp
+
+# `project(...)` version in CMakeLists.txt
+sed -i 's/'\
+'project(alpaka[[:blank:]]\+VERSION.*/'\
+'project(alpaka VERSION '$VERSION_STR'/g' \
+    $REPO_DIR/CMakeLists.txt
+
+
+# Epilog ######################################################################
+
+echo
+echo "Done. Please check your source, e.g. via"
+echo "  git diff"
+echo "now and commit the changes if no errors occured."


### PR DESCRIPTION
Prepares #366 

The goal is to "configure" - "build" (nothing to do) and "install" Alpaka just like any other C++ library via a standardized and well-defined CMake workflow.

### To Do

- [x] rebase against `develop`
- [ ] move logic from `alpakaConfig.cmake` to root `CMakeLists.txt`; generate `alpakaConfig.cmake`
- [ ] move and install helpers in `cmake/` as well
- [ ] remove `Findalpaka.cmake`: legacy script; only needed when a `*Config.cmake` package is not present
- [x] unset [`CMAKE_SIZEOF_VOID_P`](https://github.com/QuantStack/xtensor/blob/0.15.7/CMakeLists.txt#L167-L171) before creating `alpakaConfig.cmake`; [docs](https://cmake.org/cmake/help/v3.0/variable/CMAKE_SIZEOF_VOID_P.html)
- [ ] decide if `Alpaka` should be spelled uppercase in project name (and all CMake options/variables, config package, etc.)
- [ ] decide when to set `ALPAKA_ACC_...` vars: ideally allow *after* install as well

### References

- https://www.youtube.com/watch?v=bsXLMQ6WgIk
- https://cliutils.gitlab.io/modern-cmake/

Projects:
- https://github.com/openPMD/openPMD-api
- https://github.com/pngwriter/pngwriter
- https://github.com/QuantStack/xtensor