### PR TITLE
rename getProductOfExtent to getExtentProduct to be more consistent

### DIFF
--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -131,7 +131,7 @@ namespace alpaka
             template<
                 typename TExtent,
                 size_t... TIndices>
-            ALPAKA_FN_HOST_ACC auto getProductOfExtentInternal(
+            ALPAKA_FN_HOST_ACC auto getExtentProductInternal(
                 TExtent const & extent,
 #if BOOST_ARCH_CUDA_DEVICE
                 alpaka::meta::IndexSequence<TIndices...> const &)
@@ -155,13 +155,13 @@ namespace alpaka
         ALPAKA_NO_HOST_ACC_WARNING
         template<
             typename TExtent>
-        ALPAKA_FN_HOST_ACC auto getProductOfExtent(
+        ALPAKA_FN_HOST_ACC auto getExtentProduct(
             TExtent const & extent = TExtent())
         -> idx::Idx<TExtent>
         {
             using IdxSequence = alpaka::meta::MakeIndexSequence<dim::Dim<TExtent>::value>;
             return
-                detail::getProductOfExtentInternal(
+                detail::getExtentProductInternal(
                     extent,
                     IdxSequence());
         }

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -126,7 +126,7 @@ namespace alpaka
                             TExtent const & extent)
                         -> TIdx
                         {
-                            auto const extentElementCount(extent::getProductOfExtent(extent));
+                            auto const extentElementCount(extent::getExtentProduct(extent));
 
                             return extentElementCount;
                         }
@@ -472,7 +472,7 @@ namespace alpaka
                                 ALPAKA_CUDA_RT_CHECK_IGNORE(
                                     cudaHostRegister(
                                         const_cast<void *>(reinterpret_cast<void const *>(mem::view::getPtrNative(buf))),
-                                        extent::getProductOfExtent(buf) * sizeof(elem::Elem<buf::BufCpu<TElem, TDim, TIdx>>),
+                                        extent::getExtentProduct(buf) * sizeof(elem::Elem<buf::BufCpu<TElem, TDim, TIdx>>),
                                         cudaHostRegisterDefault),
                                     cudaErrorHostMemoryAlreadyRegistered);
 

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -671,7 +671,7 @@ namespace alpaka
                             ALPAKA_CUDA_RT_CHECK(
                                 cudaHostRegister(
                                     const_cast<void *>(reinterpret_cast<void const *>(mem::view::getPtrNative(buf))),
-                                    extent::getProductOfExtent(buf) * sizeof(elem::Elem<BufCpu<TElem, TDim, TIdx>>),
+                                    extent::getExtentProduct(buf) * sizeof(elem::Elem<BufCpu<TElem, TDim, TIdx>>),
                                     cudaHostRegisterMapped));
                         }
                         // If it is already the same device, nothing has to be mapped.

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -126,7 +126,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     // alpaka::mem::view::traits::GetPtrNative
                     {
-                        if(alpaka::extent::getProductOfExtent(view) != static_cast<TIdx>(0u))
+                        if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
                         {
                             // The pointer is only required to be non-null when the extent is > 0.
                             TElem const * const invalidPtr(nullptr);

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -287,7 +287,7 @@ struct MatMulTester
             << ", workDiv: " << workDiv
             << ")" << std::endl;
 
-        // Allocate the A and B matrices as st::vectors because this allows them to be filled with uint32_t(1).
+        // Allocate the A and B matrices as std::vectors because this allows them to be filled with uint32_t(1).
         // alpaka::mem::view::set only supports setting all bytes leading to a value of 16843009 in all elements.
         std::vector<Val> bufAHost1d(m * k, static_cast<Val>(1));
         std::vector<Val> bufBHost1d(k * n, static_cast<Val>(1));


### PR DESCRIPTION
I already mentioned this more than two years ago in #106.