### PR TITLE
alpaka::ignore_unused

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -49,7 +49,7 @@
 
 #include <alpaka/core/Fibers.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <boost/predef.h>
 
 #include <memory>
@@ -179,7 +179,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> alpaka::acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(3));

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -52,7 +52,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <limits>
 #include <typeinfo>
@@ -173,7 +173,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> alpaka::acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return {
                         // m_multiProcessorCount

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -51,7 +51,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <omp.h>
 
@@ -175,7 +175,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> alpaka::acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(std::min(4, ::omp_get_max_threads())));

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -51,7 +51,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <omp.h>
 
@@ -175,7 +175,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(std::min(4, ::omp_get_max_threads())));

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -47,7 +47,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <memory>
 #include <typeinfo>
@@ -167,7 +167,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return {
                         // m_multiProcessorCount

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -47,7 +47,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <memory>
 #include <typeinfo>
@@ -165,7 +165,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return {
                         // m_multiProcessorCount

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -46,7 +46,7 @@
 // Implementation details.
 #include <alpaka/dev/DevCpu.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <boost/predef.h>
 
 #include <memory>
@@ -176,7 +176,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> acc::AccDevProps<TDim, TIdx>
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
 #ifdef ALPAKA_CI
                     auto const blockThreadCountMax(static_cast<TIdx>(8));

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/atomic/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -70,7 +70,7 @@ namespace alpaka
                     T const & value)
                 -> T
                 {
-                    boost::ignore_unused(atomic);
+                    alpaka::ignore_unused(atomic);
                     return TOp()(addr, value);
                 }
                 //-----------------------------------------------------------------------------
@@ -81,7 +81,7 @@ namespace alpaka
                     T const & value)
                 -> T
                 {
-                    boost::ignore_unused(atomic);
+                    alpaka::ignore_unused(atomic);
                     return TOp()(addr, compare, value);
                 }
             };

--- a/include/alpaka/atomic/AtomicOmpCritSec.hpp
+++ b/include/alpaka/atomic/AtomicOmpCritSec.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/atomic/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -79,7 +79,7 @@ namespace alpaka
                     T const & value)
                 -> T
                 {
-                    boost::ignore_unused(atomic);
+                    alpaka::ignore_unused(atomic);
                     T old;
                     // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
                     #pragma omp critical (AlpakaOmpAtomicOp)
@@ -96,7 +96,7 @@ namespace alpaka
                     T const & value)
                 -> T
                 {
-                    boost::ignore_unused(atomic);
+                    alpaka::ignore_unused(atomic);
                     T old;
                     // \TODO: Currently not only the access to the same memory location is protected by a mutex but all atomic ops on all threads.
                     #pragma omp critical (AlpakaOmpAtomicOp2)

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -73,7 +73,7 @@ namespace alpaka
                         block::sync::BlockSyncBarrierOmp const & blockSync)
                     -> void
                     {
-                        boost::ignore_unused(blockSync);
+                        alpaka::ignore_unused(blockSync);
 
                         // NOTE: This waits for all threads in all blocks.
                         // If multiple blocks are executed in parallel this is not optimal.

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -67,7 +67,7 @@ namespace alpaka
                         block::sync::BlockSyncNoOp const & /*blockSync*/)
                     -> void
                     {
-                        //boost::ignore_unused(blockSync);
+                        //alpaka::ignore_unused(blockSync);
                         // Nothing to do.
                     }
                 };
@@ -86,7 +86,7 @@ namespace alpaka
                         int predicate)
                     -> int
                     {
-                        //boost::ignore_unused(blockSync);
+                        //alpaka::ignore_unused(blockSync);
                         return predicate;
                     }
                 };

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -24,7 +24,7 @@
 #include <alpaka/core/Common.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 #include <boost/predef.h>
 
@@ -64,7 +64,7 @@ namespace alpaka
                 {
 #ifdef NDEBUG
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(arg);
+                    alpaka::ignore_unused(arg);
 #endif
 #else
                     assert(arg >= 0);
@@ -88,7 +88,7 @@ namespace alpaka
                 -> void
                 {
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(arg);
+                    alpaka::ignore_unused(arg);
 #endif
                     // Nothing to do for unsigned types.
                 }

--- a/include/alpaka/core/Unused.hpp
+++ b/include/alpaka/core/Unused.hpp
@@ -1,0 +1,49 @@
+/**
+* \file
+* Copyright 2018 Axel Huebl
+*
+* This file is part of alpaka.
+*
+* alpaka is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* alpaka is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with alpaka.
+* If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <alpaka/core/Common.hpp>
+
+#include <boost/config.hpp>
+
+namespace alpaka
+{
+    ALPAKA_NO_HOST_ACC_WARNING
+    template< typename... Ts >
+    BOOST_FORCEINLINE
+    BOOST_CXX14_CONSTEXPR
+    ALPAKA_FN_HOST_ACC
+    void
+    ignore_unused( Ts const& ... )
+    {}
+
+    ALPAKA_NO_HOST_ACC_WARNING
+    template< typename... Ts >
+    BOOST_FORCEINLINE
+    BOOST_CXX14_CONSTEXPR
+    ALPAKA_FN_HOST_ACC
+    void
+    ignore_unused()
+    {}
+
+} // namespace alpaka
+

--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/dev/cpu/SysInfo.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <map>
 #include <mutex>
@@ -211,7 +211,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> std::string
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return dev::cpu::detail::getCpuName();
                 }
@@ -228,7 +228,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> std::size_t
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return dev::cpu::detail::getTotalGlobalMemSizeBytes();
                 }
@@ -245,7 +245,7 @@ namespace alpaka
                     dev::DevCpu const & dev)
                 -> std::size_t
                 {
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     return dev::cpu::detail::getFreeGlobalMemSizeBytes();
                 }
@@ -264,7 +264,7 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_FULL_LOG_SCOPE;
 
-                    boost::ignore_unused(dev);
+                    alpaka::ignore_unused(dev);
 
                     // The CPU does nothing on reset.
                 }

--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -30,7 +30,7 @@
 #include <alpaka/wait/Traits.hpp>
 #include <alpaka/dev/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <cassert>
 #include <mutex>
@@ -263,7 +263,7 @@ namespace alpaka
                 {
                     ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 
-                    boost::ignore_unused(spQueueImpl);
+                    alpaka::ignore_unused(spQueueImpl);
 
                     auto spEventImpl(event.m_spEventImpl);
 
@@ -421,7 +421,7 @@ namespace alpaka
                     event::EventCpu const & event)
                 -> void
                 {
-                    boost::ignore_unused(spQueueImpl);
+                    alpaka::ignore_unused(spQueueImpl);
 
                     // Copy the shared pointer of the event implementation.
                     // This is forwarded to the lambda that is enqueued into the queue to ensure that the event implementation is alive as long as it is enqueued.

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -43,7 +43,7 @@
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <omp.h>
 
@@ -149,7 +149,7 @@ namespace alpaka
                 // The number of threads in this block.
                 TIdx const blockThreadCount(blockThreadExtent.prod());
                 int const iBlockThreadCount(static_cast<int>(blockThreadCount));
-                boost::ignore_unused(iBlockThreadCount);
+                alpaka::ignore_unused(iBlockThreadCount);
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());
                 ::omp_set_dynamic(0);
@@ -173,7 +173,7 @@ namespace alpaka
                             if((::omp_get_thread_num() == 0) && (acc.m_gridBlockIdx.sum() == static_cast<TIdx>(0)))
                             {
                                 int const numThreads(::omp_get_num_threads());
-                                boost::ignore_unused(numThreads);
+                                alpaka::ignore_unused(numThreads);
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
                                 std::cout << BOOST_CURRENT_FUNCTION << " omp_get_num_threads: " << numThreads << std::endl;
 #endif

--- a/include/alpaka/exec/ExecCpuSerial.hpp
+++ b/include/alpaka/exec/ExecCpuSerial.hpp
@@ -39,7 +39,7 @@
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/ApplyTuple.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <boost/assert.hpp>
 
 #include <tuple>

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -28,7 +28,7 @@
 #include <alpaka/dim/DimIntegralConst.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <type_traits>
@@ -141,7 +141,7 @@ namespace alpaka
             -> idx::Idx<TExtent>
             {
 #if !BOOST_ARCH_PTX
-                boost::ignore_unused(indices);
+                alpaka::ignore_unused(indices);
 #endif
                 return
                     meta::foldr(

--- a/include/alpaka/idx/Accessors.hpp
+++ b/include/alpaka/idx/Accessors.hpp
@@ -35,7 +35,7 @@
 
 #include <boost/config.hpp>
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <utility>
@@ -208,7 +208,7 @@ namespace alpaka
         -> vec::Vec<dim::Dim<TIdxWorkDiv>, idx::Idx<TIdxWorkDiv>>
         {
 #if !BOOST_ARCH_PTX
-            boost::ignore_unused(idxWorkDiv);
+            alpaka::ignore_unused(idxWorkDiv);
 #endif
             return gridThreadIdx * threadElemExtent;
         }

--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -25,7 +25,7 @@
 #include <alpaka/core/Common.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 namespace alpaka
@@ -67,7 +67,7 @@ namespace alpaka
                 -> vec::Vec<dim::DimInt<TidxDim>, TElem>
                 {
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(extent);
+                    alpaka::ignore_unused(extent);
 #endif
                     return idx;
                 }

--- a/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
@@ -35,7 +35,7 @@
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/core/Positioning.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -108,7 +108,7 @@ namespace alpaka
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //boost::ignore_unused(idx);
+                    //alpaka::ignore_unused(idx);
                     return vec::cast<TIdx>(offset::getOffsetVecEnd<TDim>(threadIdx));
                 }
             };

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -30,7 +30,7 @@
 
 #include <alpaka/core/Positioning.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <omp.h>
 
@@ -107,7 +107,7 @@ namespace alpaka
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    boost::ignore_unused(idx);
+                    alpaka::ignore_unused(idx);
                     // We assume that the thread id is positive.
                     assert(::omp_get_thread_num()>=0);
                     // \TODO: Would it be faster to precompute the index and cache it inside an array?

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/vec/Vec.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <map>
 #include <cassert>
@@ -115,7 +115,7 @@ namespace alpaka
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    boost::ignore_unused(workDiv);
+                    alpaka::ignore_unused(workDiv);
                     auto const fiberId(boost::this_fiber::get_id());
                     auto const fiberEntry(idx.m_fibersToIndices.find(fiberId));
                     assert(fiberEntry != idx.m_fibersToIndices.end());

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -29,7 +29,7 @@
 
 #include <alpaka/vec/Vec.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <thread>
 #include <map>
@@ -114,7 +114,7 @@ namespace alpaka
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    boost::ignore_unused(workDiv);
+                    alpaka::ignore_unused(workDiv);
                     auto const threadId(std::this_thread::get_id());
                     auto const threadEntry(idx.m_threadToIndexMap.find(threadId));
                     assert(threadEntry != idx.m_threadToIndexMap.end());

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/vec/Vec.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -100,8 +100,8 @@ namespace alpaka
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    boost::ignore_unused(idx);
-                    boost::ignore_unused(workDiv);
+                    alpaka::ignore_unused(idx);
+                    alpaka::ignore_unused(workDiv);
                     return vec::Vec<TDim, TIdx>::zeros();
                 }
             };

--- a/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
@@ -35,7 +35,7 @@
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/core/Positioning.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -108,7 +108,7 @@ namespace alpaka
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //boost::ignore_unused(idx);
+                    //alpaka::ignore_unused(idx);
                     return vec::cast<TIdx>(offset::getOffsetVecEnd<TDim>(blockIdx));
                 }
             };

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -28,7 +28,7 @@
 
 #include <alpaka/vec/Vec.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -107,7 +107,7 @@ namespace alpaka
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    boost::ignore_unused(workDiv);
+                    alpaka::ignore_unused(workDiv);
                     return idx.m_gridBlockIdx;
                 }
             };

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -35,7 +35,7 @@
 
 #include <boost/predef.h>
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <type_traits>
@@ -109,10 +109,10 @@ namespace alpaka
                 -> idx::Idx<TAcc>
                 {
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(kernelFnObj);
-                    boost::ignore_unused(blockThreadExtent);
-                    boost::ignore_unused(threadElemExtent);
-                    boost::ignore_unused(args...);
+                    alpaka::ignore_unused(kernelFnObj);
+                    alpaka::ignore_unused(blockThreadExtent);
+                    alpaka::ignore_unused(threadElemExtent);
+                    alpaka::ignore_unused(args...);
 #endif
 
                     return 0;

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/abs/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::abs(arg))
                 {
-                    //boost::ignore_unused(abs);
+                    //alpaka::ignore_unused(abs);
                     return ::abs(arg);
                 }
             };

--- a/include/alpaka/math/abs/AbsStl.hpp
+++ b/include/alpaka/math/abs/AbsStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/abs/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cstdlib>
@@ -59,7 +59,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::abs(arg))
                 {
-                    boost::ignore_unused(abs);
+                    alpaka::ignore_unused(abs);
                     return std::abs(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/acos/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -70,7 +70,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::acos(arg))
                 {
-                    //boost::ignore_unused(acos);
+                    //alpaka::ignore_unused(acos);
                     return ::acos(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosStl.hpp
+++ b/include/alpaka/math/acos/AcosStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/acos/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::acos(arg))
                 {
-                    boost::ignore_unused(acos);
+                    alpaka::ignore_unused(acos);
                     return std::acos(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/asin/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::asin(arg))
                 {
-                    //boost::ignore_unused(asin);
+                    //alpaka::ignore_unused(asin);
                     return ::asin(arg);
                 }
             };

--- a/include/alpaka/math/asin/AsinStl.hpp
+++ b/include/alpaka/math/asin/AsinStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/asin/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::asin(arg))
                 {
-                    boost::ignore_unused(asin);
+                    alpaka::ignore_unused(asin);
                     return std::asin(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/atan/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::atan(arg))
                 {
-                    //boost::ignore_unused(atan);
+                    //alpaka::ignore_unused(atan);
                     return ::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanStl.hpp
+++ b/include/alpaka/math/atan/AtanStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/atan/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::atan(arg))
                 {
-                    boost::ignore_unused(atan);
+                    alpaka::ignore_unused(atan);
                     return std::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/atan2/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -73,7 +73,7 @@ namespace alpaka
                     Tx const & x)
                 -> decltype(::atan2(y, x))
                 {
-                    //boost::ignore_unused(abs);
+                    //alpaka::ignore_unused(abs);
                     return ::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2Stl.hpp
+++ b/include/alpaka/math/atan2/Atan2Stl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/atan2/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,7 +61,7 @@ namespace alpaka
                     Tx const & x)
                 -> decltype(std::atan2(y, x))
                 {
-                    boost::ignore_unused(abs);
+                    alpaka::ignore_unused(abs);
                     return std::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/cbrt/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -65,7 +65,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))
                 {
-                    //boost::ignore_unused(cbrt);
+                    //alpaka::ignore_unused(cbrt);
                     return std::cbrt(arg);
                 }
             };

--- a/include/alpaka/math/cbrt/CbrtStl.hpp
+++ b/include/alpaka/math/cbrt/CbrtStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/cbrt/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))
                 {
-                    boost::ignore_unused(cbrt);
+                    alpaka::ignore_unused(cbrt);
                     return std::cbrt(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/ceil/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::ceil(arg))
                 {
-                    //boost::ignore_unused(ceil);
+                    //alpaka::ignore_unused(ceil);
                     return ::ceil(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilStl.hpp
+++ b/include/alpaka/math/ceil/CeilStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/ceil/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::ceil(arg))
                 {
-                    boost::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil);
                     return std::ceil(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/cos/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::cos(arg))
                 {
-                    //boost::ignore_unused(cos);
+                    //alpaka::ignore_unused(cos);
                     return ::cos(arg);
                 }
             };

--- a/include/alpaka/math/cos/CosStl.hpp
+++ b/include/alpaka/math/cos/CosStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/cos/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::cos(arg))
                 {
-                    boost::ignore_unused(cos);
+                    alpaka::ignore_unused(cos);
                     return std::cos(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/erf/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::erf(arg))
                 {
-                    //boost::ignore_unused(erf);
+                    //alpaka::ignore_unused(erf);
                     return ::erf(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfStl.hpp
+++ b/include/alpaka/math/erf/ErfStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/erf/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::erf(arg))
                 {
-                    boost::ignore_unused(erf);
+                    alpaka::ignore_unused(erf);
                     return std::erf(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/exp/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::exp(arg))
                 {
-                    //boost::ignore_unused(exp);
+                    //alpaka::ignore_unused(exp);
                     return ::exp(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpStl.hpp
+++ b/include/alpaka/math/exp/ExpStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/exp/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::exp(arg))
                 {
-                    boost::ignore_unused(exp);
+                    alpaka::ignore_unused(exp);
                     return std::exp(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/floor/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::floor(arg))
                 {
-                    //boost::ignore_unused(floor);
+                    //alpaka::ignore_unused(floor);
                     return ::floor(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorStl.hpp
+++ b/include/alpaka/math/floor/FloorStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/floor/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::floor(arg))
                 {
-                    boost::ignore_unused(floor);
+                    alpaka::ignore_unused(floor);
                     return std::floor(arg);
                 }
             };

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/fmod/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -73,7 +73,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(::fmod(x, y))
                 {
-                    //boost::ignore_unused(fmod);
+                    //alpaka::ignore_unused(fmod);
                     return ::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/fmod/FmodStl.hpp
+++ b/include/alpaka/math/fmod/FmodStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/fmod/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,7 +61,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::fmod(x, y))
                 {
-                    boost::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod);
                     return std::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/log/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::log(arg))
                 {
-                    //boost::ignore_unused(log);
+                    //alpaka::ignore_unused(log);
                     return ::log(arg);
                 }
             };

--- a/include/alpaka/math/log/LogStl.hpp
+++ b/include/alpaka/math/log/LogStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/log/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::log(arg))
                 {
-                    boost::ignore_unused(log);
+                    alpaka::ignore_unused(log);
                     return std::log(arg);
                 }
             };

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/max/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -73,7 +73,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(::max(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    //alpaka::ignore_unused(max);
                     return ::max(x, y);
                 }
             };
@@ -98,7 +98,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(::fmax(x, y))
                 {
-                    //boost::ignore_unused(max);
+                    //alpaka::ignore_unused(max);
                     return ::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/max/MaxStl.hpp
+++ b/include/alpaka/math/max/MaxStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/max/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -62,7 +62,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::max(x, y))
                 {
-                    boost::ignore_unused(max);
+                    alpaka::ignore_unused(max);
                     return std::max(x, y);
                 }
             };
@@ -87,7 +87,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::fmax(x, y))
                 {
-                    boost::ignore_unused(max);
+                    alpaka::ignore_unused(max);
                     return std::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/min/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -74,7 +74,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(::min(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    //alpaka::ignore_unused(min);
                     return ::min(x, y);
                 }
             };
@@ -99,7 +99,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(::fmin(x, y))
                 {
-                    //boost::ignore_unused(min);
+                    //alpaka::ignore_unused(min);
                     return ::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinStl.hpp
+++ b/include/alpaka/math/min/MinStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/min/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -62,7 +62,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::min(x, y))
                 {
-                    boost::ignore_unused(min);
+                    alpaka::ignore_unused(min);
                     return std::min(x, y);
                 }
             };
@@ -87,7 +87,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::fmin(x, y))
                 {
-                    boost::ignore_unused(min);
+                    alpaka::ignore_unused(min);
                     return std::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/pow/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -73,7 +73,7 @@ namespace alpaka
                     TExp const & exp)
                 -> decltype(::pow(base, exp))
                 {
-                    //boost::ignore_unused(pow);
+                    //alpaka::ignore_unused(pow);
                     return ::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/pow/PowStl.hpp
+++ b/include/alpaka/math/pow/PowStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/pow/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,7 +61,7 @@ namespace alpaka
                     TExp const & exp)
                 -> decltype(std::pow(base, exp))
                 {
-                    boost::ignore_unused(pow);
+                    alpaka::ignore_unused(pow);
                     return std::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/remainder/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::remainder(arg))
                 {
-                    //boost::ignore_unused(remainder);
+                    //alpaka::ignore_unused(remainder);
                     return ::remainder(arg);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderStl.hpp
+++ b/include/alpaka/math/remainder/RemainderStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/remainder/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,7 +61,7 @@ namespace alpaka
                     Ty const & y)
                 -> decltype(std::remainder(x, y))
                 {
-                    boost::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder);
                     return std::remainder(x, y);
                 }
             };

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/round/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::round(arg))
                 {
-                    //boost::ignore_unused(round);
+                    //alpaka::ignore_unused(round);
                     return ::round(arg);
                 }
             };
@@ -88,7 +88,7 @@ namespace alpaka
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(lround);
+                    //alpaka::ignore_unused(lround);
                     return ::lround(arg);
                 }
             };
@@ -107,7 +107,7 @@ namespace alpaka
                     TArg const & arg)
                 -> long int
                 {
-                    //boost::ignore_unused(llround);
+                    //alpaka::ignore_unused(llround);
                     return ::llround(arg);
                 }
             };

--- a/include/alpaka/math/round/RoundStl.hpp
+++ b/include/alpaka/math/round/RoundStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/round/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::round(arg))
                 {
-                    boost::ignore_unused(round);
+                    alpaka::ignore_unused(round);
                     return std::round(arg);
                 }
             };
@@ -76,7 +76,7 @@ namespace alpaka
                     TArg const & arg)
                 -> long int
                 {
-                    boost::ignore_unused(lround);
+                    alpaka::ignore_unused(lround);
                     return std::lround(arg);
                 }
             };
@@ -95,7 +95,7 @@ namespace alpaka
                     TArg const & arg)
                 -> long int
                 {
-                    boost::ignore_unused(llround);
+                    alpaka::ignore_unused(llround);
                     return std::llround(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/rsqrt/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))
                 {
-                    //boost::ignore_unused(rsqrt);
+                    //alpaka::ignore_unused(rsqrt);
                     return ::rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtStl.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/rsqrt/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))
                 {
-                    boost::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt);
                     return static_cast<TArg>(1)/std::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/sin/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::sin(arg))
                 {
-                    //boost::ignore_unused(sin);
+                    //alpaka::ignore_unused(sin);
                     return ::sin(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinStl.hpp
+++ b/include/alpaka/math/sin/SinStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/sin/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::sin(arg))
                 {
-                    boost::ignore_unused(sin);
+                    alpaka::ignore_unused(sin);
                     return std::sin(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/sqrt/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::sqrt(arg))
                 {
-                    //boost::ignore_unused(sqrt);
+                    //alpaka::ignore_unused(sqrt);
                     return ::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtStl.hpp
+++ b/include/alpaka/math/sqrt/SqrtStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/sqrt/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))
                 {
-                    boost::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt);
                     return std::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/tan/Traits.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::tan(arg))
                 {
-                    //boost::ignore_unused(tan);
+                    //alpaka::ignore_unused(tan);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanStl.hpp
+++ b/include/alpaka/math/tan/TanStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/tan/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::tan(arg))
                 {
-                    boost::ignore_unused(tan);
+                    alpaka::ignore_unused(tan);
                     return std::tan(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -31,7 +31,7 @@
 
 #include <alpaka/math/trunc/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,7 +69,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(::trunc(arg))
                 {
-                    //boost::ignore_unused(trunc);
+                    //alpaka::ignore_unused(trunc);
                     return ::trunc(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncStl.hpp
+++ b/include/alpaka/math/trunc/TruncStl.hpp
@@ -23,7 +23,7 @@
 
 #include <alpaka/math/trunc/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -57,7 +57,7 @@ namespace alpaka
                     TArg const & arg)
                 -> decltype(std::trunc(arg))
                 {
-                    boost::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc);
                     return std::trunc(arg);
                 }
             };

--- a/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuBoostAligned.hpp
@@ -26,7 +26,7 @@
 #include <alpaka/core/Common.hpp>
 
 #include <boost/align.hpp>
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -65,7 +65,7 @@ namespace alpaka
                         std::size_t const & sizeElems)
                     -> T *
                     {
-                        boost::ignore_unused(alloc);
+                        alpaka::ignore_unused(alloc);
                         return
                             reinterpret_cast<T *>(
                                 boost::alignment::aligned_alloc(TAlignment::value, sizeElems * sizeof(T)));
@@ -87,7 +87,7 @@ namespace alpaka
                         T const * const ptr)
                     -> void
                     {
-                        boost::ignore_unused(alloc);
+                        alpaka::ignore_unused(alloc);
                             boost::alignment::aligned_free(
                                 const_cast<void *>(
                                     reinterpret_cast<void const *>(ptr)));

--- a/include/alpaka/mem/alloc/AllocCpuNew.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuNew.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -59,7 +59,7 @@ namespace alpaka
                         std::size_t const & sizeElems)
                     -> T *
                     {
-                        boost::ignore_unused(alloc);
+                        alpaka::ignore_unused(alloc);
                         return new T[sizeElems];
                     }
                 };
@@ -78,7 +78,7 @@ namespace alpaka
                         T const * const ptr)
                     -> void
                     {
-                        boost::ignore_unused(alloc);
+                        alpaka::ignore_unused(alloc);
                         return delete[] ptr;
                     }
                 };

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -39,7 +39,7 @@
 #include <alpaka/meta/DependentFalseType.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <memory>
@@ -578,7 +578,7 @@ namespace alpaka
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
                         return bufImpl.m_bPinned;
 #else
-                        boost::ignore_unused(bufImpl);
+                        alpaka::ignore_unused(bufImpl);
                         return false;
 #endif
                     }

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -33,7 +33,7 @@
 #include <alpaka/core/Common.hpp>
 
 #include <boost/config.hpp>
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <iosfwd>
 
@@ -480,8 +480,8 @@ namespace alpaka
                         std::string const & rowSuffix)
                     -> void
                     {
-                        boost::ignore_unused(view);
-                        boost::ignore_unused(rowSeparator);
+                        alpaka::ignore_unused(view);
+                        alpaka::ignore_unused(rowSeparator);
 
                         os << rowPrefix;
 

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -26,7 +26,7 @@
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <boost/predef.h>
 
 #include <type_traits>
@@ -128,7 +128,7 @@ namespace alpaka
                 )
                 -> idx::Idx<TFixedSizeArray>
                 {
-                    //boost::ignore_unused(extent);
+                    //alpaka::ignore_unused(extent);
                     return std::extent<TFixedSizeArray, TIdxIntegralConst::value>::value;
                 }
             };

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -26,7 +26,7 @@
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <array>
 
@@ -60,7 +60,7 @@ namespace alpaka
                     std::array<TElem, Tsize> const & view)
                 -> dev::DevCpu
                 {
-                    boost::ignore_unused(view);
+                    alpaka::ignore_unused(view);
                     return pltf::getDevByIdx<pltf::PltfCpu>(0u);
                 }
             };
@@ -117,7 +117,7 @@ namespace alpaka
                 -> idx::Idx<std::array<TElem, Tsize>>
                 {
                     // C++14
-                    /*boost::ignore_unused(extent);*/
+                    /*alpaka::ignore_unused(extent);*/
                     return Tsize;
                 }
             };

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -26,7 +26,7 @@
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <vector>
 
@@ -60,7 +60,7 @@ namespace alpaka
                     std::vector<TElem, TAllocator> const & view)
                 -> dev::DevCpu
                 {
-                    boost::ignore_unused(view);
+                    alpaka::ignore_unused(view);
                     return pltf::getDevByIdx<pltf::PltfCpu>(0u);
                 }
             };

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -26,7 +26,7 @@
 #include <alpaka/meta/IntegerSequence.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 #include <boost/config.hpp>
 
@@ -101,7 +101,7 @@ namespace alpaka
             {
                 // If the the index sequence is empty, t will not be used at all.
 #if !BOOST_ARCH_PTX
-                boost::ignore_unused(t);
+                alpaka::ignore_unused(t);
 #endif
                 return
                     meta::invoke(

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -26,7 +26,7 @@
 #include <boost/config.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
@@ -52,7 +52,7 @@ namespace alpaka
         -> T
         {
 #if !BOOST_ARCH_PTX
-            boost::ignore_unused(f);
+            alpaka::ignore_unused(f);
 #endif
             return t;
         }

--- a/include/alpaka/meta/ForEachType.hpp
+++ b/include/alpaka/meta/ForEachType.hpp
@@ -25,7 +25,7 @@
 
 #include <boost/predef.h>
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <utility>
@@ -62,8 +62,8 @@ namespace alpaka
                 -> void
                 {
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(f);
-                    boost::ignore_unused(args...);
+                    alpaka::ignore_unused(f);
+                    alpaka::ignore_unused(args...);
 #endif
                 }
             };

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -27,7 +27,7 @@
 #include <alpaka/core/Common.hpp>
 
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 namespace alpaka
@@ -66,9 +66,9 @@ namespace alpaka
                 -> void
                 {
 #if !BOOST_ARCH_PTX
-                    boost::ignore_unused(idx);
-                    boost::ignore_unused(extent);
-                    boost::ignore_unused(f);
+                    alpaka::ignore_unused(idx);
+                    alpaka::ignore_unused(extent);
+                    alpaka::ignore_unused(f);
 #endif
                 }
             };
@@ -174,7 +174,7 @@ namespace alpaka
         -> void
         {
 #if !BOOST_ARCH_PTX
-            boost::ignore_unused(indexSequence);
+            alpaka::ignore_unused(indexSequence);
 #endif
 
             static_assert(

--- a/include/alpaka/queue/QueueCpuSync.hpp
+++ b/include/alpaka/queue/QueueCpuSync.hpp
@@ -28,7 +28,7 @@
 #include <alpaka/queue/Traits.hpp>
 #include <alpaka/wait/Traits.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -172,7 +172,7 @@ namespace alpaka
                     TTask const & task)
                 -> void
                 {
-                    boost::ignore_unused(queue);
+                    alpaka::ignore_unused(queue);
                     task();
                 }
             };
@@ -187,7 +187,7 @@ namespace alpaka
                     queue::QueueCpuSync const & queue)
                 -> bool
                 {
-                    boost::ignore_unused(queue);
+                    alpaka::ignore_unused(queue);
                     return true;
                 }
             };
@@ -211,7 +211,7 @@ namespace alpaka
                     queue::QueueCpuSync const & queue)
                 -> void
                 {
-                    boost::ignore_unused(queue);
+                    alpaka::ignore_unused(queue);
                 }
             };
         }

--- a/include/alpaka/rand/RandStl.hpp
+++ b/include/alpaka/rand/RandStl.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <random>
 #include <type_traits>
@@ -195,7 +195,7 @@ namespace alpaka
                         RandStl const & rand)
                     -> rand::distribution::cpu::NormalReal<T>
                     {
-                        boost::ignore_unused(rand);
+                        alpaka::ignore_unused(rand);
                         return rand::distribution::cpu::NormalReal<T>();
                     }
                 };
@@ -214,7 +214,7 @@ namespace alpaka
                         RandStl const & rand)
                     -> rand::distribution::cpu::UniformReal<T>
                     {
-                        boost::ignore_unused(rand);
+                        alpaka::ignore_unused(rand);
                         return rand::distribution::cpu::UniformReal<T>();
                     }
                 };
@@ -233,7 +233,7 @@ namespace alpaka
                         RandStl const & rand)
                     -> rand::distribution::cpu::UniformUint<T>
                     {
-                        boost::ignore_unused(rand);
+                        alpaka::ignore_unused(rand);
                         return rand::distribution::cpu::UniformUint<T>();
                     }
                 };
@@ -256,7 +256,7 @@ namespace alpaka
                         std::uint32_t const & subsequence)
                     -> rand::generator::cpu::MersenneTwister
                     {
-                        boost::ignore_unused(rand);
+                        alpaka::ignore_unused(rand);
                         return rand::generator::cpu::MersenneTwister(
                             seed,
                             subsequence);

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -27,7 +27,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <omp.h>
 
@@ -69,7 +69,7 @@ namespace alpaka
                     time::TimeOmp const & time)
                 -> std::uint64_t
                 {
-                    boost::ignore_unused(time);
+                    alpaka::ignore_unused(time);
                     // NOTE: We compute the number of clock ticks by dividing the following durations:
                     // - omp_get_wtime returns the elapsed wall clock time in seconds.
                     // - omp_get_wtick gets the timer precision, i.e., the number of seconds between two successive clock ticks. 

--- a/include/alpaka/time/TimeStl.hpp
+++ b/include/alpaka/time/TimeStl.hpp
@@ -25,7 +25,7 @@
 
 #include <alpaka/core/Common.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 //#include <ctime>
 #include <chrono>
@@ -68,7 +68,7 @@ namespace alpaka
                     time::TimeStl const & time)
                 -> std::uint64_t
                 {
-                    boost::ignore_unused(time);
+                    alpaka::ignore_unused(time);
 
                     // NOTE: high_resolution_clock returns a non-steady wall-clock time!
                     // This means that it is not ensured that the values will always increase monotonically.

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -37,7 +37,7 @@
 #include <boost/predef.h>
 #include <boost/config.hpp>
 #if !BOOST_ARCH_PTX
-    #include <boost/core/ignore_unused.hpp>
+    #include <alpaka/core/Unused.hpp>
 #endif
 
 #include <cstdint>
@@ -84,7 +84,7 @@ namespace alpaka
 #endif
         {
 #if !BOOST_ARCH_PTX
-            boost::ignore_unused(indices);
+            alpaka::ignore_unused(indices);
 #endif
             return Vec<TDim, decltype(TTFnObj<0>::create(std::forward<TArgs>(args)...))>(
                 (TTFnObj<TIndices>::create(std::forward<TArgs>(args)...))...);
@@ -216,7 +216,7 @@ namespace alpaka
             -> Vec<TDim, TVal>
             {
 #if !BOOST_ARCH_PTX
-                boost::ignore_unused(indices);
+                alpaka::ignore_unused(indices);
 #endif
                 return Vec<TDim, TVal>(
                     (TTFnObj<TIndices>::create(std::forward<TArgs>(args)...))...);
@@ -402,7 +402,7 @@ namespace alpaka
 #endif
             {
 #if !BOOST_ARCH_PTX
-                boost::ignore_unused(indices);
+                alpaka::ignore_unused(indices);
 #endif
                 return
                     meta::foldr(
@@ -955,7 +955,7 @@ namespace alpaka
                 {
 #if !BOOST_ARCH_PTX
                     // In the case of a zero dimensional vector, vec is unused.
-                    boost::ignore_unused(vec);
+                    alpaka::ignore_unused(vec);
 #endif
 
                     static_assert(sizeof...(TIndices) <= TDim::value, "The sub-vector has to be smaller (or same idx) then the origin vector.");

--- a/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
@@ -35,7 +35,7 @@
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/core/Cuda.hpp>
 
-//#include <boost/core/ignore_unused.hpp>
+//#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -126,7 +126,7 @@ namespace alpaka
                     WorkDivCudaBuiltIn<TDim, TIdx> const & /*workDiv*/)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //boost::ignore_unused(workDiv);
+                    //alpaka::ignore_unused(workDiv);
                     return vec::cast<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
                 }
             };
@@ -147,7 +147,7 @@ namespace alpaka
                     WorkDivCudaBuiltIn<TDim, TIdx> const & /*workDiv*/)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //boost::ignore_unused(workDiv);
+                    //alpaka::ignore_unused(workDiv);
                     return vec::cast<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
                 }
             };

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -44,7 +44,7 @@
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/queue/Queue.hpp>
 
-#include <boost/core/ignore_unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <iostream>
 #include <typeinfo>
@@ -209,18 +209,18 @@ namespace alpaka
                     TIndex const & ldc)
                 -> TIndex
                 {
-                    boost::ignore_unused(matMulKernel);
-                    boost::ignore_unused(m);
-                    boost::ignore_unused(n);
-                    boost::ignore_unused(k);
-                    boost::ignore_unused(alpha);
-                    boost::ignore_unused(A);
-                    boost::ignore_unused(lda);
-                    boost::ignore_unused(B);
-                    boost::ignore_unused(ldb);
-                    boost::ignore_unused(beta);
-                    boost::ignore_unused(C);
-                    boost::ignore_unused(ldc);
+                    alpaka::ignore_unused(matMulKernel);
+                    alpaka::ignore_unused(m);
+                    alpaka::ignore_unused(n);
+                    alpaka::ignore_unused(k);
+                    alpaka::ignore_unused(alpha);
+                    alpaka::ignore_unused(A);
+                    alpaka::ignore_unused(lda);
+                    alpaka::ignore_unused(B);
+                    alpaka::ignore_unused(ldb);
+                    alpaka::ignore_unused(beta);
+                    alpaka::ignore_unused(C);
+                    alpaka::ignore_unused(ldc);
 
                     // Reserve the buffer for the two blocks of A and B.
                     return 2u * blockThreadExtent.prod() * threadElemExtent.prod() * sizeof(TElem);

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -155,7 +155,7 @@ namespace alpaka
                     TArgs && ...)
                 -> idx::Idx<TAcc>
                 {
-                    boost::ignore_unused(sharedMemKernel);
+                    alpaka::ignore_unused(sharedMemKernel);
                     return blockThreadExtent.prod() * threadElemExtent.prod() * static_cast<idx::Idx<TAcc>>(sizeof(Val));
                 }
             };

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -93,7 +93,7 @@ namespace alpaka
                     TVec const & threadElemExtent)
                 -> idx::Idx<TAcc>
                 {
-                    boost::ignore_unused(blockSharedMemDyn);
+                    alpaka::ignore_unused(blockSharedMemDyn);
                     return
                         static_cast<idx::Idx<TAcc>>(sizeof(std::uint32_t)) * blockThreadExtent.prod() * threadElemExtent.prod();
                 }

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -107,8 +107,8 @@ namespace alpaka
                 {
                     using Idx = alpaka::idx::Idx<TAcc>;
 
-                    boost::ignore_unused(blockSharedMemDyn);
-                    boost::ignore_unused(threadElemExtent);
+                    alpaka::ignore_unused(blockSharedMemDyn);
+                    alpaka::ignore_unused(threadElemExtent);
                     return
                         static_cast<idx::Idx<TAcc>>(sizeof(Idx)) * blockThreadExtent.prod();
                 }

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -28,6 +28,7 @@
 #define BOOST_MPL_CFG_GPU_ENABLED
 
 #include <alpaka/alpaka.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
@@ -48,10 +49,6 @@ BOOST_AUTO_TEST_SUITE(rand_)
 class RandTestKernel
 {
 public:
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
     //-----------------------------------------------------------------------------
     ALPAKA_NO_HOST_ACC_WARNING
     template<
@@ -62,10 +59,6 @@ public:
     {
         auto gen(alpaka::rand::generator::createDefault(acc, 12345u, 6789u));
 
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wunused-variable"
-#endif
 // gcc 5.4 in combination with nvcc 8.0 fails to compile the CPU STL distributions when --expt-relaxed-constexpr is enabled
 // /usr/include/c++/5/cmath(362): error: calling a __host__ function("__builtin_logl") from a __device__ function("std::log") is not allowed
 #if !((BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(5, 0, 0)) && (BOOST_COMP_NVCC == BOOST_VERSION_NUMBER(8, 0, 0)))
@@ -75,6 +68,7 @@ public:
 #if !BOOST_ARCH_PTX
             BOOST_VERIFY(std::isfinite(r));
 #endif
+            alpaka::ignore_unused(r);
         }
 
         {
@@ -83,6 +77,7 @@ public:
 #if !BOOST_ARCH_PTX
             BOOST_VERIFY(std::isfinite(r));
 #endif
+            alpaka::ignore_unused(r);
         }
         {
             auto dist(alpaka::rand::distribution::createUniformReal<float>(acc));
@@ -101,15 +96,10 @@ public:
         {
             auto dist(alpaka::rand::distribution::createUniformUint<std::uint32_t>(acc));
             auto const r = dist(gen);
+            alpaka::ignore_unused(r);
         }
 #endif
-#if BOOST_COMP_CLANG
-    #pragma clang diagnostic pop
-#endif
     }
-#if BOOST_COMP_GNUC
-    #pragma GCC diagnostic pop
-#endif
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Add a device-side compatible `ignore_unused` function.
Trivial implementation as in `boost/core/ignore_unused.hpp`

0.3.3 backport note: only first commit for #579