### PR TITLE
Make BOOST_COMP_NVCC compatible to boost version

### DIFF
--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -69,7 +69,7 @@
 //-----------------------------------------------------------------------------
 // nvcc CUDA compiler detection
 #if !defined(BOOST_COMP_NVCC)
-    #if defined(__CUDACC__) && defined(__NVCC__)
+    #if defined(__NVCC__)
         // The __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__ and __CUDACC_VER_BUILD__
         // have been added with nvcc 7.5 and have not been available before.
         #if !defined(__CUDACC_VER_MAJOR__) || !defined(__CUDACC_VER_MINOR__) || !defined(__CUDACC_VER_BUILD__)


### PR DESCRIPTION
The version in boost does not check for `__CUDACC__` because it is not necessary. We should do the same in alpaka.