### PR TITLE
NVCC 8.0 Exact Compare

### DIFF
--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -59,9 +59,6 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE_EQUAL(true, alpaka::queue::empty(f.m_queue));
 }
 
-// gcc 5.4 in combination with nvcc 8.0 fails to compile those tests when --expt-relaxed-constexpr is enabled
-// /usr/include/c++/5/tuple(484) (col. 17): error: calling a __host__ function("std::_Tuple_impl<(unsigned long)0ul,  :: > ::_Tuple_impl [subobject]") from a __device__ function("std::tuple< :: > ::tuple") is not allowed
-#if !((BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(5, 0, 0)) && (BOOST_COMP_NVCC == BOOST_VERSION_NUMBER(8, 0, 0)))
 //-----------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE_TEMPLATE(
     queueCallbackIsWorking,
@@ -123,6 +120,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     BOOST_REQUIRE_EQUAL(true, alpaka::queue::empty(f.m_queue));
     BOOST_REQUIRE_EQUAL(true, CallbackFinished);
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/rand/src/RandTest.cpp
+++ b/test/unit/rand/src/RandTest.cpp
@@ -58,9 +58,6 @@ class RandTestKernel
         T_Generator & gen
     ) const
     {
-// gcc 5.4 in combination with nvcc 8.0 fails to compile the CPU STL distributions when --expt-relaxed-constexpr is enabled
-// /usr/include/c++/5/cmath(362): error: calling a __host__ function("__builtin_logl") from a __device__ function("std::log") is not allowed
-#if !((BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(5, 0, 0)) && (BOOST_COMP_NVCC == BOOST_VERSION_NUMBER(8, 0, 0)))
         {
             auto dist(alpaka::rand::distribution::createNormalReal<float>(acc));
             auto const r = dist(gen);
@@ -99,7 +96,6 @@ class RandTestKernel
             auto const r = dist(gen);
             alpaka::ignore_unused(r);
         }
-#endif
     }
 
 public:


### PR DESCRIPTION
Exclusions for NVCC 8.0 are too exact.
There is no zero-patch-level release, but two 8.0.X releases.

Update: checked in CMake now, removed.

This is the GCC 5.4+ "std::tuple" with CUDA 8.0 bug work-around. Since we check it in CMake, we could also remove it here.
https://gist.github.com/ax3l/9489132

Introduced in #474