### PR TITLE
TinyMT Engine: Default Seed

### DIFF
--- a/include/alpaka/rand/TinyMT/Engine.hpp
+++ b/include/alpaka/rand/TinyMT/Engine.hpp
@@ -64,20 +64,24 @@ namespace cpu
 
         void seed( result_type value = default_seed() )
         {
-            tinymt32_init( &prng, value );
-        }
-
-        TinyMTengine( std::uint32_t const & seedValue )
-        {
             // parameters from TinyMT/jump/sample.c
             prng.mat1 = 0x8f7011ee;
             prng.mat2 = 0xfc78ff1f;
             prng.tmat = 0x3793fdff;
 
+            tinymt32_init( &prng, value );
+        }
+
+        TinyMTengine( std::uint32_t const & seedValue )
+        {
             seed( seedValue );
         }
 
-        TinyMTengine() = delete;
+        TinyMTengine()
+        {
+            std::uint32_t const magicSeed = 42u;
+            seed( magicSeed );
+        }
 
         result_type operator()()
         {


### PR DESCRIPTION
Follow-up to #579: Add a default constructor for users that don't care about a seed. Or for users that default-init and overwrite.

Caused compile-issue in PIConGPU during acceptance test for Alpaka 0.3.3