### PR TITLE
Move `runtime_error` out of the debug block

### DIFF
--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -145,8 +145,10 @@ namespace alpaka
 
                 // The number of blocks in the grid.
                 TIdx const numBlocksInGrid(gridBlockExtent.prod());
-                // There is only ever one thread in a block in the OpenMP 2.0 block accelerator.
-                BOOST_VERIFY(blockThreadExtent.prod() == static_cast<TIdx>(1u));
+                if(blockThreadExtent.prod() != static_cast<TIdx>(1u))
+                {
+                    throw std::runtime_error("Only one thread per block allowed in the OpenMP 2.0 block accelerator!");
+                }
 
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -169,27 +169,28 @@ namespace alpaka
                         // Therefore we use 'omp parallel' with the specified number of threads in a block.
                         #pragma omp parallel num_threads(iBlockThreadCount)
                         {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                            // GCC 5.1 fails with:
-                            // error: redeclaration of const int& iBlockThreadCount
-                            // if(numThreads != iBlockThreadCount
-                            //                ^
-                            // note: const int& iBlockThreadCount previously declared here
-                            // #pragma omp parallel num_threads(iBlockThreadCount)
-                            //         ^
-#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0))
                             // The first thread does some checks in the first block executed.
-                            if((::omp_get_thread_num() == 0) && (acc.m_gridBlockIdx.sum() == 0u))
+                            if((::omp_get_thread_num() == 0) && (acc.m_gridBlockIdx.sum() == static_cast<TIdx>(0)))
                             {
                                 int const numThreads(::omp_get_num_threads());
+                                boost::ignore_unused(numThreads);
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                                 std::cout << BOOST_CURRENT_FUNCTION << " omp_get_num_threads: " << numThreads << std::endl;
+#endif
+                                // GCC 5.1 fails with:
+                                // error: redeclaration of const int& iBlockThreadCount
+                                // if(numThreads != iBlockThreadCount)
+                                //                  ^
+                                // note: const int& iBlockThreadCount previously declared here
+                                // #pragma omp parallel num_threads(iBlockThreadCount)
+                                //         ^
+#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0))
                                 if(numThreads != iBlockThreadCount)
                                 {
                                     throw std::runtime_error("The OpenMP 2.0 runtime did not use the number of threads that had been required!");
                                 }
+#endif
                             }
-#endif
-#endif
                             boundKernelFnObj(
                                 acc);
 


### PR DESCRIPTION
A user would get the runtime error only in a debug build, which differs to
other runtime errors, like the one in Omp2blocks which checks if
#threads/block == 1.

Converted to `BOOST_VERIFY_MSG` on the way.