### PR TITLE
Use inheriting constructor for ViewSubView

### DIFF
--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -52,54 +52,6 @@ namespace alpaka
             {
             public:
                 //-----------------------------------------------------------------------------
-                //! \param view The view this view is a sub-view of.
-                template<
-                    typename TView>
-                ViewSubView(
-                    TView const & view) :
-                        m_viewParentView(
-                            mem::view::getPtrNative(view),
-                            dev::getDev(view),
-                            extent::getExtentVec(view),
-                            mem::view::getPitchBytesVec(view)),
-                        m_extentElements(extent::getExtentVec(view)),
-                        m_offsetsElements(vec::Vec<TDim, TIdx>::all(0))
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    static_assert(
-                        std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The dev type of TView and the TDev template parameter have to be identical!");
-
-                    static_assert(
-                        std::is_same<TIdx, idx::Idx<TView>>::value,
-                        "The idx type of TView and the TIdx template parameter have to be identical!");
-                }
-                //-----------------------------------------------------------------------------
-                //! \param view The view this view is a sub-view of.
-                template<
-                    typename TView>
-                ViewSubView(
-                    TView & view) :
-                        m_viewParentView(
-                            mem::view::getPtrNative(view),
-                            dev::getDev(view),
-                            extent::getExtentVec(view),
-                            mem::view::getPitchBytesVec(view)),
-                        m_extentElements(extent::getExtentVec(view)),
-                        m_offsetsElements(vec::Vec<TDim, TIdx>::all(0))
-                {
-                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
-
-                    static_assert(
-                        std::is_same<TDev, dev::Dev<TView>>::value,
-                        "The dev type of TView and the TDev template parameter have to be identical!");
-
-                    static_assert(
-                        std::is_same<TIdx, idx::Idx<TView>>::value,
-                        "The idx type of TView and the TIdx template parameter have to be identical!");
-                }
-                //-----------------------------------------------------------------------------
                 //! Constructor.
                 //! \param view The view this view is a sub-view of.
                 //! \param extentElements The extent in elements.
@@ -196,6 +148,34 @@ namespace alpaka
                         "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
                     assert(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
+                }
+
+                //-----------------------------------------------------------------------------
+                //! \param view The view this view is a sub-view of.
+                template<
+                    typename TView>
+                ViewSubView(
+                    TView const & view) :
+                        ViewSubView(
+                            view,
+                            view,
+                            vec::Vec<TDim, TIdx>::all(0))
+                {
+                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
+                }
+
+                //-----------------------------------------------------------------------------
+                //! \param view The view this view is a sub-view of.
+                template<
+                    typename TView>
+                ViewSubView(
+                    TView & view) :
+                        ViewSubView(
+                            view,
+                            view,
+                            vec::Vec<TDim, TIdx>::all(0))
+                {
+                    ALPAKA_DEBUG_FULL_LOG_SCOPE;
                 }
 
             public:

--- a/test/unit/kernel/src/KernelWithHostConstexpr.cpp
+++ b/test/unit/kernel/src/KernelWithHostConstexpr.cpp
@@ -28,10 +28,10 @@
 #define BOOST_MPL_CFG_GPU_ENABLED
 
 #include <alpaka/alpaka.hpp>
-#include <alpaka/test/acc/Acc.hpp>                  // alpaka::test::acc::TestAccs
-#include <alpaka/test/KernelExecutionFixture.hpp>   // alpaka::test::KernelExecutionFixture
+#include <alpaka/test/acc/Acc.hpp>
+#include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/predef.h>                           // BOOST_COMP_CLANG
+#include <boost/predef.h>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
This simplifies the implementation and adds a test case for the constructors without offset because this was missing.