### PR TITLE
Test const buffers

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -63,6 +63,9 @@ namespace alpaka
                     class BufCpuImpl final :
                         public mem::alloc::AllocCpuBoostAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>
                     {
+                        static_assert(
+                            !std::is_const<TIdx>::value,
+                            "The idx type of the buffer can not be const!");
                     public:
                         //-----------------------------------------------------------------------------
                         template<

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -64,6 +64,9 @@ namespace alpaka
                         public mem::alloc::AllocCpuBoostAligned<std::integral_constant<std::size_t, core::vectorization::defaultAlignment>>
                     {
                         static_assert(
+                            !std::is_const<TElem>::value,
+                            "The elem type of the buffer can not be const because the C++ Standard forbids containers of const elements!");
+                        static_assert(
                             !std::is_const<TIdx>::value,
                             "The idx type of the buffer can not be const!");
                     public:

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -69,6 +69,9 @@ namespace alpaka
                 typename TIdx>
             class BufCudaRt
             {
+                static_assert(
+                    !std::is_const<TIdx>::value,
+                    "The idx type of the buffer can not be const!");
             private:
                 using Elem = TElem;
                 using Dim = TDim;

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -106,7 +106,7 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 //! Frees the shared buffer.
                 ALPAKA_FN_HOST static auto freeBuffer(
-                    TElem * memPtr,
+                    TElem * const memPtr,
                     dev::DevCudaRt const & dev)
                 -> void
                 {
@@ -320,10 +320,10 @@ namespace alpaka
                 //#############################################################################
                 //! The CUDA 1D memory allocation trait specialization.
                 template<
-                    typename T,
+                    typename TElem,
                     typename TIdx>
                 struct Alloc<
-                    T,
+                    TElem,
                     dim::DimInt<1u>,
                     TIdx,
                     dev::DevCudaRt>
@@ -334,12 +334,12 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto alloc(
                         dev::DevCudaRt const & dev,
                         TExtent const & extent)
-                    -> mem::buf::BufCudaRt<T, dim::DimInt<1u>, TIdx>
+                    -> mem::buf::BufCudaRt<TElem, dim::DimInt<1u>, TIdx>
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         auto const width(extent::getWidth(extent));
-                        auto const widthBytes(width * static_cast<TIdx>(sizeof(T)));
+                        auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
 
                         // Set the current device.
                         ALPAKA_CUDA_RT_CHECK(
@@ -360,9 +360,9 @@ namespace alpaka
                             << std::endl;
 #endif
                         return
-                            mem::buf::BufCudaRt<T, dim::DimInt<1u>, TIdx>(
+                            mem::buf::BufCudaRt<TElem, dim::DimInt<1u>, TIdx>(
                                 dev,
-                                reinterpret_cast<T *>(memPtr),
+                                reinterpret_cast<TElem *>(memPtr),
                                 static_cast<TIdx>(widthBytes),
                                 extent);
                     }
@@ -370,10 +370,10 @@ namespace alpaka
                 //#############################################################################
                 //! The CUDA 2D memory allocation trait specialization.
                 template<
-                    typename T,
+                    typename TElem,
                     typename TIdx>
                 struct Alloc<
-                    T,
+                    TElem,
                     dim::DimInt<2u>,
                     TIdx,
                     dev::DevCudaRt>
@@ -384,12 +384,12 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto alloc(
                         dev::DevCudaRt const & dev,
                         TExtent const & extent)
-                    -> mem::buf::BufCudaRt<T, dim::DimInt<2u>, TIdx>
+                    -> mem::buf::BufCudaRt<TElem, dim::DimInt<2u>, TIdx>
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         auto const width(extent::getWidth(extent));
-                        auto const widthBytes(width * static_cast<TIdx>(sizeof(T)));
+                        auto const widthBytes(width * static_cast<TIdx>(sizeof(TElem)));
                         auto const height(extent::getHeight(extent));
 
                         // Set the current device.
@@ -417,9 +417,9 @@ namespace alpaka
                             << std::endl;
 #endif
                         return
-                            mem::buf::BufCudaRt<T, dim::DimInt<2u>, TIdx>(
+                            mem::buf::BufCudaRt<TElem, dim::DimInt<2u>, TIdx>(
                                 dev,
-                                reinterpret_cast<T *>(memPtr),
+                                reinterpret_cast<TElem *>(memPtr),
                                 static_cast<TIdx>(pitchBytes),
                                 extent);
                     }
@@ -427,10 +427,10 @@ namespace alpaka
                 //#############################################################################
                 //! The CUDA 3D memory allocation trait specialization.
                 template<
-                    typename T,
+                    typename TElem,
                     typename TIdx>
                 struct Alloc<
-                    T,
+                    TElem,
                     dim::DimInt<3u>,
                     TIdx,
                     dev::DevCudaRt>
@@ -441,13 +441,13 @@ namespace alpaka
                     ALPAKA_FN_HOST static auto alloc(
                         dev::DevCudaRt const & dev,
                         TExtent const & extent)
-                    -> mem::buf::BufCudaRt<T, dim::DimInt<3u>, TIdx>
+                    -> mem::buf::BufCudaRt<TElem, dim::DimInt<3u>, TIdx>
                     {
                         ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
                         cudaExtent const cudaExtentVal(
                             make_cudaExtent(
-                                static_cast<std::size_t>(extent::getWidth(extent) * static_cast<TIdx>(sizeof(T))),
+                                static_cast<std::size_t>(extent::getWidth(extent) * static_cast<TIdx>(sizeof(TElem))),
                                 static_cast<std::size_t>(extent::getHeight(extent)),
                                 static_cast<std::size_t>(extent::getDepth(extent))));
 
@@ -476,9 +476,9 @@ namespace alpaka
                             << std::endl;
 #endif
                         return
-                            mem::buf::BufCudaRt<T, dim::DimInt<3u>, TIdx>(
+                            mem::buf::BufCudaRt<TElem, dim::DimInt<3u>, TIdx>(
                                 dev,
-                                reinterpret_cast<T *>(cudaPitchedPtrVal.ptr),
+                                reinterpret_cast<TElem *>(cudaPitchedPtrVal.ptr),
                                 static_cast<TIdx>(cudaPitchedPtrVal.pitch),
                                 extent);
                     }

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -70,6 +70,9 @@ namespace alpaka
             class BufCudaRt
             {
                 static_assert(
+                    !std::is_const<TElem>::value,
+                    "The elem type of the buffer can not be const because the C++ Standard forbids containers of const elements!");
+                static_assert(
                     !std::is_const<TIdx>::value,
                     "The idx type of the buffer can not be const!");
             private:

--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -42,6 +42,9 @@ namespace alpaka
                 typename TIdx>
             class ViewPlainPtr final
             {
+                static_assert(
+                    !std::is_const<TIdx>::value,
+                    "The idx type of the view can not be const!");
             public:
                 //-----------------------------------------------------------------------------
                 ALPAKA_NO_HOST_ACC_WARNING

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -50,6 +50,9 @@ namespace alpaka
                 typename TIdx>
             class ViewSubView
             {
+                static_assert(
+                    !std::is_const<TIdx>::value,
+                    "The idx type of the view can not be const!");
             public:
                 //-----------------------------------------------------------------------------
                 //! \param view The view this view is a sub-view of.

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -126,6 +126,15 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     // alpaka::mem::view::traits::GetPtrNative
                     {
+                        // The view is a const& so the pointer has to point to a const value.
+                        using NativePtr = decltype(alpaka::mem::view::getPtrNative(view));
+                        static_assert(
+                            std::is_pointer<NativePtr>::value,
+                            "The value returned by getPtrNative has to be a pointer.");
+                        static_assert(
+                            std::is_const<typename std::remove_pointer<NativePtr>::type>::value,
+                            "The value returned by getPtrNative has to be const when the view is const.");
+
                         if(alpaka::extent::getExtentProduct(view) != static_cast<TIdx>(0u))
                         {
                             // The pointer is only required to be non-null when the extent is > 0.
@@ -357,6 +366,19 @@ namespace alpaka
                 -> void
                 {
                     using Idx = alpaka::idx::Idx<TView>;
+
+                    //-----------------------------------------------------------------------------
+                    // alpaka::mem::view::traits::GetPtrNative
+                    {
+                        // The view is a non-const so the pointer has to point to a non-const value.
+                        using NativePtr = decltype(alpaka::mem::view::getPtrNative(view));
+                        static_assert(
+                            std::is_pointer<NativePtr>::value,
+                            "The value returned by getPtrNative has to be a pointer.");
+                        static_assert(
+                            !std::is_const<typename std::remove_pointer<NativePtr>::type>::value,
+                            "The value returned by getPtrNative has to be non-const when the view is non-const.");
+                    }
 
                     auto const extent(alpaka::extent::getExtentVec(view));
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -137,4 +137,53 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
             extent);
 }
 
+
+//-----------------------------------------------------------------------------
+template<
+    typename TAcc>
+static auto basicBufferOperationsConstTest(
+    alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
+-> void
+{
+    using Dev = alpaka::dev::Dev<TAcc>;
+    using Pltf = alpaka::pltf::Pltf<Dev>;
+    using Queue = alpaka::test::queue::DefaultQueue<Dev>;
+
+    using Elem = float;
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Idx = alpaka::idx::Idx<TAcc>;
+
+    Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+    Queue queue(dev);
+
+    //-----------------------------------------------------------------------------
+    // alpaka::mem::buf::alloc
+    auto const buf(alpaka::mem::buf::alloc<Elem, Idx>(dev, extent));
+
+    //-----------------------------------------------------------------------------
+    auto const offset(alpaka::vec::Vec<Dim, Idx>::zeros());
+    alpaka::test::mem::view::viewTestImmutable<
+        Elem>(
+            buf,
+            dev,
+            extent,
+            offset);
+}
+
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    memBufConstTest,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    using Dim = alpaka::dim::Dim<TAcc>;
+    using Idx = alpaka::idx::Idx<TAcc>;
+
+    auto const extent(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentBufVal>(Idx()));
+
+    basicBufferOperationsConstTest<
+        TAcc>(
+            extent);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This tests that you can only get a pointer to a const value from a const buffer.
Furthermore, some static_asserts are added which check for invalid template parameters which otherwise lead to hard to understand template errors. 