### PR TITLE
CMake Test Option and Unified Requirement Backport 0.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,26 @@
 #
 
 ################################################################################
-# Required CMake version.
+# Required CMake version
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.7.0)
 
-PROJECT("alpakaAll")
+project("alpakaAll")
+
+################################################################################
+# Options and Variants
+
+option(alpaka_BUILD_EXAMPLES "Build the examples" ON)
+
+include(CTest)
+# automatically defines: BUILD_TESTING, default is ON
 
 ################################################################################
 # Add subdirectories.
 
-ADD_SUBDIRECTORY("example/")
-ADD_SUBDIRECTORY("test/")
+if(alpaka_BUILD_EXAMPLES)
+    add_subdirectory("example/")
+endif()
+if(BUILD_TESTING)
+    add_subdirectory("test/")
+endif()

--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -18,8 +18,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# CUDA_SOURCE_PROPERTY_FORMAT is only supported starting from 3.3.0.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 #------------------------------------------------------------------------------
 # Calls CUDA_ADD_EXECUTABLE or ADD_EXECUTABLE depending on the enabled alpaka accelerators.

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -18,8 +18,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-# CUDA_SOURCE_PROPERTY_FORMAT is only supported starting from 3.3.0.
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 #------------------------------------------------------------------------------
 # Calls CUDA_ADD_LIBRARY or ADD_LIBRARY depending on the enabled alpaka

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaExamples")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaTest")
 

--- a/test/analysis/CMakeLists.txt
+++ b/test/analysis/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaAnalysisTest")
 

--- a/test/analysis/headerCheck/CMakeLists.txt
+++ b/test/analysis/headerCheck/CMakeLists.txt
@@ -106,5 +106,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(headerCheck PROPERTIES FOLDER "test/analysis")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/integ/CMakeLists.txt
+++ b/test/integ/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaIntegTest")
 

--- a/test/integ/cudaOnly/CMakeLists.txt
+++ b/test/integ/cudaOnly/CMakeLists.txt
@@ -81,5 +81,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/integ")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -22,7 +22,7 @@
 # Required CMake version.
 ################################################################################
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 PROJECT("alpakaUnitTest")
 

--- a/test/unit/acc/CMakeLists.txt
+++ b/test/unit/acc/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/atomic/CMakeLists.txt
+++ b/test/unit/atomic/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/block/shared/CMakeLists.txt
+++ b/test/unit/block/shared/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/block/sync/CMakeLists.txt
+++ b/test/unit/block/sync/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/event/CMakeLists.txt
+++ b/test/unit/event/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/idx/CMakeLists.txt
+++ b/test/unit/idx/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/kernel/CMakeLists.txt
+++ b/test/unit/kernel/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/mem/buf/CMakeLists.txt
+++ b/test/unit/mem/buf/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/mem/view/CMakeLists.txt
+++ b/test/unit/mem/view/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/meta/CMakeLists.txt
+++ b/test/unit/meta/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/rand/CMakeLists.txt
+++ b/test/unit/rand/CMakeLists.txt
@@ -87,5 +87,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/stream/CMakeLists.txt
+++ b/test/unit/stream/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/time/CMakeLists.txt
+++ b/test/unit/time/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})

--- a/test/unit/vec/CMakeLists.txt
+++ b/test/unit/vec/CMakeLists.txt
@@ -82,5 +82,4 @@ ENDIF()
 # Group the targets into subfolders for IDEs supporting this.
 SET_TARGET_PROPERTIES(${_TARGET_NAME} PROPERTIES FOLDER "test/unit")
 
-ENABLE_TESTING()
 ADD_TEST(NAME ${_TARGET_NAME} COMMAND ${_TARGET_NAME})


### PR DESCRIPTION
Included fixes
  CMake: Root Options #476
  CMake: Unify Requirement of 3.7.0+ #477


This PR replaces #507. I had compile issues in #507 therefore I will split the backports in smaller parts.