### PR TITLE
back-port  to 0.3.2

### DIFF
--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -145,8 +145,10 @@ namespace alpaka
 
                 // The number of blocks in the grid.
                 TSize const numBlocksInGrid(gridBlockExtent.prod());
-                // There is only ever one thread in a block in the OpenMP 2.0 block accelerator.
-                BOOST_VERIFY(blockThreadExtent.prod() == static_cast<TSize>(1u));
+                if(blockThreadExtent.prod() != static_cast<TSize>(1u))
+                {
+                    throw std::runtime_error("Only one thread per block allowed in the OpenMP 2.0 block accelerator!");
+                }
 
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -169,27 +169,28 @@ namespace alpaka
                         // Therefore we use 'omp parallel' with the specified number of threads in a block.
                         #pragma omp parallel num_threads(iBlockThreadCount)
                         {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                            // GCC 5.1 fails with:
-                            // error: redeclaration of const int& iBlockThreadCount
-                            // if(numThreads != iBlockThreadCount
-                            //                ^
-                            // note: const int& iBlockThreadCount previously declared here
-                            // #pragma omp parallel num_threads(iBlockThreadCount)
-                            //         ^
-#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0))
                             // The first thread does some checks in the first block executed.
-                            if((::omp_get_thread_num() == 0) && (acc.m_gridBlockIdx.sum() == 0u))
+                            if((::omp_get_thread_num() == 0) && (acc.m_gridBlockIdx.sum() == static_cast<TSize>(0)))
                             {
                                 int const numThreads(::omp_get_num_threads());
+                                boost::ignore_unused(numThreads);
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                                 std::cout << BOOST_CURRENT_FUNCTION << " omp_get_num_threads: " << numThreads << std::endl;
+#endif
+                                // GCC 5.1 fails with:
+                                // error: redeclaration of const int& iBlockThreadCount
+                                // if(numThreads != iBlockThreadCount)
+                                //                  ^
+                                // note: const int& iBlockThreadCount previously declared here
+                                // #pragma omp parallel num_threads(iBlockThreadCount)
+                                //         ^
+#if (!BOOST_COMP_GNUC) || (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0)) || (BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0))
                                 if(numThreads != iBlockThreadCount)
                                 {
                                     throw std::runtime_error("The OpenMP 2.0 runtime did not use the number of threads that had been required!");
                                 }
+#endif
                             }
-#endif
-#endif
                             boundKernelFnObj(
                                 acc);
 

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -112,12 +112,13 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    // Set the current device. \TODO: Is setting the current device before cudaFree required?
+                    // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
                             dev.m_iDevice));
                     // Free the buffer.
-                    cudaFree(reinterpret_cast<void *>(memPtr));
+                    ALPAKA_CUDA_RT_CHECK(
+                      cudaFree(reinterpret_cast<void *>(memPtr)));
                 }
 
             public:

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -563,7 +563,7 @@ namespace alpaka
                                 dstNativePtr,
                                 static_cast<std::size_t>(dstPitchBytesX),
                                 static_cast<std::size_t>(dstWidth),
-                                static_cast<std::size_t>(dstPitchBytesY/dstPitchBytesX));
+                                static_cast<std::size_t>(dstPitchBytesY / dstPitchBytesX));
                         cudaMemCpy3DParms.extent =
                             make_cudaExtent(
                                 static_cast<std::size_t>(extentWidthBytes),
@@ -615,7 +615,7 @@ namespace alpaka
                                 dstNativePtr,
                                 static_cast<std::size_t>(dstPitchBytesX),
                                 static_cast<std::size_t>(dstWidth),
-                                static_cast<std::size_t>(dstPitchBytesY/dstPitchBytesX));
+                                static_cast<std::size_t>(dstPitchBytesY / dstPitchBytesX));
                         cudaMemCpy3DPeerParms.extent =
                             make_cudaExtent(
                                 static_cast<std::size_t>(extentWidthBytes),
@@ -629,7 +629,7 @@ namespace alpaka
                                 const_cast<void *>(srcNativePtr),
                                 static_cast<std::size_t>(srcPitchBytesX),
                                 static_cast<std::size_t>(srcWidth),
-                                static_cast<std::size_t>(srcPitchBytesY/srcPitchBytesX));
+                                static_cast<std::size_t>(srcPitchBytesY / srcPitchBytesX));
 
                         return cudaMemCpy3DPeerParms;
                     }
@@ -689,7 +689,7 @@ namespace alpaka
                                 const_cast<void *>(srcNativePtr),
                                 static_cast<std::size_t>(srcPitchBytesX),
                                 static_cast<std::size_t>(srcWidth),
-                                static_cast<std::size_t>(srcPitchBytesY/srcPitchBytesX));
+                                static_cast<std::size_t>(srcPitchBytesY / srcPitchBytesX));
 
                         return cudaMemCpy3DPeerParms;
                     }
@@ -722,6 +722,11 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    if(task.m_extentWidthBytes == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -782,6 +787,11 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    if(task.m_extentWidthBytes == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -840,6 +850,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -908,6 +924,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -974,6 +996,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0 || task.m_extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 
@@ -1028,6 +1056,12 @@ namespace alpaka
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                     task.printDebug();
 #endif
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(task.m_extentWidthBytes == 0 || task.m_extentHeight == 0 || task.m_extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const & iDstDev(task.m_iDstDevice);
                     auto const & iSrcDev(task.m_iSrcDevice);
 

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -162,7 +162,12 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
+
+                    if(extentWidth == 0)
+                    {
+                        return;
+                    }
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
 #endif
@@ -173,6 +178,9 @@ namespace alpaka
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
                             iDevice));
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
+
                     // Initiate the memory set.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaMemsetAsync(
@@ -214,12 +222,19 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
+
+                    if(extentWidth == 0)
+                    {
+                        return;
+                    }
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
 #endif
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(buf)));
                     assert(extentWidth <= dstWidth);
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
 
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
@@ -265,8 +280,15 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
                     auto const extentHeight(extent::getHeight(extent));
+
+                    if(extentWidth == 0 || extentHeight == 0)
+                    {
+                        return;
+                    }
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
                     auto const dstHeight(extent::getHeight(buf));
@@ -323,8 +345,15 @@ namespace alpaka
                     auto const & iDevice(task.m_iDevice);
 
                     auto const extentWidth(extent::getWidth(extent));
-                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
                     auto const extentHeight(extent::getHeight(extent));
+
+                    if(extentWidth == 0 || extentHeight == 0)
+                    {
+                        return;
+                    }
+
+                    auto const extentWidthBytes(extentWidth * static_cast<Size>(sizeof(elem::Elem<TView>)));
+
 #if !defined(NDEBUG)
                     auto const dstWidth(extent::getWidth(buf));
                     auto const dstHeight(extent::getHeight(buf));
@@ -338,6 +367,7 @@ namespace alpaka
                     ALPAKA_CUDA_RT_CHECK(
                         cudaSetDevice(
                             iDevice));
+
                     // Initiate the memory set.
                     ALPAKA_CUDA_RT_CHECK(
                         cudaMemset2D(
@@ -383,6 +413,13 @@ namespace alpaka
                     auto const extentWidth(extent::getWidth(extent));
                     auto const extentHeight(extent::getHeight(extent));
                     auto const extentDepth(extent::getDepth(extent));
+
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const dstWidth(extent::getWidth(buf));
 #if !defined(NDEBUG)
                     auto const dstHeight(extent::getHeight(buf));
@@ -401,7 +438,7 @@ namespace alpaka
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Size>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY/dstPitchBytesX)));
+                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
                     cudaExtent const cudaExtentVal(
                         make_cudaExtent(
@@ -457,6 +494,13 @@ namespace alpaka
                     auto const extentWidth(extent::getWidth(extent));
                     auto const extentHeight(extent::getHeight(extent));
                     auto const extentDepth(extent::getDepth(extent));
+
+                    // This is not only an optimization but also prevents a division by zero.
+                    if(extentWidth == 0 || extentHeight == 0 || extentDepth == 0)
+                    {
+                        return;
+                    }
+
                     auto const dstWidth(extent::getWidth(buf));
 #if !defined(NDEBUG)
                     auto const dstHeight(extent::getHeight(buf));
@@ -475,7 +519,7 @@ namespace alpaka
                             dstNativePtr,
                             static_cast<size_t>(dstPitchBytesX),
                             static_cast<size_t>(dstWidth * static_cast<Size>(sizeof(Elem))),
-                            static_cast<size_t>(dstPitchBytesY/dstPitchBytesX)));
+                            static_cast<size_t>(dstPitchBytesY / dstPitchBytesX)));
 
                     cudaExtent const cudaExtentVal(
                         make_cudaExtent(

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -410,12 +410,12 @@ namespace alpaka
                         {
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                            // Set the current device. \TODO: Is setting the current device before cudaFree required?
+                            // Set the current device.
                             ALPAKA_CUDA_RT_CHECK(
                                 cudaSetDevice(
                                     m_dev.m_iDevice));
                             // Free the buffer.
-                            cudaFree(m_devMem);
+                            ALPAKA_CUDA_RT_CHECK(cudaFree(m_devMem));
                         }
 
                         //-----------------------------------------------------------------------------


### PR DESCRIPTION
back-port of three PR's

- Move `runtime_error` out of the debug block #549
- Fixes CUDA driver API error handler. #548
- Fix cuda memcpy and memset for zero sized buffers (division by zero) #544

The commits are unchanged expect that the new namepsace `idx::Idx` is not used.