### PR TITLE
Extend BlockSharedMemSt tests to better exhibit faulty implementations

### DIFF
--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -62,30 +62,34 @@ public:
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Waddress"  // warning: the compiler can assume that the address of ‘a’ will never be NULL [-Waddress]
 #endif
-        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &a);
+        // Multiple runs to make sure it really works.
+        for(std::size_t i=0u; i<10; ++i)
+        {
+            auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &a);
 
-        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &b);
+            auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &b);
 
-        auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<float *>(nullptr) != &c);
+            auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<float *>(nullptr) != &c);
 
-        auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<double *>(nullptr) != &d);
+            auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<double *>(nullptr) != &d);
 
-        auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<std::uint64_t *>(nullptr) != &e);
+            auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<std::uint64_t *>(nullptr) != &e);
 
 
-        auto && f = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &f[0]);
+            auto && f = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
-        auto && g = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &g[0]);
+            auto && g = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
-        auto && h = alpaka::block::shared::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
-        BOOST_VERIFY(static_cast<double *>(nullptr) != &h[0]);
+            auto && h = alpaka::block::shared::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
+            BOOST_VERIFY(static_cast<double *>(nullptr) != &h[0]);
+        }
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
     #pragma GCC diagnostic pop
 #endif
@@ -101,8 +105,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     using Dim = alpaka::dim::Dim<TAcc>;
     using Idx = alpaka::idx::Idx<TAcc>;
 
+    // Use multiple threads to make sure the synchronization really works.
     alpaka::test::KernelExecutionFixture<TAcc> fixture(
-        alpaka::vec::Vec<Dim, Idx>::ones());
+        alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(3u)));
 
     BlockSharedMemStNonNullTestKernel kernel;
 
@@ -124,37 +129,42 @@ public:
         TAcc const & acc) const
     -> void
     {
-        auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_VERIFY(&a != &b);
-        auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-        BOOST_VERIFY(&b != &c);
-        BOOST_VERIFY(&a != &c);
-        BOOST_VERIFY(&b != &c);
+        // Multiple runs to make sure it really works.
+        for(std::size_t i=0u; i<10; ++i)
+        {
+            auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            BOOST_VERIFY(&a != &b);
+            auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
+            BOOST_VERIFY(&b != &c);
+            BOOST_VERIFY(&a != &c);
+            BOOST_VERIFY(&b != &c);
 
-        auto && d = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_VERIFY(&a != &d[0]);
-        BOOST_VERIFY(&b != &d[0]);
-        BOOST_VERIFY(&c != &d[0]);
-        auto && e = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-        BOOST_VERIFY(&a != &e[0]);
-        BOOST_VERIFY(&b != &e[0]);
-        BOOST_VERIFY(&c != &e[0]);
-        BOOST_VERIFY(&d[0] != &e[0]);
+            auto && d = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            BOOST_VERIFY(&a != &d[0]);
+            BOOST_VERIFY(&b != &d[0]);
+            BOOST_VERIFY(&c != &d[0]);
+            auto && e = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
+            BOOST_VERIFY(&a != &e[0]);
+            BOOST_VERIFY(&b != &e[0]);
+            BOOST_VERIFY(&c != &e[0]);
+            BOOST_VERIFY(&d[0] != &e[0]);
+        }
     }
 };
 
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE(
-    sameTypeDifferentAdress,
+    sameTypeDifferentAddress,
     TAcc,
     alpaka::test::acc::TestAccs)
 {
     using Dim = alpaka::dim::Dim<TAcc>;
     using Idx = alpaka::idx::Idx<TAcc>;
 
+    // Use multiple threads to make sure the synchronization really works.
     alpaka::test::KernelExecutionFixture<TAcc> fixture(
-        alpaka::vec::Vec<Dim, Idx>::ones());
+        alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(3u)));
 
     BlockSharedMemStSameTypeDifferentAdressTestKernel kernel;
 


### PR DESCRIPTION
I was trying to optimize some of the static block shared memory implementations and extended the test a bit to show when the multithreading part fails (which can not fail when there is only ever one thread).