### PR TITLE
Fix cuda memcpy and memset for zero sized buffers (division by zero)

### DIFF
--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -563,7 +563,7 @@ namespace alpaka
                                 dstNativePtr,
                                 static_cast<std::size_t>(dstPitchBytesX),
                                 static_cast<std::size_t>(dstWidth),
-                                static_cast<std::size_t>(dstPitchBytesY/dstPitchBytesX));
+                                static_cast<std::size_t>(dstPitchBytesY / dstPitchBytesX));
                         cudaMemCpy3DParms.extent =
                             make_cudaExtent(
                                 static_cast<std::size_t>(extentWidthBytes),
@@ -615,7 +615,7 @@ namespace alpaka
                                 dstNativePtr,
                                 static_cast<std::size_t>(dstPitchBytesX),
                                 static_cast<std::size_t>(dstWidth),
-                                static_cast<std::size_t>(dstPitchBytesY/dstPitchBytesX));
+                                static_cast<std::size_t>(dstPitchBytesY / dstPitchBytesX));
                         cudaMemCpy3DPeerParms.extent =
                             make_cudaExtent(
                                 static_cast<std::size_t>(extentWidthBytes),
@@ -629,7 +629,7 @@ namespace alpaka
                                 const_cast<void *>(srcNativePtr),
                                 static_cast<std::size_t>(srcPitchBytesX),
                                 static_cast<std::size_t>(srcWidth),
-                                static_cast<std::size_t>(srcPitchBytesY/srcPitchBytesX));
+                                static_cast<std::size_t>(srcPitchBytesY / srcPitchBytesX));
 
                         return cudaMemCpy3DPeerParms;
                     }
@@ -689,7 +689,7 @@ namespace alpaka
                                 const_cast<void *>(srcNativePtr),
                                 static_cast<std::size_t>(srcPitchBytesX),
                                 static_cast<std::size_t>(srcWidth),
-                                static_cast<std::size_t>(srcPitchBytesY/srcPitchBytesX));
+                                static_cast<std::size_t>(srcPitchBytesY / srcPitchBytesX));
 
                         return cudaMemCpy3DPeerParms;
                     }
@@ -722,6 +722,11 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    if(task.m_extentWidthBytes == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -782,6 +787,11 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    if(task.m_extentWidthBytes == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -840,6 +850,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -908,6 +924,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -974,6 +996,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0 || task.m_extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -1028,6 +1056,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0 || task.m_extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -162,6 +162,12 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
+
+                    if(extentWidth == 0)
+                    {
+                        return;
+                    }
+
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
@@ -214,6 +220,12 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
+
+                    if(extentWidth == 0)
+                    {
+                        return;
+                    }
+
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
@@ -265,8 +277,15 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
                     auto const extentHeight(extent::getHeight(extent));
+
+                    if(extentWidth == 0 || extentHeight == 0)
+                    {
+                        return;
+                    }
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
                     auto const dstHeight(extent::getHeight(buf));
@@ -323,8 +342,15 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
                     auto const extentHeight(extent::getHeight(extent));
+
+                    if(extentWidth == 0 || extentHeight == 0)
+                    {
+                        return;
+                    }
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
                     auto const dstHeight(extent::getHeight(buf));
@@ -338,6 +364,7 @@ namespace alpaka
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
                             iDevice));
+
                     // Initiate the memory set.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaMemset2D(
@@ -383,6 +410,13 @@ namespace alpaka
                     auto const extentWidth(extent::getWidth(extent));
                     auto const extentHeight(extent::getHeight(extent));
                     auto const extentDepth(extent::getDepth(extent));
+
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const dstWidth(extent::getWidth(buf));
 #if !defined(NDEBUG)
                     auto const dstHeight(extent::getHeight(buf));
@@ -401,7 +435,7 @@ namespace alpaka
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY/dstPitchBytesX)));
+                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
                     cudaExtent const cudaExtentVal(
                         make_cudaExtent(
@@ -457,6 +491,13 @@ namespace alpaka
                     auto const extentWidth(extent::getWidth(extent));
                     auto const extentHeight(extent::getHeight(extent));
                     auto const extentDepth(extent::getDepth(extent));
+
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const dstWidth(extent::getWidth(buf));
 #if !defined(NDEBUG)
                     auto const dstHeight(extent::getHeight(buf));
@@ -475,7 +516,7 @@ namespace alpaka
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Idx>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY/dstPitchBytesX)));
+                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
                     cudaExtent const cudaExtentVal(
                         make_cudaExtent(


### PR DESCRIPTION
This fixes the failing memBuf test from #537 