### PR TITLE
Adds proper float comparison for axpy test.

### DIFF
--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -169,10 +169,6 @@ namespace alpaka
 
                 //#############################################################################
                 //! Compares element-wise that all bytes are set to the same value.
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
-#endif
                 struct VerifyBytesSetKernel
                 {
                     ALPAKA_NO_HOST_ACC_WARNING
@@ -189,25 +185,15 @@ namespace alpaka
                         (void)acc;
                         for(auto it = begin; it != end; ++it)
                         {
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
-#endif
                             auto const& elem = *it;
                             auto const pBytes = reinterpret_cast<std::uint8_t const *>(&elem);
                             for(std::size_t i = 0u; i < elemSizeInByte; ++i)
                             {
                                 BOOST_VERIFY(pBytes[i] == byte);
                             }
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic pop
-#endif
                         }
                     }
                 };
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic pop
-#endif
                 //-----------------------------------------------------------------------------
                 template<
                     typename TAcc,

--- a/test/integ/axpy/src/main.cpp
+++ b/test/integ/axpy/src/main.cpp
@@ -38,6 +38,7 @@
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic pop
 #endif
+#include <boost/math/special_functions/relative_difference.hpp>
 
 #include <alpaka/alpaka.hpp>
 #include <alpaka/test/MeasureKernelRunTime.hpp>
@@ -46,6 +47,7 @@
 
 #include <iostream>
 #include <typeinfo>
+#include <limits>
 
 //#############################################################################
 //! A vector addition kernel.
@@ -104,10 +106,6 @@ using TestAccs = alpaka::test::acc::EnabledAccs<
     alpaka::dim::DimInt<1u>,
     std::size_t>;
 
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wfloat-equal"  // "comparing floating point with == or != is unsafe"
-#endif
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(
     calculateAxpy,
@@ -237,14 +235,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     {
         auto const & val(pHostResultData[i]);
         auto const correctResult(alpha * alpaka::mem::view::getPtrNative(memBufHostX)[i] + alpaka::mem::view::getPtrNative(memBufHostOrigY)[i]);
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wfloat-equal" // "comparing floating point with == or != is unsafe"
-#endif
-        if(val != correctResult)
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic pop
-#endif
+        if( boost::math::relative_difference(val, correctResult) > std::numeric_limits<Val>::epsilon() )
         {
             std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
             resultCorrect = false;
@@ -253,8 +244,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
     BOOST_REQUIRE_EQUAL(true, resultCorrect);
 }
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic pop
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes axpy test (refers to #537 )
- adds proper floating point comparison by using Boost's relative difference

There is a ViewTest.hpp file, where float-equal warnings shall be ignored.
For the bytes comparison the warning pragmas will be removed (no floats compared here).
There is another line `BOOST_VERIFY(*beginA == *beginB);`, which indeed compares floats again.
It is possible to branch by value type for doing exact and floating-point comparison respectively. If you want me to do that in this PR, let me know.