### PR TITLE
ViewSubView clean up

### DIFF
--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -146,9 +146,7 @@ namespace alpaka
                         std::is_same<TDim, dim::Dim<TOffsets>>::value,
                         "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                    assert((offset::getOffsetX(relativeOffsetsElements)+extent::getWidth(extentElements)) <= extent::getWidth(view));
-                    assert((offset::getOffsetY(relativeOffsetsElements)+extent::getHeight(extentElements)) <= extent::getHeight(view));
-                    assert((offset::getOffsetZ(relativeOffsetsElements)+extent::getDepth(extentElements)) <= extent::getDepth(view));
+                    assert(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
                 }
                 //-----------------------------------------------------------------------------
                 //! Constructor.
@@ -197,9 +195,7 @@ namespace alpaka
                         std::is_same<TDim, dim::Dim<TOffsets>>::value,
                         "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                    assert((offset::getOffsetX(relativeOffsetsElements)+extent::getWidth(extentElements)) <= extent::getWidth(view));
-                    assert((offset::getOffsetY(relativeOffsetsElements)+extent::getHeight(extentElements)) <= extent::getHeight(view));
-                    assert((offset::getOffsetZ(relativeOffsetsElements)+extent::getDepth(extentElements)) <= extent::getDepth(view));
+                    assert(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
                 }
 
             public:

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -69,7 +69,7 @@ namespace alpaka
 
                     static_assert(
                         std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The idx type of TView and the TDev template parameter have to be identical!");
+                        "The dev type of TView and the TDev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -93,7 +93,7 @@ namespace alpaka
 
                     static_assert(
                         std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The idx type of TView and the TDev template parameter have to be identical!");
+                        "The dev type of TView and the TDev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -124,7 +124,7 @@ namespace alpaka
 
                     static_assert(
                         std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The idx type of TView and the TDev template parameter have to be identical!");
+                        "The dev type of TView and the TDev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -173,7 +173,7 @@ namespace alpaka
 
                     static_assert(
                         std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The idx type of TView and the TDev template parameter have to be identical!");
+                        "The dev type of TView and the TDev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -51,11 +51,6 @@ namespace alpaka
             class ViewSubView
             {
             public:
-                using Dev = TDev;
-                using Elem = TElem;
-                using Dim = TDim;
-
-            public:
                 //-----------------------------------------------------------------------------
                 //! \param view The view this view is a sub-view of.
                 template<
@@ -65,12 +60,20 @@ namespace alpaka
                         m_viewParentView(
                             mem::view::getPtrNative(view),
                             dev::getDev(view),
-                            extent::getExtentVecEnd<TDim>(view),
-                            mem::view::getPitchBytesVecEnd<TDim>(view)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(view)),
+                            extent::getExtentVec(view),
+                            mem::view::getPitchBytesVec(view)),
+                        m_extentElements(extent::getExtentVec(view)),
                         m_offsetsElements(vec::Vec<TDim, TIdx>::all(0))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                    static_assert(
+                        std::is_same<TDev, dev::Dev<TView>>::value,
+                        "The idx type of TView and the TDev template parameter have to be identical!");
+
+                    static_assert(
+                        std::is_same<TIdx, idx::Idx<TView>>::value,
+                        "The idx type of TView and the TIdx template parameter have to be identical!");
                 }
                 //-----------------------------------------------------------------------------
                 //! \param view The view this view is a sub-view of.
@@ -81,12 +84,16 @@ namespace alpaka
                         m_viewParentView(
                             mem::view::getPtrNative(view),
                             dev::getDev(view),
-                            extent::getExtentVecEnd<TDim>(view),
-                            mem::view::getPitchBytesVecEnd<TDim>(view)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(view)),
+                            extent::getExtentVec(view),
+                            mem::view::getPitchBytesVec(view)),
+                        m_extentElements(extent::getExtentVec(view)),
                         m_offsetsElements(vec::Vec<TDim, TIdx>::all(0))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
+
+                    static_assert(
+                        std::is_same<TDev, dev::Dev<TView>>::value,
+                        "The idx type of TView and the TDev template parameter have to be identical!");
 
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TView>>::value,
@@ -108,22 +115,36 @@ namespace alpaka
                         m_viewParentView(
                             mem::view::getPtrNative(view),
                             dev::getDev(view),
-                            extent::getExtentVecEnd<TDim>(view),
-                            mem::view::getPitchBytesVecEnd<TDim>(view)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(extentElements)),
-                        m_offsetsElements(offset::getOffsetVecEnd<TDim>(relativeOffsetsElements))
+                            extent::getExtentVec(view),
+                            mem::view::getPitchBytesVec(view)),
+                        m_extentElements(extent::getExtentVec(extentElements)),
+                        m_offsetsElements(offset::getOffsetVec(relativeOffsetsElements))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     static_assert(
-                        std::is_same<TDim, dim::Dim<TExtent>>::value,
-                        "The buffer and the extent are required to have the same dimensionality!");
+                        std::is_same<TDev, dev::Dev<TView>>::value,
+                        "The idx type of TView and the TDev template parameter have to be identical!");
+
+                    static_assert(
+                        std::is_same<TIdx, idx::Idx<TView>>::value,
+                        "The idx type of TView and the TIdx template parameter have to be identical!");
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TExtent>>::value,
                         "The idx type of TExtent and the TIdx template parameter have to be identical!");
                     static_assert(
-                        std::is_same<TIdx, idx::Idx<TView>>::value,
-                        "The idx type of TView and the TIdx template parameter have to be identical!");
+                        std::is_same<TIdx, idx::Idx<TOffsets>>::value,
+                        "The idx type of TOffsets and the TIdx template parameter have to be identical!");
+
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TView>>::value,
+                        "The dim type of TView and the TDim template parameter have to be identical!");
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TExtent>>::value,
+                        "The dim type of TExtent and the TDim template parameter have to be identical!");
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TOffsets>>::value,
+                        "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
                     assert((offset::getOffsetX(relativeOffsetsElements)+extent::getWidth(extentElements)) <= extent::getWidth(view));
                     assert((offset::getOffsetY(relativeOffsetsElements)+extent::getHeight(extentElements)) <= extent::getHeight(view));
@@ -145,22 +166,36 @@ namespace alpaka
                         m_viewParentView(
                             mem::view::getPtrNative(view),
                             dev::getDev(view),
-                            extent::getExtentVecEnd<TDim>(view),
-                            mem::view::getPitchBytesVecEnd<TDim>(view)),
-                        m_extentElements(extent::getExtentVecEnd<TDim>(extentElements)),
-                        m_offsetsElements(offset::getOffsetVecEnd<TDim>(relativeOffsetsElements))
+                            extent::getExtentVec(view),
+                            mem::view::getPitchBytesVec(view)),
+                        m_extentElements(extent::getExtentVec(extentElements)),
+                        m_offsetsElements(offset::getOffsetVec(relativeOffsetsElements))
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                     static_assert(
-                        std::is_same<TDim, dim::Dim<TExtent>>::value,
-                        "The buffer and the extent are required to have the same dimensionality!");
+                        std::is_same<TDev, dev::Dev<TView>>::value,
+                        "The idx type of TView and the TDev template parameter have to be identical!");
+
+                    static_assert(
+                        std::is_same<TIdx, idx::Idx<TView>>::value,
+                        "The idx type of TView and the TIdx template parameter have to be identical!");
                     static_assert(
                         std::is_same<TIdx, idx::Idx<TExtent>>::value,
                         "The idx type of TExtent and the TIdx template parameter have to be identical!");
                     static_assert(
-                        std::is_same<TIdx, idx::Idx<TView>>::value,
-                        "The idx type of TView and the TIdx template parameter have to be identical!");
+                        std::is_same<TIdx, idx::Idx<TOffsets>>::value,
+                        "The idx type of TOffsets and the TIdx template parameter have to be identical!");
+
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TView>>::value,
+                        "The dim type of TView and the TDim template parameter have to be identical!");
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TExtent>>::value,
+                        "The dim type of TExtent and the TDim template parameter have to be identical!");
+                    static_assert(
+                        std::is_same<TDim, dim::Dim<TOffsets>>::value,
+                        "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
                     assert((offset::getOffsetX(relativeOffsetsElements)+extent::getWidth(extentElements)) <= extent::getWidth(view));
                     assert((offset::getOffsetY(relativeOffsetsElements)+extent::getHeight(extentElements)) <= extent::getHeight(view));

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -52,6 +52,8 @@ BOOST_AUTO_TEST_SUITE(memView)
 //! 2D: sizeof(TIdx) * (5, 4)
 //! 3D: sizeof(TIdx) * (5, 4, 3)
 //! 4D: sizeof(TIdx) * (5, 4, 3, 2)
+// We have to be careful with the extents used.
+// When Idx is a 8 bit signed integer and Dim is 4, the extent is extremely limited.
 //#############################################################################
 template<
     std::size_t Tidx>
@@ -108,8 +110,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
     Queue queue(dev);
 
-    // We have to be careful with the extents used.
-    // When Idx is a 8 bit signed integer and Dim is 4, the extent is extremely limited.
     auto const extentBuf(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentBufVal>(Idx()));
     auto buf(alpaka::mem::buf::alloc<Elem, Idx>(dev, extentBuf));
 


### PR DESCRIPTION
This cleans up the ViewSubView class by removing the incomplete support for change of dimension. This missing feature is already requested in #106 and if I find some time, I may be working on it in the future.