### PR TITLE
ignore_unused in Device

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -48,8 +48,8 @@
 #include <alpaka/dev/DevCpu.hpp>
 
 #include <alpaka/core/Fibers.hpp>
-
 #include <alpaka/core/Unused.hpp>
+
 #include <boost/predef.h>
 
 #include <memory>

--- a/include/alpaka/alpaka.hpp
+++ b/include/alpaka/alpaka.hpp
@@ -83,6 +83,7 @@
 #include <alpaka/core/Fibers.hpp>
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Unroll.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <alpaka/core/Utility.hpp>
 #include <alpaka/core/Vectorize.hpp>
 //-----------------------------------------------------------------------------

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -26,7 +26,6 @@
 #include <alpaka/block/sync/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 namespace alpaka

--- a/include/alpaka/block/sync/BlockSyncNoOp.hpp
+++ b/include/alpaka/block/sync/BlockSyncNoOp.hpp
@@ -24,7 +24,6 @@
 #include <alpaka/block/sync/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 namespace alpaka

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -22,10 +22,8 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 #include <boost/predef.h>
 
 #include <cassert>
@@ -51,21 +49,11 @@ namespace alpaka
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(
-#ifdef NDEBUG
-#if !BOOST_ARCH_PTX
                     TArg const & arg)
-#else
-                    TArg const &)
-#endif
-#else
-                    TArg const & arg)
-#endif
                 -> void
                 {
 #ifdef NDEBUG
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(arg);
-#endif
 #else
                     assert(arg >= 0);
 #endif
@@ -80,16 +68,10 @@ namespace alpaka
             {
                 ALPAKA_NO_HOST_ACC_WARNING
                 ALPAKA_FN_HOST_ACC static auto assertValueUnsigned(
-#if !BOOST_ARCH_PTX
                     TArg const & arg)
-#else
-                    TArg const &)
-#endif
                 -> void
                 {
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(arg);
-#endif
                     // Nothing to do for unsigned types.
                 }
             };

--- a/include/alpaka/extent/Traits.hpp
+++ b/include/alpaka/extent/Traits.hpp
@@ -27,9 +27,7 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
+#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <functional>
@@ -133,16 +131,11 @@ namespace alpaka
                 size_t... TIndices>
             ALPAKA_FN_HOST_ACC auto getExtentProductInternal(
                 TExtent const & extent,
-#if BOOST_ARCH_PTX
-                alpaka::meta::IndexSequence<TIndices...> const &)
-#else
                 alpaka::meta::IndexSequence<TIndices...> const & indices)
-#endif
             -> idx::Idx<TExtent>
             {
-#if !BOOST_ARCH_PTX
                 alpaka::ignore_unused(indices);
-#endif
+
                 return
                     meta::foldr(
                         std::multiplies<idx::Idx<TExtent>>(),

--- a/include/alpaka/idx/Accessors.hpp
+++ b/include/alpaka/idx/Accessors.hpp
@@ -33,10 +33,9 @@
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/workdiv/Traits.hpp>
 
+#include <alpaka/core/Unused.hpp>
+
 #include <boost/config.hpp>
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #include <utility>
 
@@ -198,18 +197,13 @@ namespace alpaka
             typename TGridThreadIdx,
             typename TThreadElemExtent>
         ALPAKA_FN_HOST_ACC auto getIdxThreadFirstElem(
-#if BOOST_ARCH_PTX
-            TIdxWorkDiv const &,
-#else
             TIdxWorkDiv const & idxWorkDiv,
-#endif
             TGridThreadIdx const & gridThreadIdx,
             TThreadElemExtent const & threadElemExtent)
         -> vec::Vec<dim::Dim<TIdxWorkDiv>, idx::Idx<TIdxWorkDiv>>
         {
-#if !BOOST_ARCH_PTX
             alpaka::ignore_unused(idxWorkDiv);
-#endif
+
             return gridThreadIdx * threadElemExtent;
         }
         //-----------------------------------------------------------------------------

--- a/include/alpaka/idx/MapIdx.hpp
+++ b/include/alpaka/idx/MapIdx.hpp
@@ -24,9 +24,7 @@
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/core/Common.hpp>
 
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -59,16 +57,11 @@ namespace alpaka
                     typename TElem>
                 ALPAKA_FN_HOST_ACC static auto mapIdx(
                     vec::Vec<dim::DimInt<TidxDim>, TElem> const & idx,
-#if !BOOST_ARCH_PTX
                     vec::Vec<dim::DimInt<TidxDim>, TElem> const & extent)
-#else
-                    vec::Vec<dim::DimInt<TidxDim>, TElem> const &)
-#endif
                 -> vec::Vec<dim::DimInt<TidxDim>, TElem>
                 {
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(extent);
-#endif
+
                     return idx;
                 }
             };

--- a/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
@@ -34,8 +34,7 @@
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/core/Positioning.hpp>
-
-//#include <alpaka/core/Unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -104,11 +103,11 @@ namespace alpaka
                 template<
                     typename TWorkDiv>
                 ALPAKA_FN_ACC_CUDA_ONLY static auto getIdx(
-                    idx::bt::IdxBtCudaBuiltIn<TDim, TIdx> const & /*idx*/,
+                    idx::bt::IdxBtCudaBuiltIn<TDim, TIdx> const & idx,
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //alpaka::ignore_unused(idx);
+                    alpaka::ignore_unused(idx);
                     return vec::cast<TIdx>(offset::getOffsetVecEnd<TDim>(threadIdx));
                 }
             };

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -29,7 +29,6 @@
 #include <alpaka/idx/MapIdx.hpp>
 
 #include <alpaka/core/Positioning.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <omp.h>

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -26,12 +26,11 @@
 #include <alpaka/idx/Traits.hpp>
 
 #include <alpaka/core/Fibers.hpp>
-
 #include <alpaka/core/Positioning.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/vec/Vec.hpp>
 
-#include <alpaka/core/Unused.hpp>
 
 #include <map>
 #include <cassert>

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -26,10 +26,9 @@
 #include <alpaka/idx/Traits.hpp>
 
 #include <alpaka/core/Positioning.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/vec/Vec.hpp>
-
-#include <alpaka/core/Unused.hpp>
 
 #include <thread>
 #include <map>

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -24,10 +24,9 @@
 #include <alpaka/idx/Traits.hpp>
 
 #include <alpaka/core/Positioning.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/vec/Vec.hpp>
-
-#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {

--- a/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
@@ -34,8 +34,7 @@
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/core/Cuda.hpp>
 #include <alpaka/core/Positioning.hpp>
-
-//#include <alpaka/core/Unused.hpp>
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -104,11 +103,11 @@ namespace alpaka
                 template<
                     typename TWorkDiv>
                 ALPAKA_FN_ACC_CUDA_ONLY static auto getIdx(
-                    idx::gb::IdxGbCudaBuiltIn<TDim, TIdx> const & /*idx*/,
+                    idx::gb::IdxGbCudaBuiltIn<TDim, TIdx> const & idx,
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //alpaka::ignore_unused(idx);
+                    alpaka::ignore_unused(idx);
                     return vec::cast<TIdx>(offset::getOffsetVecEnd<TDim>(blockIdx));
                 }
             };

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -25,10 +25,9 @@
 #include <alpaka/dim/Traits.hpp>
 
 #include <alpaka/core/Positioning.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/vec/Vec.hpp>
-
-#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {

--- a/include/alpaka/kernel/Traits.hpp
+++ b/include/alpaka/kernel/Traits.hpp
@@ -23,6 +23,7 @@
 
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/dim/Traits.hpp>
 #include <alpaka/idx/Traits.hpp>
@@ -34,9 +35,6 @@
 #endif
 
 #include <boost/predef.h>
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #include <type_traits>
 
@@ -95,25 +93,16 @@ namespace alpaka
                     typename TDim,
                     typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(
-#if !BOOST_ARCH_PTX
                     TKernelFnObj const & kernelFnObj,
                     vec::Vec<TDim, idx::Idx<TAcc>> const & blockThreadExtent,
                     vec::Vec<TDim, idx::Idx<TAcc>> const & threadElemExtent,
                     TArgs const & ... args)
-#else
-                    TKernelFnObj const &,
-                    vec::Vec<TDim, idx::Idx<TAcc>> const &,
-                    vec::Vec<TDim, idx::Idx<TAcc>> const &,
-                    TArgs const & ...)
-#endif
                 -> idx::Idx<TAcc>
                 {
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(kernelFnObj);
                     alpaka::ignore_unused(blockThreadExtent);
                     alpaka::ignore_unused(threadElemExtent);
                     alpaka::ignore_unused(args...);
-#endif
 
                     return 0;
                 }

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/abs/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto abs(
-                    AbsCudaBuiltIn const & /*abs*/,
+                    AbsCudaBuiltIn const & abs,
                     TArg const & arg)
                 -> decltype(::abs(arg))
                 {
-                    //alpaka::ignore_unused(abs);
+                    alpaka::ignore_unused(abs);
                     return ::abs(arg);
                 }
             };

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/acos/Traits.hpp>
-
-#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/asin/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto asin(
-                    AsinCudaBuiltIn const & /*asin*/,
+                    AsinCudaBuiltIn const & asin,
                     TArg const & arg)
                 -> decltype(::asin(arg))
                 {
-                    //alpaka::ignore_unused(asin);
+                    alpaka::ignore_unused(asin);
                     return ::asin(arg);
                 }
             };

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/atan/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto atan(
-                    AtanCudaBuiltIn const & /*atan*/,
+                    AtanCudaBuiltIn const & atan,
                     TArg const & arg)
                 -> decltype(::atan(arg))
                 {
-                    //alpaka::ignore_unused(atan);
+                    alpaka::ignore_unused(atan);
                     return ::atan(arg);
                 }
             };

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/atan2/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -68,12 +67,12 @@ namespace alpaka
                     && std::is_floating_point<Tx>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto atan2(
-                    Atan2CudaBuiltIn const & /*abs*/,
+                    Atan2CudaBuiltIn const & atan2,
                     Ty const & y,
                     Tx const & x)
                 -> decltype(::atan2(y, x))
                 {
-                    //alpaka::ignore_unused(abs);
+                    alpaka::ignore_unused(atan2);
                     return ::atan2(y, x);
                 }
             };

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/cbrt/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #include <cmath>
@@ -61,11 +60,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto cbrt(
-                    CbrtCudaBuiltIn const & /*cbrt*/,
+                    CbrtCudaBuiltIn const & cbrt,
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))
                 {
-                    //alpaka::ignore_unused(cbrt);
+                    alpaka::ignore_unused(cbrt);
                     return std::cbrt(arg);
                 }
             };

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/ceil/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto ceil(
-                    CeilCudaBuiltIn const & /*ceil*/,
+                    CeilCudaBuiltIn const & ceil,
                     TArg const & arg)
                 -> decltype(::ceil(arg))
                 {
-                    //alpaka::ignore_unused(ceil);
+                    alpaka::ignore_unused(ceil);
                     return ::ceil(arg);
                 }
             };

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/erf/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto erf(
-                    ErfCudaBuiltIn const & /*erf*/,
+                    ErfCudaBuiltIn const & erf,
                     TArg const & arg)
                 -> decltype(::erf(arg))
                 {
-                    //alpaka::ignore_unused(erf);
+                    alpaka::ignore_unused(erf);
                     return ::erf(arg);
                 }
             };

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/exp/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto exp(
-                    ExpCudaBuiltIn const & /*exp*/,
+                    ExpCudaBuiltIn const & exp,
                     TArg const & arg)
                 -> decltype(::exp(arg))
                 {
-                    //alpaka::ignore_unused(exp);
+                    alpaka::ignore_unused(exp);
                     return ::exp(arg);
                 }
             };

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/floor/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto floor(
-                    FloorCudaBuiltIn const & /*floor*/,
+                    FloorCudaBuiltIn const & floor,
                     TArg const & arg)
                 -> decltype(::floor(arg))
                 {
-                    //alpaka::ignore_unused(floor);
+                    alpaka::ignore_unused(floor);
                     return ::floor(arg);
                 }
             };

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/fmod/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -68,12 +67,12 @@ namespace alpaka
                     && std::is_floating_point<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto fmod(
-                    FmodCudaBuiltIn const & /*fmod*/,
+                    FmodCudaBuiltIn const & fmod,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmod(x, y))
                 {
-                    //alpaka::ignore_unused(fmod);
+                    alpaka::ignore_unused(fmod);
                     return ::fmod(x, y);
                 }
             };

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/log/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto log(
-                    LogCudaBuiltIn const & /*log*/,
+                    LogCudaBuiltIn const & log,
                     TArg const & arg)
                 -> decltype(::log(arg))
                 {
-                    //alpaka::ignore_unused(log);
+                    alpaka::ignore_unused(log);
                     return ::log(arg);
                 }
             };

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/max/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -68,12 +67,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto max(
-                    MaxCudaBuiltIn const & /*max*/,
+                    MaxCudaBuiltIn const & max,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::max(x, y))
                 {
-                    //alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max);
                     return ::max(x, y);
                 }
             };
@@ -93,12 +92,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto max(
-                    MaxCudaBuiltIn const & /*max*/,
+                    MaxCudaBuiltIn const & max,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmax(x, y))
                 {
-                    //alpaka::ignore_unused(max);
+                    alpaka::ignore_unused(max);
                     return ::fmax(x, y);
                 }
             };

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/min/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -69,12 +68,12 @@ namespace alpaka
                     && std::is_integral<Ty>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto min(
-                    MinCudaBuiltIn const & /*min*/,
+                    MinCudaBuiltIn const & min,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::min(x, y))
                 {
-                    //alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min);
                     return ::min(x, y);
                 }
             };
@@ -94,12 +93,12 @@ namespace alpaka
                         && std::is_integral<Ty>::value)>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto max(
-                    MinCudaBuiltIn const & /*min*/,
+                    MinCudaBuiltIn const & min,
                     Tx const & x,
                     Ty const & y)
                 -> decltype(::fmin(x, y))
                 {
-                    //alpaka::ignore_unused(min);
+                    alpaka::ignore_unused(min);
                     return ::fmin(x, y);
                 }
             };

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/pow/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -68,12 +67,12 @@ namespace alpaka
                     && std::is_floating_point<TExp>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto pow(
-                    PowCudaBuiltIn const & /*pow*/,
+                    PowCudaBuiltIn const & pow,
                     TBase const & base,
                     TExp const & exp)
                 -> decltype(::pow(base, exp))
                 {
-                    //alpaka::ignore_unused(pow);
+                    alpaka::ignore_unused(pow);
                     return ::pow(base, exp);
                 }
             };

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/remainder/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto remainder(
-                    RemainderCudaBuiltIn const & /*remainder*/,
+                    RemainderCudaBuiltIn const & remainder,
                     TArg const & arg)
                 -> decltype(::remainder(arg))
                 {
-                    //alpaka::ignore_unused(remainder);
+                    alpaka::ignore_unused(remainder);
                     return ::remainder(arg);
                 }
             };

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/round/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto round(
-                    RoundCudaBuiltIn const & /*round*/,
+                    RoundCudaBuiltIn const & round,
                     TArg const & arg)
                 -> decltype(::round(arg))
                 {
-                    //alpaka::ignore_unused(round);
+                    alpaka::ignore_unused(round);
                     return ::round(arg);
                 }
             };
@@ -84,11 +83,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto lround(
-                    RoundCudaBuiltIn const & /*lround*/,
+                    RoundCudaBuiltIn const & lround,
                     TArg const & arg)
                 -> long int
                 {
-                    //alpaka::ignore_unused(lround);
+                    alpaka::ignore_unused(lround);
                     return ::lround(arg);
                 }
             };
@@ -103,11 +102,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto llround(
-                    RoundCudaBuiltIn const & /*llround*/,
+                    RoundCudaBuiltIn const & llround,
                     TArg const & arg)
                 -> long int
                 {
-                    //alpaka::ignore_unused(llround);
+                    alpaka::ignore_unused(llround);
                     return ::llround(arg);
                 }
             };

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/rsqrt/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto rsqrt(
-                    RsqrtCudaBuiltIn const & /*rsqrt*/,
+                    RsqrtCudaBuiltIn const & rsqrt,
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))
                 {
-                    //alpaka::ignore_unused(rsqrt);
+                    alpaka::ignore_unused(rsqrt);
                     return ::rsqrt(arg);
                 }
             };

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/sin/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto sin(
-                    SinCudaBuiltIn const & /*sin*/,
+                    SinCudaBuiltIn const & sin,
                     TArg const & arg)
                 -> decltype(::sin(arg))
                 {
-                    //alpaka::ignore_unused(sin);
+                    alpaka::ignore_unused(sin);
                     return ::sin(arg);
                 }
             };

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/sqrt/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto sqrt(
-                    SqrtCudaBuiltIn const & /*sqrt*/,
+                    SqrtCudaBuiltIn const & sqrt,
                     TArg const & arg)
                 -> decltype(::sqrt(arg))
                 {
-                    //alpaka::ignore_unused(sqrt);
+                    alpaka::ignore_unused(sqrt);
                     return ::sqrt(arg);
                 }
             };

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/tan/Traits.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto tan(
-                    TanCudaBuiltIn const & /*tan*/,
+                    TanCudaBuiltIn const & tan,
                     TArg const & arg)
                 -> decltype(::tan(arg))
                 {
-                    //alpaka::ignore_unused(tan);
+                    alpaka::ignore_unused(tan);
                     return ::tanf(arg);
                 }
             };

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -24,14 +24,13 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
 #include <alpaka/math/trunc/Traits.hpp>
-
-#include <alpaka/core/Unused.hpp>
 
 #include <type_traits>
 #if BOOST_COMP_NVCC >= BOOST_VERSION_NUMBER(9, 1, 0)
@@ -65,11 +64,11 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_FN_ACC_CUDA_ONLY static auto trunc(
-                    TruncCudaBuiltIn const & /*trunc*/,
+                    TruncCudaBuiltIn const & trunc,
                     TArg const & arg)
                 -> decltype(::trunc(arg))
                 {
-                    //alpaka::ignore_unused(trunc);
+                    alpaka::ignore_unused(trunc);
                     return ::trunc(arg);
                 }
             };

--- a/include/alpaka/mem/alloc/AllocCpuNew.hpp
+++ b/include/alpaka/mem/alloc/AllocCpuNew.hpp
@@ -24,7 +24,6 @@
 #include <alpaka/mem/alloc/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 namespace alpaka

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <alpaka/core/Vectorize.hpp>
+#include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 
 #include <alpaka/dev/Traits.hpp>
@@ -37,10 +38,6 @@
 #include <alpaka/mem/alloc/AllocCpuBoostAligned.hpp>
 
 #include <alpaka/meta/DependentFalseType.hpp>
-
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #include <memory>
 

--- a/include/alpaka/mem/view/Traits.hpp
+++ b/include/alpaka/mem/view/Traits.hpp
@@ -31,9 +31,9 @@
 #include <alpaka/vec/Vec.hpp>
 #include <alpaka/meta/Fold.hpp>
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/config.hpp>
-#include <alpaka/core/Unused.hpp>
 
 #include <iosfwd>
 

--- a/include/alpaka/mem/view/ViewCompileTimeArray.hpp
+++ b/include/alpaka/mem/view/ViewCompileTimeArray.hpp
@@ -25,8 +25,8 @@
 #include <alpaka/mem/buf/Traits.hpp>
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
+
 #include <boost/predef.h>
 
 #include <type_traits>

--- a/include/alpaka/mem/view/ViewStdArray.hpp
+++ b/include/alpaka/mem/view/ViewStdArray.hpp
@@ -25,7 +25,6 @@
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <array>

--- a/include/alpaka/mem/view/ViewStdVector.hpp
+++ b/include/alpaka/mem/view/ViewStdVector.hpp
@@ -25,7 +25,6 @@
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/pltf/PltfCpu.hpp>
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <vector>

--- a/include/alpaka/meta/ApplyTuple.hpp
+++ b/include/alpaka/meta/ApplyTuple.hpp
@@ -22,12 +22,10 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <alpaka/meta/IntegerSequence.hpp>
 
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 #include <boost/config.hpp>
 
 #include <utility>
@@ -100,9 +98,8 @@ namespace alpaka
 #endif
             {
                 // If the the index sequence is empty, t will not be used at all.
-#if !BOOST_ARCH_PTX
                 alpaka::ignore_unused(t);
-#endif
+
                 return
                     meta::invoke(
                         std::forward<F>(f),

--- a/include/alpaka/meta/Fold.hpp
+++ b/include/alpaka/meta/Fold.hpp
@@ -22,12 +22,9 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/config.hpp>
-
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
     #include <type_traits>
@@ -43,17 +40,12 @@ namespace alpaka
             typename TFnObj,
             typename T>
         ALPAKA_FN_HOST_ACC auto foldr(
-#if BOOST_ARCH_PTX
-            TFnObj const &,
-#else
             TFnObj const & f,
-#endif
             T const & t)
         -> T
         {
-#if !BOOST_ARCH_PTX
             alpaka::ignore_unused(f);
-#endif
+
             return t;
         }
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION

--- a/include/alpaka/meta/ForEachType.hpp
+++ b/include/alpaka/meta/ForEachType.hpp
@@ -22,11 +22,9 @@
 #pragma once
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/predef.h>
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #include <utility>
 
@@ -52,19 +50,12 @@ namespace alpaka
                     typename TFnObj,
                     typename... TArgs>
                 ALPAKA_FN_HOST_ACC static auto forEachTypeHelper(
-#if !BOOST_ARCH_PTX
                     TFnObj && f,
                     TArgs && ... args)
-#else
-                    TFnObj &&,
-                    TArgs && ...)
-#endif
                 -> void
                 {
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(f);
                     alpaka::ignore_unused(args...);
-#endif
                 }
             };
             //#############################################################################

--- a/include/alpaka/meta/NdLoop.hpp
+++ b/include/alpaka/meta/NdLoop.hpp
@@ -25,10 +25,7 @@
 #include <alpaka/dim/Traits.hpp>
 #include <alpaka/meta/IntegerSequence.hpp>
 #include <alpaka/core/Common.hpp>
-
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
+#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -54,22 +51,14 @@ namespace alpaka
                     typename TExtentVec,
                     typename TFnObj>
                 ALPAKA_FN_HOST_ACC static auto ndLoop(
-#if !BOOST_ARCH_PTX
                     TIndex & idx,
                     TExtentVec const & extent,
                     TFnObj const & f)
-#else
-                    TIndex &,
-                    TExtentVec const &,
-                    TFnObj const &)
-#endif
                 -> void
                 {
-#if !BOOST_ARCH_PTX
                     alpaka::ignore_unused(idx);
                     alpaka::ignore_unused(extent);
                     alpaka::ignore_unused(f);
-#endif
                 }
             };
             //#############################################################################
@@ -153,9 +142,7 @@ namespace alpaka
         //! Loops over an n-dimensional iteration index variable calling f(idx, args...) for each iteration.
         //! The loops are nested in the order given by the IndexSequence with the first element being the outermost and the last index the innermost loop.
         //!
-#if !BOOST_ARCH_PTX
         //! \param indexSequence A sequence of indices being a permutation of the values [0, dim-1], where every values occurs at most once.
-#endif
         //! \param extent N-dimensional loop extent.
         //! \param f The function called at each iteration.
         ALPAKA_NO_HOST_ACC_WARNING
@@ -164,18 +151,12 @@ namespace alpaka
             typename TFnObj,
             std::size_t... Tdims>
         ALPAKA_FN_HOST_ACC auto ndLoop(
-#if !BOOST_ARCH_PTX
             meta::IndexSequence<Tdims...> const & indexSequence,
-#else
-            meta::IndexSequence<Tdims...> const &,
-#endif
             TExtentVec const & extent,
             TFnObj const & f)
         -> void
         {
-#if !BOOST_ARCH_PTX
             alpaka::ignore_unused(indexSequence);
-#endif
 
             static_assert(
                 dim::Dim<TExtentVec>::value > 0u,

--- a/include/alpaka/rand/RandStl.hpp
+++ b/include/alpaka/rand/RandStl.hpp
@@ -24,7 +24,6 @@
 #include <alpaka/rand/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <random>

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -26,7 +26,6 @@
 #include <alpaka/time/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <omp.h>

--- a/include/alpaka/time/TimeStl.hpp
+++ b/include/alpaka/time/TimeStl.hpp
@@ -24,7 +24,6 @@
 #include <alpaka/time/Traits.hpp>
 
 #include <alpaka/core/Common.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 //#include <ctime>

--- a/include/alpaka/vec/Vec.hpp
+++ b/include/alpaka/vec/Vec.hpp
@@ -33,12 +33,10 @@
 #include <alpaka/core/Align.hpp>
 #include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
 
 #include <boost/predef.h>
 #include <boost/config.hpp>
-#if !BOOST_ARCH_PTX
-    #include <alpaka/core/Unused.hpp>
-#endif
 
 #include <cstdint>
 #include <ostream>
@@ -73,19 +71,14 @@ namespace alpaka
             typename TIdxSize,
             TIdxSize... TIndices>
         ALPAKA_FN_HOST_ACC auto createVecFromIndexedFnArbitrary(
-#if BOOST_ARCH_PTX
-            meta::IntegerSequence<TIdxSize, TIndices...> const &,
-#else
             meta::IntegerSequence<TIdxSize, TIndices...> const & indices,
-#endif
             TArgs && ... args)
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
         -> Vec<TDim, decltype(TTFnObj<0>::create(std::forward<TArgs>(args)...))>
 #endif
         {
-#if !BOOST_ARCH_PTX
             alpaka::ignore_unused(indices);
-#endif
+
             return Vec<TDim, decltype(TTFnObj<0>::create(std::forward<TArgs>(args)...))>(
                 (TTFnObj<TIndices>::create(std::forward<TArgs>(args)...))...);
         }
@@ -207,17 +200,12 @@ namespace alpaka
                 typename TIdxSize,
                 TIdxSize... TIndices>
             ALPAKA_FN_HOST_ACC static auto createVecFromIndexedFnArbitrary(
-#if BOOST_ARCH_PTX
-                meta::IntegerSequence<TIdxSize, TIndices...> const &,
-#else
                 meta::IntegerSequence<TIdxSize, TIndices...> const & indices,
-#endif
                 TArgs && ... args)
             -> Vec<TDim, TVal>
             {
-#if !BOOST_ARCH_PTX
                 alpaka::ignore_unused(indices);
-#endif
+
                 return Vec<TDim, TVal>(
                     (TTFnObj<TIndices>::create(std::forward<TArgs>(args)...))...);
             }
@@ -389,11 +377,7 @@ namespace alpaka
                 std::size_t... TIndices>
             ALPAKA_FN_HOST_ACC auto foldrByIndices(
                 TFnObj const & f,
-#if BOOST_ARCH_PTX
-                meta::IntegerSequence<std::size_t, TIndices...> const &) const
-#else
                 meta::IntegerSequence<std::size_t, TIndices...> const & indices) const
-#endif
 #ifdef BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
             -> decltype(
                 meta::foldr(
@@ -401,9 +385,8 @@ namespace alpaka
                     ((*this)[TIndices])...))
 #endif
             {
-#if !BOOST_ARCH_PTX
                 alpaka::ignore_unused(indices);
-#endif
+
                 return
                     meta::foldr(
                         f,
@@ -953,10 +936,8 @@ namespace alpaka
                     Vec<TDim, TVal> const & vec)
                 -> Vec<dim::DimInt<sizeof...(TIndices)>, TVal>
                 {
-#if !BOOST_ARCH_PTX
                     // In the case of a zero dimensional vector, vec is unused.
                     alpaka::ignore_unused(vec);
-#endif
 
                     static_assert(sizeof...(TIndices) <= TDim::value, "The sub-vector has to be smaller (or same idx) then the origin vector.");
 

--- a/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
@@ -24,6 +24,8 @@
 #ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
 
 #include <alpaka/core/Common.hpp>
+#include <alpaka/core/Unused.hpp>
+#include <alpaka/core/Cuda.hpp>
 
 #if !BOOST_LANG_CUDA
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
@@ -33,9 +35,6 @@
 #include <alpaka/idx/Traits.hpp>
 
 #include <alpaka/vec/Vec.hpp>
-#include <alpaka/core/Cuda.hpp>
-
-//#include <alpaka/core/Unused.hpp>
 
 namespace alpaka
 {
@@ -123,10 +122,10 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 //! \return The number of blocks in each dimension of the grid.
                 ALPAKA_FN_ACC_CUDA_ONLY static auto getWorkDiv(
-                    WorkDivCudaBuiltIn<TDim, TIdx> const & /*workDiv*/)
+                    WorkDivCudaBuiltIn<TDim, TIdx> const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //alpaka::ignore_unused(workDiv);
+                    alpaka::ignore_unused(workDiv);
                     return vec::cast<TIdx>(extent::getExtentVecEnd<TDim>(gridDim));
                 }
             };
@@ -144,10 +143,10 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 //! \return The number of threads in each dimension of a block.
                 ALPAKA_FN_ACC_CUDA_ONLY static auto getWorkDiv(
-                    WorkDivCudaBuiltIn<TDim, TIdx> const & /*workDiv*/)
+                    WorkDivCudaBuiltIn<TDim, TIdx> const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
-                    //alpaka::ignore_unused(workDiv);
+                    alpaka::ignore_unused(workDiv);
                     return vec::cast<TIdx>(extent::getExtentVecEnd<TDim>(blockDim));
                 }
             };

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -43,7 +43,6 @@
 #include <alpaka/test/MeasureKernelRunTime.hpp>
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/queue/Queue.hpp>
-
 #include <alpaka/core/Unused.hpp>
 
 #include <iostream>


### PR DESCRIPTION
- Use `ignore_unused` in device functions.
- regroup `alpaka/core/` includes
- Add `alpaka/core/Unused.hpp` to `alpaka/alpaka.hpp` include.

Follow-up to #582