### PR TITLE
Fixes CUDA driver API error handler.

### DIFF
--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -118,12 +118,13 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    // Set the current device. \TODO: Is setting the current device before cudaFree required?
+                    // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
                             dev.m_iDevice));
                     // Free the buffer.
-                    cudaFree(reinterpret_cast<void *>(memPtr));
+                    ALPAKA_CUDA_RT_CHECK(
+                      cudaFree(reinterpret_cast<void *>(memPtr)));
                 }
 
             public:

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -408,12 +408,12 @@ namespace alpaka
                         {
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                            // Set the current device. \TODO: Is setting the current device before cudaFree required?
+                            // Set the current device.
                             ALPAKA_CUDA_RT_CHECK(
                                 cudaSetDevice(
                                     m_dev.m_iDevice));
                             // Free the buffer.
-                            cudaFree(m_devMem);
+                            ALPAKA_CUDA_RT_CHECK(cudaFree(m_devMem));
                         }
 
                         //-----------------------------------------------------------------------------


### PR DESCRIPTION
- adds error handling to `cudaFree` (e.g. if pointer has been already deallocated, error will occur)
- the cast to `cudaError_t` in `cudaDrvCheck` gave wrong error codes, as runtime and driver API error codes are different, so driver API error handling is used now

Example (refers to #546):
```
/alpaka/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp(650) cuStreamWaitValue32( static_cast<CUstream>(queue.m_spQueueImpl->m_CudaQueue), reinterpret_cast<CUdeviceptr>(event.m_spEventImpl->m_devMem), 0x01010101u, CU_STREAM_WAIT_VALUE_GEQ) : 
'unrecognized error code': 'unrecognized error code'!
```
now correctly reports:
```
'CUDA_ERROR_NOT_SUPPORTED': 'operation not supported'!
```
