### PR TITLE
Tests: fix CMake empty `ALPAKA_CUDA_ARCH`

### DIFF
--- a/script/travis/compileExec.sh
+++ b/script/travis/compileExec.sh
@@ -27,6 +27,36 @@
 set -eo pipefail
 
 #-------------------------------------------------------------------------------
+
+# create a cmake variable definition if an environment variable exists
+#
+# This function can not handle environment variables with spaces in its content.
+#
+# @param $1 environment variable name
+# @param $2 cmake variable name (optional)
+#           if not defined than cmake variable name is equal to environment name
+# 
+# @result if $2 exists cmake variable definition else nothing is returned
+#
+# @code{.bash}
+# FOO=ON
+# echo "$(env2cmake FOO)" # returns "-DFOO=ON"
+# echo "$(env2cmake FOO CMAKE_FOO_DEF)" # returns "-DCMAKE_FOO_DEF=ON"
+# echo "$(env2cmake BAR)" # returns nothing
+# @endcode
+function env2cmake()
+{
+    if [ $# -ne 2 ] ; then
+        cmakeName=$1
+    else
+        cmakeName=$2
+    fi
+    if [ -v "$1" ] ; then
+        echo -n "-D$cmakeName=${!1}"
+    fi
+}
+
+#-------------------------------------------------------------------------------
 # Build and execute all tests.
 echo KMP_DEVICE_THREAD_LIMIT=${KMP_DEVICE_THREAD_LIMIT}
 echo KMP_ALL_THREADS=${KMP_ALL_THREADS}
@@ -43,7 +73,7 @@ cmake -G "Unix Makefiles" \
     -DALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE="${ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLE}" -DALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE="${ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLE}" -DALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE="${ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE}" \
     -DALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE="${ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLE}"\
     -DALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE="${ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE}" -DALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE="${ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE}" -DALPAKA_ACC_CPU_BT_OMP4_ENABLE="${ALPAKA_ACC_CPU_BT_OMP4_ENABLE}" \
-    -DALPAKA_ACC_GPU_CUDA_ENABLE="${ALPAKA_ACC_GPU_CUDA_ENABLE}" -DALPAKA_CUDA_VERSION="${ALPAKA_CUDA_VER}" -DALPAKA_CUDA_COMPILER="${ALPAKA_CUDA_COMPILER}" -DALPAKA_ACC_GPU_CUDA_ONLY_MODE="${ALPAKA_ACC_GPU_CUDA_ONLY_MODE}" -DALPAKA_CUDA_ARCH="${ALPAKA_CUDA_ARCH}"\
+    "$(env2cmake ALPAKA_ACC_GPU_CUDA_ENABLE)" "$(env2cmake ALPAKA_CUDA_VER ALPAKA_CUDA_VERSION)" "$(env2cmake ALPAKA_ACC_GPU_CUDA_ONLY_MODE)" "$(env2cmake ALPAKA_CUDA_ARCH)" "$(env2cmake ALPAKA_CUDA_COMPILER)" \
     -DALPAKA_DEBUG="${ALPAKA_DEBUG}" -DALPAKA_CI="${ALPAKA_CI}" \
     "../../"
 make VERBOSE=1


### PR DESCRIPTION
In `compileExec.sh` cmake variables where set during the execution of `cmake` e.g. `-DALPAKA_CUDA_ARCH="${ALPAKA_CUDA_ARCH}"`.
In the case where the environment variable `ALPAKA_CUDA_ARCH` is not defined the cuda architecture for
cmake will be set to empty. This overwrites our define for the minimum CUDA architecture which we derivein CMake out of the used CUDA Toolkit version. This results into an crash if we use clang as compiler.

Error:
```
clang-4.0: error: cannot find libdevice for sm_20. Provide path to different CUDA installation via --cuda-path, or pass -nocudalib to build without linking with libdevice.
```