### PR TITLE
fixes kernel host pointer bug in vectorAdd example.

### DIFF
--- a/example/vectorAdd/src/main.cpp
+++ b/example/vectorAdd/src/main.cpp
@@ -150,8 +150,8 @@ auto main()
     auto const exec(alpaka::exec::create<Acc>(
         workDiv,
         kernel,
-        pBufHostA,
-        pBufHostB,
+        alpaka::mem::view::getPtrNative(bufAccA),
+        alpaka::mem::view::getPtrNative(bufAccB),
         alpaka::mem::view::getPtrNative(bufAccC),
         numElements));
 


### PR DESCRIPTION
- host pointer replaced by Acc pointer in kernel execution.

Example failed when CUDA accelerator is used. 

(See also Issue #502 for the question how to deal with backend testing.)