### PR TITLE
Add test for const ViewSubView and clean up handling of such memory operations

### DIFF
--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -65,6 +65,10 @@ namespace alpaka
                         using Elem = elem::Elem<TViewSrc>;
 
                         static_assert(
+                            !std::is_const<TViewDst>::value,
+                            "The destination view can not be const!");
+
+                        static_assert(
                             dim::Dim<TViewDst>::value == dim::Dim<TViewSrc>::value,
                             "The source and the destination view are required to have the same dimensionality!");
                         static_assert(

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -61,6 +61,10 @@ namespace alpaka
                         using Elem = elem::Elem<TView>;
 
                         static_assert(
+                            !std::is_const<TView>::value,
+                            "The destination view can not be const!");
+
+                        static_assert(
                             dim::Dim<TView>::value == dim::Dim<TExtent>::value,
                             "The destination view and the extent are required to have the same dimensionality!");
                         static_assert(

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -76,6 +76,10 @@ namespace alpaka
                         TExtent>
                     {
                         static_assert(
+                            !std::is_const<TViewDst>::value,
+                            "The destination view can not be const!");
+
+                        static_assert(
                             dim::Dim<TViewDst>::value == dim::Dim<TViewSrc>::value,
                             "The source and the destination view are required to have the same dimensionality!");
                         static_assert(
@@ -155,6 +159,10 @@ namespace alpaka
                         TViewSrc,
                         TExtent>
                     {
+                        static_assert(
+                            !std::is_const<TViewDst>::value,
+                            "The destination view can not be const!");
+
                         static_assert(
                             dim::Dim<TViewDst>::value == dim::Dim<TViewSrc>::value,
                             "The source and the destination view are required to have the same dimensionality!");
@@ -266,6 +274,10 @@ namespace alpaka
                         TViewSrc,
                         TExtent>
                     {
+                        static_assert(
+                            !std::is_const<TViewDst>::value,
+                            "The destination view can not be const!");
+
                         static_assert(
                             dim::Dim<TViewDst>::value == dim::Dim<TViewSrc>::value,
                             "The source and the destination view are required to have the same dimensionality!");

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -79,8 +79,12 @@ namespace alpaka
                                 m_iDevice(dev::getDev(buf).m_iDevice)
                         {
                             static_assert(
+                                !std::is_const<TView>::value,
+                                "The destination view can not be const!");
+
+                            static_assert(
                                 dim::Dim<TView>::value == dim::Dim<TExtent>::value,
-                                "The destination buffer and the extent are required to have the same dimensionality!");
+                                "The destination view and the extent are required to have the same dimensionality!");
                         }
 
                         TView & m_buf;

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -70,13 +70,13 @@ namespace alpaka
                     {
                         //-----------------------------------------------------------------------------
                         TaskSetCuda(
-                            TView & buf,
+                            TView & view,
                             std::uint8_t const & byte,
                             TExtent const & extent) :
-                                m_buf(buf),
+                                m_view(view),
                                 m_byte(byte),
                                 m_extent(extent),
-                                m_iDevice(dev::getDev(buf).m_iDevice)
+                                m_iDevice(dev::getDev(view).m_iDevice)
                         {
                             static_assert(
                                 !std::is_const<TView>::value,
@@ -87,7 +87,7 @@ namespace alpaka
                                 "The destination view and the extent are required to have the same dimensionality!");
                         }
 
-                        TView & m_buf;
+                        TView & m_view;
                         std::uint8_t const m_byte;
                         TExtent const m_extent;
                         std::int32_t const m_iDevice;
@@ -109,7 +109,7 @@ namespace alpaka
                         typename TExtent,
                         typename TView>
                     ALPAKA_FN_HOST static auto createTaskSet(
-                        TView & buf,
+                        TView & view,
                         std::uint8_t const & byte,
                         TExtent const & extent)
                     -> mem::view::cuda::detail::TaskSetCuda<
@@ -122,7 +122,7 @@ namespace alpaka
                                 TDim,
                                 TView,
                                 TExtent>(
-                                    buf,
+                                    view,
                                     byte,
                                     extent);
                     }
@@ -160,7 +160,7 @@ namespace alpaka
 
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -174,9 +174,9 @@ namespace alpaka
 
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 #if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(buf));
+                    auto const dstWidth(extent::getWidth(view));
 #endif
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
 
                     // Set the current device.
@@ -218,7 +218,7 @@ namespace alpaka
 
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -232,9 +232,9 @@ namespace alpaka
 
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 #if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(buf));
+                    auto const dstWidth(extent::getWidth(view));
 #endif
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
 
                     // Set the current device.
@@ -275,7 +275,7 @@ namespace alpaka
 
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -291,11 +291,11 @@ namespace alpaka
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 
 #if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(buf));
-                    auto const dstHeight(extent::getHeight(buf));
+                    auto const dstWidth(extent::getWidth(view));
+                    auto const dstHeight(extent::getHeight(view));
 #endif
-                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(buf));
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
                     assert(extentHeight <= dstHeight);
 
@@ -340,7 +340,7 @@ namespace alpaka
 
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -356,11 +356,11 @@ namespace alpaka
                     auto const extentWidthBytes(extentWidth * static_cast<Idx>(sizeof(elem::Elem<TView>)));
 
 #if !defined(NDEBUG)
-                    auto const dstWidth(extent::getWidth(buf));
-                    auto const dstHeight(extent::getHeight(buf));
+                    auto const dstWidth(extent::getWidth(view));
+                    auto const dstHeight(extent::getHeight(view));
 #endif
-                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(buf));
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
                     assert(extentHeight <= dstHeight);
 
@@ -406,7 +406,7 @@ namespace alpaka
                     using Elem = alpaka::elem::Elem<TView>;
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -421,14 +421,14 @@ namespace alpaka
                         return;
                     }
 
-                    auto const dstWidth(extent::getWidth(buf));
+                    auto const dstWidth(extent::getWidth(view));
 #if !defined(NDEBUG)
-                    auto const dstHeight(extent::getHeight(buf));
-                    auto const dstDepth(extent::getDepth(buf));
+                    auto const dstHeight(extent::getHeight(view));
+                    auto const dstDepth(extent::getDepth(view));
 #endif
-                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(buf));
-                    auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(buf));
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
+                    auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(view));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
                     assert(extentHeight <= dstHeight);
                     assert(extentDepth <= dstDepth);
@@ -487,7 +487,7 @@ namespace alpaka
                     using Elem = alpaka::elem::Elem<TView>;
                     using Idx = idx::Idx<TExtent>;
 
-                    auto & buf(task.m_buf);
+                    auto & view(task.m_view);
                     auto const & byte(task.m_byte);
                     auto const & extent(task.m_extent);
                     auto const & iDevice(task.m_iDevice);
@@ -502,14 +502,14 @@ namespace alpaka
                         return;
                     }
 
-                    auto const dstWidth(extent::getWidth(buf));
+                    auto const dstWidth(extent::getWidth(view));
 #if !defined(NDEBUG)
-                    auto const dstHeight(extent::getHeight(buf));
-                    auto const dstDepth(extent::getDepth(buf));
+                    auto const dstHeight(extent::getHeight(view));
+                    auto const dstDepth(extent::getDepth(view));
 #endif
-                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(buf));
-                    auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(buf));
-                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
+                    auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
+                    auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(view));
+                    auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
                     assert(extentWidth <= dstWidth);
                     assert(extentHeight <= dstHeight);
                     assert(extentDepth <= dstDepth);

--- a/test/common/include/alpaka/test/mem/view/ViewTest.hpp
+++ b/test/common/include/alpaka/test/mem/view/ViewTest.hpp
@@ -54,7 +54,7 @@ namespace alpaka
                     typename TIdx,
                     typename TDev,
                     typename TView>
-                static auto viewTestImmutable(
+                static auto testViewImmutable(
                     TView const & view,
                     TDev const & dev,
                     alpaka::vec::Vec<TDim, TIdx> const & extent,
@@ -346,13 +346,11 @@ namespace alpaka
                     typename TAcc,
                     typename TView,
                     typename TQueue>
-                static auto viewTestMutable(
+                static auto testViewMutable(
                     TQueue & queue,
                     TView & view)
                 -> void
                 {
-                    using Idx = alpaka::idx::Idx<TView>;
-
                     //-----------------------------------------------------------------------------
                     // alpaka::mem::view::traits::GetPtrNative
                     {
@@ -380,6 +378,7 @@ namespace alpaka
                     // alpaka::mem::view::copy
                     {
                         using Elem = alpaka::elem::Elem<TView>;
+                        using Idx = alpaka::idx::Idx<TView>;
 
                         auto const devAcc = alpaka::dev::getDev(view);
 

--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -70,7 +70,7 @@ struct CreateExtentBufVal
 //-----------------------------------------------------------------------------
 template<
     typename TAcc>
-static auto basicBufferOperationsTest(
+static auto testBufferMutable(
     alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
 -> void
 {
@@ -91,7 +91,7 @@ static auto basicBufferOperationsTest(
 
     //-----------------------------------------------------------------------------
     auto const offset(alpaka::vec::Vec<Dim, Idx>::zeros());
-    alpaka::test::mem::view::viewTestImmutable<
+    alpaka::test::mem::view::testViewImmutable<
         Elem>(
             buf,
             dev,
@@ -99,7 +99,7 @@ static auto basicBufferOperationsTest(
             offset);
 
     //-----------------------------------------------------------------------------
-    alpaka::test::mem::view::viewTestMutable<
+    alpaka::test::mem::view::testViewMutable<
         TAcc>(
             queue,
             buf);
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
     auto const extent(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentBufVal>(Idx()));
 
-    basicBufferOperationsTest<
+    testBufferMutable<
         TAcc>(
             extent);
 }
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
     auto const extent(alpaka::vec::Vec<Dim, Idx>::zeros());
 
-    basicBufferOperationsTest<
+    testBufferMutable<
         TAcc>(
             extent);
 }
@@ -141,20 +141,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 //-----------------------------------------------------------------------------
 template<
     typename TAcc>
-static auto basicBufferOperationsConstTest(
+static auto testBufferImmutable(
     alpaka::vec::Vec<alpaka::dim::Dim<TAcc>, alpaka::idx::Idx<TAcc>> const & extent)
 -> void
 {
     using Dev = alpaka::dev::Dev<TAcc>;
     using Pltf = alpaka::pltf::Pltf<Dev>;
-    using Queue = alpaka::test::queue::DefaultQueue<Dev>;
 
     using Elem = float;
     using Dim = alpaka::dim::Dim<TAcc>;
     using Idx = alpaka::idx::Idx<TAcc>;
 
     Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
-    Queue queue(dev);
 
     //-----------------------------------------------------------------------------
     // alpaka::mem::buf::alloc
@@ -162,7 +160,7 @@ static auto basicBufferOperationsConstTest(
 
     //-----------------------------------------------------------------------------
     auto const offset(alpaka::vec::Vec<Dim, Idx>::zeros());
-    alpaka::test::mem::view::viewTestImmutable<
+    alpaka::test::mem::view::testViewImmutable<
         Elem>(
             buf,
             dev,
@@ -181,7 +179,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
     auto const extent(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentBufVal>(Idx()));
 
-    basicBufferOperationsConstTest<
+    testBufferImmutable<
         TAcc>(
             extent);
 }

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -113,7 +113,7 @@ namespace view
         typename TIdx,
         typename TBuf>
     auto testViewSubViewImmutable(
-        alpaka::mem::view::ViewSubView<TDev, TElem, TDim, TIdx> & view,
+        alpaka::mem::view::ViewSubView<TDev, TElem, TDim, TIdx> const & view,
         TBuf & buf,
         TDev const & dev,
         alpaka::vec::Vec<TDim, TIdx> const & extentView,
@@ -247,6 +247,32 @@ namespace view
 
         alpaka::test::mem::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
+
+    //-----------------------------------------------------------------------------
+    template<
+        typename TAcc,
+        typename TElem>
+    auto testViewSubViewOffsetConst()
+    -> void
+    {
+        using Dev = alpaka::dev::Dev<TAcc>;
+        using Pltf = alpaka::pltf::Pltf<Dev>;
+
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Idx = alpaka::idx::Idx<TAcc>;
+        using View = alpaka::mem::view::ViewSubView<Dev, TElem, Dim, Idx>;
+
+        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentBufVal>(Idx()));
+        auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
+
+        auto const extentView(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentViewVal>(Idx()));
+        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(sizeof(Idx)));
+        View const view(buf, extentView, offsetView);
+
+        alpaka::test::mem::view::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);
+    }
 }
 }
 }
@@ -273,6 +299,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     alpaka::test::acc::TestAccs)
 {
     alpaka::test::mem::view::testViewSubViewOffset<TAcc, float>();
+}
+
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    viewSubViewOffsetConstTest,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    alpaka::test::mem::view::testViewSubViewOffsetConst<TAcc, float>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2015-2017 Benjamin Worpitz
+ * Copyright 2015-2018 Benjamin Worpitz
  *
  * This file is part of alpaka.
  *
@@ -112,7 +112,7 @@ namespace view
         typename TDim,
         typename TIdx,
         typename TBuf>
-    auto viewSubViewTest(
+    auto testViewSubViewImmutable(
         alpaka::mem::view::ViewSubView<TDev, TElem, TDim, TIdx> & view,
         TBuf & buf,
         TDev const & dev,
@@ -121,20 +121,12 @@ namespace view
     -> void
     {
         //-----------------------------------------------------------------------------
-        alpaka::test::mem::view::viewTestImmutable<
+        alpaka::test::mem::view::testViewImmutable<
             TElem>(
                 view,
                 dev,
                 extentView,
                 offsetView);
-
-        using Queue = alpaka::test::queue::DefaultQueue<TDev>;
-        Queue queue(dev);
-        //-----------------------------------------------------------------------------
-        alpaka::test::mem::view::viewTestMutable<
-            TAcc>(
-                queue,
-                view);
 
         //-----------------------------------------------------------------------------
         // alpaka::mem::view::traits::GetPitchBytes
@@ -173,8 +165,42 @@ namespace view
     //-----------------------------------------------------------------------------
     template<
         typename TAcc,
+        typename TDev,
+        typename TElem,
+        typename TDim,
+        typename TIdx,
+        typename TBuf>
+    auto testViewSubViewMutable(
+        alpaka::mem::view::ViewSubView<TDev, TElem, TDim, TIdx> & view,
+        TBuf & buf,
+        TDev const & dev,
+        alpaka::vec::Vec<TDim, TIdx> const & extentView,
+        alpaka::vec::Vec<TDim, TIdx> const & offsetView)
+    -> void
+    {
+        //-----------------------------------------------------------------------------
+        testViewSubViewImmutable<
+            TAcc>(
+                view,
+                buf,
+                dev,
+                extentView,
+                offsetView);
+
+        using Queue = alpaka::test::queue::DefaultQueue<TDev>;
+        Queue queue(dev);
+        //-----------------------------------------------------------------------------
+        alpaka::test::mem::view::testViewMutable<
+            TAcc>(
+                queue,
+                view);
+    }
+
+    //-----------------------------------------------------------------------------
+    template<
+        typename TAcc,
         typename TElem>
-    auto viewSubViewTestNoOffset()
+    auto testViewSubViewNoOffset()
     -> void
     {
         using Dev = alpaka::dev::Dev<TAcc>;
@@ -193,14 +219,14 @@ namespace view
         auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(0)));
         View view(buf);
 
-        alpaka::test::mem::view::viewSubViewTest<TAcc>(view, buf, dev, extentView, offsetView);
+        alpaka::test::mem::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
 
     //-----------------------------------------------------------------------------
     template<
         typename TAcc,
         typename TElem>
-    auto viewSubViewTestOffset()
+    auto testViewSubViewOffset()
     -> void
     {
         using Dev = alpaka::dev::Dev<TAcc>;
@@ -219,7 +245,7 @@ namespace view
         auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(sizeof(Idx)));
         View view(buf, extentView, offsetView);
 
-        alpaka::test::mem::view::viewSubViewTest<TAcc>(view, buf, dev, extentView, offsetView);
+        alpaka::test::mem::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
     }
 }
 }
@@ -237,7 +263,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     TAcc,
     alpaka::test::acc::TestAccs)
 {
-    alpaka::test::mem::view::viewSubViewTestNoOffset<TAcc, float>();
+    alpaka::test::mem::view::testViewSubViewNoOffset<TAcc, float>();
 }
 
 //-----------------------------------------------------------------------------
@@ -246,7 +272,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     TAcc,
     alpaka::test::acc::TestAccs)
 {
-    alpaka::test::mem::view::viewSubViewTestOffset<TAcc, float>();
+    alpaka::test::mem::view::testViewSubViewOffset<TAcc, float>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
* Add static asserts that the destination buffer of memory operations can not be const (the operations are currently failing further down the call stack so this should enhance the error search)
* Add test case for const `ViewSubView`
* Rename `buf` to `view` for CUDA memory operations, this had already been done for the CPU operations