### PR TITLE
Rename internal task creation traits for clarity

### DIFF
--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -57,7 +57,7 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopyBase
+                    struct TaskCopyCpuBase
                     {
                         using ExtentSize = idx::Idx<TExtent>;
                         using DstSize = idx::Idx<TViewDst>;
@@ -86,7 +86,7 @@ namespace alpaka
                             "The source and the destination view are required to have the same element type!");
 
                         //-----------------------------------------------------------------------------
-                        TaskCopyBase(
+                        TaskCopyCpuBase(
                             TViewDst & viewDst,
                             TViewSrc const & viewSrc,
                             TExtent const & extent) :
@@ -148,15 +148,15 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy : public TaskCopyBase<TDim, TViewDst, TViewSrc, TExtent>
+                    struct TaskCopyCpu : public TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>
                     {
                         using DimMin1 = dim::DimInt<TDim::value - 1u>;
-                        using typename TaskCopyBase<TDim, TViewDst, TViewSrc, TExtent>::ExtentSize;
-                        using typename TaskCopyBase<TDim, TViewDst, TViewSrc, TExtent>::DstSize;
-                        using typename TaskCopyBase<TDim, TViewDst, TViewSrc, TExtent>::SrcSize;
+                        using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::ExtentSize;
+                        using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::DstSize;
+                        using typename TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::SrcSize;
 
                         //-----------------------------------------------------------------------------
-                        using TaskCopyBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopyBase;
+                        using TaskCopyCpuBase<TDim, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
 
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST auto operator()() const
@@ -194,14 +194,14 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy<
+                    struct TaskCopyCpu<
                         dim::DimInt<1u>,
                         TViewDst,
                         TViewSrc,
-                        TExtent> : public TaskCopyBase<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>
+                        TExtent> : public TaskCopyCpuBase<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>
                     {
                         //-----------------------------------------------------------------------------
-                        using TaskCopyBase<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopyBase;
+                        using TaskCopyCpuBase<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>::TaskCopyCpuBase;
 
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST auto operator()() const
@@ -232,7 +232,7 @@ namespace alpaka
                 //! Copies from CPU memory into CPU memory.
                 template<
                     typename TDim>
-                struct TaskCopy<
+                struct CreateTaskCopy<
                     TDim,
                     dev::DevCpu,
                     dev::DevCpu>
@@ -242,18 +242,18 @@ namespace alpaka
                         typename TExtent,
                         typename TViewSrc,
                         typename TViewDst>
-                    ALPAKA_FN_HOST static auto taskCopy(
+                    ALPAKA_FN_HOST static auto createTaskCopy(
                         TViewDst & viewDst,
                         TViewSrc const & viewSrc,
                         TExtent const & extent)
-                    -> cpu::detail::TaskCopy<
+                    -> cpu::detail::TaskCopyCpu<
                         TDim,
                         TViewDst,
                         TViewSrc,
                         TExtent>
                     {
                         return
-                            cpu::detail::TaskCopy<
+                            cpu::detail::TaskCopyCpu<
                                 TDim,
                                 TViewDst,
                                 TViewSrc,

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -54,7 +54,7 @@ namespace alpaka
                         typename TDim,
                         typename TView,
                         typename TExtent>
-                    struct TaskSetBase
+                    struct TaskSetCpuBase
                     {
                         using ExtentSize = idx::Idx<TExtent>;
                         using DstSize = idx::Idx<TView>;
@@ -72,7 +72,7 @@ namespace alpaka
                             "The view and the extent are required to have compatible idx type!");
 
                         //-----------------------------------------------------------------------------
-                        TaskSetBase(
+                        TaskSetCpuBase(
                             TView & view,
                             std::uint8_t const & byte,
                             TExtent const & extent) :
@@ -120,14 +120,14 @@ namespace alpaka
                         typename TDim,
                         typename TView,
                         typename TExtent>
-                    struct TaskSet : public TaskSetBase<TDim, TView, TExtent>
+                    struct TaskSetCpu : public TaskSetCpuBase<TDim, TView, TExtent>
                     {
                         using DimMin1 = dim::DimInt<TDim::value - 1u>;
-                        using typename TaskSetBase<TDim, TView, TExtent>::ExtentSize;
-                        using typename TaskSetBase<TDim, TView, TExtent>::DstSize;
+                        using typename TaskSetCpuBase<TDim, TView, TExtent>::ExtentSize;
+                        using typename TaskSetCpuBase<TDim, TView, TExtent>::DstSize;
 
                         //-----------------------------------------------------------------------------
-                        using TaskSetBase<TDim, TView, TExtent>::TaskSetBase;
+                        using TaskSetCpuBase<TDim, TView, TExtent>::TaskSetCpuBase;
 
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST auto operator()() const
@@ -163,13 +163,13 @@ namespace alpaka
                     template<
                         typename TView,
                         typename TExtent>
-                    struct TaskSet<
+                    struct TaskSetCpu<
                         dim::DimInt<1u>,
                         TView,
-                        TExtent> : public TaskSetBase<dim::DimInt<1u>, TView, TExtent>
+                        TExtent> : public TaskSetCpuBase<dim::DimInt<1u>, TView, TExtent>
                     {
                         //-----------------------------------------------------------------------------
-                        using TaskSetBase<dim::DimInt<1u>, TView, TExtent>::TaskSetBase;
+                        using TaskSetCpuBase<dim::DimInt<1u>, TView, TExtent>::TaskSetCpuBase;
 
                         //-----------------------------------------------------------------------------
                         ALPAKA_FN_HOST auto operator()() const
@@ -198,7 +198,7 @@ namespace alpaka
                 //! The CPU device memory set trait specialization.
                 template<
                     typename TDim>
-                struct TaskSet<
+                struct CreateTaskSet<
                     TDim,
                     dev::DevCpu>
                 {
@@ -206,17 +206,17 @@ namespace alpaka
                     template<
                         typename TExtent,
                         typename TView>
-                    ALPAKA_FN_HOST static auto taskSet(
+                    ALPAKA_FN_HOST static auto createTaskSet(
                         TView & view,
                         std::uint8_t const & byte,
                         TExtent const & extent)
-                    -> cpu::detail::TaskSet<
+                    -> cpu::detail::TaskSetCpu<
                         TDim,
                         TView,
                         TExtent>
                     {
                         return
-                            cpu::detail::TaskSet<
+                            cpu::detail::TaskSetCpu<
                                 TDim,
                                 TView,
                                 TExtent>(

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -61,7 +61,7 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy;
+                    struct TaskCopyCuda;
 
                     //#############################################################################
                     //! The 1D CUDA memory copy trait.
@@ -69,7 +69,7 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy<
+                    struct TaskCopyCuda<
                         dim::DimInt<1>,
                         TViewDst,
                         TViewSrc,
@@ -89,7 +89,7 @@ namespace alpaka
                         using Idx = idx::Idx<TExtent>;
 
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_HOST TaskCopy(
+                        ALPAKA_FN_HOST TaskCopyCuda(
                             TViewDst & viewDst,
                             TViewSrc const & viewSrc,
                             TExtent const & extent,
@@ -149,7 +149,7 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy<
+                    struct TaskCopyCuda<
                         dim::DimInt<2>,
                         TViewDst,
                         TViewSrc,
@@ -169,7 +169,7 @@ namespace alpaka
                         using Idx = idx::Idx<TExtent>;
 
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_HOST TaskCopy(
+                        ALPAKA_FN_HOST TaskCopyCuda(
                             TViewDst & viewDst,
                             TViewSrc const & viewSrc,
                             TExtent const & extent,
@@ -260,7 +260,7 @@ namespace alpaka
                         typename TViewDst,
                         typename TViewSrc,
                         typename TExtent>
-                    struct TaskCopy<
+                    struct TaskCopyCuda<
                         dim::DimInt<3>,
                         TViewDst,
                         TViewSrc,
@@ -280,7 +280,7 @@ namespace alpaka
                         using Idx = idx::Idx<TExtent>;
 
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_HOST TaskCopy(
+                        ALPAKA_FN_HOST TaskCopyCuda(
                             TViewDst & viewDst,
                             TViewSrc const & viewSrc,
                             TExtent const & extent,
@@ -383,14 +383,14 @@ namespace alpaka
             }
 
             //-----------------------------------------------------------------------------
-            // Trait specializations for TaskCopy.
+            // Trait specializations for CreateTaskCopy.
             namespace traits
             {
                 //#############################################################################
                 //! The CUDA to CPU memory copy trait specialization.
                 template<
                     typename TDim>
-                struct TaskCopy<
+                struct CreateTaskCopy<
                     TDim,
                     dev::DevCpu,
                     dev::DevCudaRt>
@@ -400,11 +400,11 @@ namespace alpaka
                         typename TExtent,
                         typename TViewSrc,
                         typename TViewDst>
-                    ALPAKA_FN_HOST static auto taskCopy(
+                    ALPAKA_FN_HOST static auto createTaskCopy(
                         TViewDst & viewDst,
                         TViewSrc const & viewSrc,
                         TExtent const & extent)
-                    -> mem::view::cuda::detail::TaskCopy<
+                    -> mem::view::cuda::detail::TaskCopyCuda<
                         TDim,
                         TViewDst,
                         TViewSrc,
@@ -416,7 +416,7 @@ namespace alpaka
                             dev::getDev(viewSrc).m_iDevice);
 
                         return
-                            mem::view::cuda::detail::TaskCopy<
+                            mem::view::cuda::detail::TaskCopyCuda<
                                 TDim,
                                 TViewDst,
                                 TViewSrc,
@@ -433,7 +433,7 @@ namespace alpaka
                 //! The CPU to CUDA memory copy trait specialization.
                 template<
                     typename TDim>
-                struct TaskCopy<
+                struct CreateTaskCopy<
                     TDim,
                     dev::DevCudaRt,
                     dev::DevCpu>
@@ -443,11 +443,11 @@ namespace alpaka
                         typename TExtent,
                         typename TViewSrc,
                         typename TViewDst>
-                    ALPAKA_FN_HOST static auto taskCopy(
+                    ALPAKA_FN_HOST static auto createTaskCopy(
                         TViewDst & viewDst,
                         TViewSrc const & viewSrc,
                         TExtent const & extent)
-                    -> mem::view::cuda::detail::TaskCopy<
+                    -> mem::view::cuda::detail::TaskCopyCuda<
                         TDim,
                         TViewDst,
                         TViewSrc,
@@ -459,7 +459,7 @@ namespace alpaka
                             dev::getDev(viewDst).m_iDevice);
 
                         return
-                            mem::view::cuda::detail::TaskCopy<
+                            mem::view::cuda::detail::TaskCopyCuda<
                                 TDim,
                                 TViewDst,
                                 TViewSrc,
@@ -476,7 +476,7 @@ namespace alpaka
                 //! The CUDA to CUDA memory copy trait specialization.
                 template<
                     typename TDim>
-                struct TaskCopy<
+                struct CreateTaskCopy<
                     TDim,
                     dev::DevCudaRt,
                     dev::DevCudaRt>
@@ -486,11 +486,11 @@ namespace alpaka
                         typename TExtent,
                         typename TViewSrc,
                         typename TViewDst>
-                    ALPAKA_FN_HOST static auto taskCopy(
+                    ALPAKA_FN_HOST static auto createTaskCopy(
                         TViewDst & viewDst,
                         TViewSrc const & viewSrc,
                         TExtent const & extent)
-                    -> mem::view::cuda::detail::TaskCopy<
+                    -> mem::view::cuda::detail::TaskCopyCuda<
                         TDim,
                         TViewDst,
                         TViewSrc,
@@ -499,7 +499,7 @@ namespace alpaka
                         ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
                         return
-                            mem::view::cuda::detail::TaskCopy<
+                            mem::view::cuda::detail::TaskCopyCuda<
                                 TDim,
                                 TViewDst,
                                 TViewSrc,
@@ -523,7 +523,7 @@ namespace alpaka
                         typename TViewSrc,
                         typename TViewDst>
                     ALPAKA_FN_HOST auto buildCudaMemcpy3DParms(
-                        mem::view::cuda::detail::TaskCopy<dim::DimInt<3>, TViewDst, TViewSrc, TExtent> const & task)
+                        mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3>, TViewDst, TViewSrc, TExtent> const & task)
                     -> cudaMemcpy3DParms
                     {
                         ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -579,7 +579,7 @@ namespace alpaka
                         typename TViewSrc,
                         typename TExtent>
                     ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms(
-                        mem::view::cuda::detail::TaskCopy<dim::DimInt<2>, TViewDst, TViewSrc, TExtent> const & task)
+                        mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<2>, TViewDst, TViewSrc, TExtent> const & task)
                     -> cudaMemcpy3DPeerParms
                     {
                         ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -639,7 +639,7 @@ namespace alpaka
                         typename TViewSrc,
                         typename TExtent>
                     ALPAKA_FN_HOST auto buildCudaMemcpy3DPeerParms(
-                        mem::view::cuda::detail::TaskCopy<dim::DimInt<3>, TViewDst, TViewSrc, TExtent> const & task)
+                        mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3>, TViewDst, TViewSrc, TExtent> const & task)
                     -> cudaMemcpy3DPeerParms
                     {
                         ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -709,12 +709,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -769,12 +769,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<1u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -827,12 +827,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -895,12 +895,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<2u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -961,12 +961,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
@@ -1015,12 +1015,12 @@ namespace alpaka
                 typename TViewDst>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskCopy<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent>>
+                mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskCopy<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
+                    mem::view::cuda::detail::TaskCopyCuda<dim::DimInt<3u>, TViewDst, TViewSrc, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -66,10 +66,10 @@ namespace alpaka
                         typename TDim,
                         typename TView,
                         typename TExtent>
-                    struct TaskSet
+                    struct TaskSetCuda
                     {
                         //-----------------------------------------------------------------------------
-                        TaskSet(
+                        TaskSetCuda(
                             TView & buf,
                             std::uint8_t const & byte,
                             TExtent const & extent) :
@@ -96,7 +96,7 @@ namespace alpaka
                 //! The CUDA device memory set trait specialization.
                 template<
                     typename TDim>
-                struct TaskSet<
+                struct CreateTaskSet<
                     TDim,
                     dev::DevCudaRt>
                 {
@@ -104,17 +104,17 @@ namespace alpaka
                     template<
                         typename TExtent,
                         typename TView>
-                    ALPAKA_FN_HOST static auto taskSet(
+                    ALPAKA_FN_HOST static auto createTaskSet(
                         TView & buf,
                         std::uint8_t const & byte,
                         TExtent const & extent)
-                    -> mem::view::cuda::detail::TaskSet<
+                    -> mem::view::cuda::detail::TaskSetCuda<
                         TDim,
                         TView,
                         TExtent>
                     {
                         return
-                            mem::view::cuda::detail::TaskSet<
+                            mem::view::cuda::detail::TaskSetCuda<
                                 TDim,
                                 TView,
                                 TExtent>(
@@ -137,12 +137,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<1u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<1u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<1u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<1u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -189,12 +189,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<1u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<1u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<1u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<1u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -240,12 +240,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<2u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<2u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<2u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<2u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -298,12 +298,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<2u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<2u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<2u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<2u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -355,12 +355,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtAsync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<3u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<3u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtAsync & queue,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<3u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<3u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
@@ -429,12 +429,12 @@ namespace alpaka
                 typename TExtent>
             struct Enqueue<
                 queue::QueueCudaRtSync,
-                mem::view::cuda::detail::TaskSet<dim::DimInt<3u>, TView, TExtent>>
+                mem::view::cuda::detail::TaskSetCuda<dim::DimInt<3u>, TView, TExtent>>
             {
                 //-----------------------------------------------------------------------------
                 ALPAKA_FN_HOST static auto enqueue(
                     queue::QueueCudaRtSync &,
-                    mem::view::cuda::detail::TaskSet<dim::DimInt<3u>, TView, TExtent> const & task)
+                    mem::view::cuda::detail::TaskSetCuda<dim::DimInt<3u>, TView, TExtent> const & task)
                 -> void
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -151,17 +151,17 @@ namespace alpaka
                 }
 
                 //#############################################################################
-                //! The memory set trait.
+                //! The memory set task trait.
                 //!
                 //! Fills the view with data.
                 template<
                     typename TDim,
                     typename TDev,
                     typename TSfinae = void>
-                struct TaskSet;
+                struct CreateTaskSet;
 
                 //#############################################################################
-                //! The memory copy trait.
+                //! The memory copy task trait.
                 //!
                 //! Copies memory from one view into another view possibly on a different device.
                 template<
@@ -169,7 +169,7 @@ namespace alpaka
                     typename TDevDst,
                     typename TDevSrc,
                     typename TSfinae = void>
-                struct TaskCopy;
+                struct CreateTaskCopy;
 
                 //#############################################################################
                 //! The static device memory view creation trait.
@@ -285,16 +285,16 @@ namespace alpaka
             template<
                 typename TExtent,
                 typename TView>
-            ALPAKA_FN_HOST auto taskSet(
+            ALPAKA_FN_HOST auto createTaskSet(
                 TView & view,
                 std::uint8_t const & byte,
                 TExtent const & extent)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
-                traits::TaskSet<
+                traits::CreateTaskSet<
                     dim::Dim<TView>,
                     dev::Dev<TView>>
-                ::taskSet(
+                ::createTaskSet(
                     view,
                     byte,
                     extent))
@@ -305,10 +305,10 @@ namespace alpaka
                     "The view and the extent are required to have the same dimensionality!");
 
                 return
-                    traits::TaskSet<
+                    traits::CreateTaskSet<
                         dim::Dim<TView>,
                         dev::Dev<TView>>
-                    ::taskSet(
+                    ::createTaskSet(
                         view,
                         byte,
                         extent);
@@ -317,10 +317,10 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             //! Sets the memory to the given value asynchronously.
             //!
+            //! \param queue The queue to enqueue the view fill task into.
             //! \param view The memory view to fill.
             //! \param byte Value to set for each element of the specified view.
             //! \param extent The extent of the view to fill.
-            //! \param queue The queue to enqueue the view fill task into.
             template<
                 typename TExtent,
                 typename TView,
@@ -334,7 +334,7 @@ namespace alpaka
             {
                 queue::enqueue(
                     queue,
-                    mem::view::taskSet(
+                    mem::view::createTaskSet(
                         view,
                         byte,
                         extent));
@@ -350,17 +350,17 @@ namespace alpaka
                 typename TExtent,
                 typename TViewSrc,
                 typename TViewDst>
-            ALPAKA_FN_HOST auto taskCopy(
+            ALPAKA_FN_HOST auto createTaskCopy(
                 TViewDst & viewDst,
                 TViewSrc const & viewSrc,
                 TExtent const & extent)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
-                traits::TaskCopy<
+                traits::CreateTaskCopy<
                     dim::Dim<TViewDst>,
                     dev::Dev<TViewDst>,
                     dev::Dev<TViewSrc>>
-                ::taskCopy(
+                ::createTaskCopy(
                     viewDst,
                     viewSrc,
                     extent))
@@ -377,23 +377,23 @@ namespace alpaka
                     "The source and the destination view are required to have the same element type!");
 
                 return
-                    traits::TaskCopy<
+                    traits::CreateTaskCopy<
                         dim::Dim<TViewDst>,
                         dev::Dev<TViewDst>,
                         dev::Dev<TViewSrc>>
-                    ::taskCopy(
+                    ::createTaskCopy(
                         viewDst,
                         viewSrc,
                         extent);
             }
 
             //-----------------------------------------------------------------------------
-            //! Copies memory possibly between different memory spaces asynchronously.
+            //! Copies memory possibly between different memory spaces.
             //!
+            //! \param queue The queue to enqueue the view copy task into.
             //! \param viewDst The destination memory view.
             //! \param viewSrc The source memory view.
             //! \param extent The extent of the view to copy.
-            //! \param queue The queue to enqueue the view copy task into.
             template<
                 typename TExtent,
                 typename TViewSrc,
@@ -408,7 +408,7 @@ namespace alpaka
             {
                 queue::enqueue(
                     queue,
-                    mem::view::taskCopy(
+                    mem::view::createTaskCopy(
                         viewDst,
                         viewSrc,
                         extent));


### PR DESCRIPTION
This should not have any influence on external code (as there are no known external code bases defining new device or buffer types I know of).