### PR TITLE
Replace ALPAKA_FN_ACC_CUDA_ONLY by __device__

### DIFF
--- a/doc/markdown/user/implementation/mapping/CUDA.md
+++ b/doc/markdown/user/implementation/mapping/CUDA.md
@@ -29,10 +29,11 @@ NOTE: You have to be careful when mixing alpaka and non alpaka CUDA code. The CU
 |CUDA|alpaka|
 |---|---|
 |\_\_host\_\_|ALPAKA_FN_HOST|
-|\_\_global\_\_|ALPAKA_FN_HOST_ACC|
-|\_\_device\_\_ \_\_host\_\_|ALPAKA_FN_HOST_ACC|
-|\_\_device\_\_|ALPAKA_FN_ACC_CUDA_ONLY|
+|\_\_device\_\_|ALPAKA_FN_ACC*|
+|\_\_global\_\_|ALPAKA_FN_ACC*|
+|\_\_host\_\_ \_\_device\_\_|ALPAKA_FN_HOST_ACC|
 
+\* You can not call CUDA only methods except when ALPAKA_ACC_GPU_CUDA_ONLY_MODE is enabled.
 
 *Memory*
 

--- a/include/alpaka/acc/AccGpuCudaRt.hpp
+++ b/include/alpaka/acc/AccGpuCudaRt.hpp
@@ -95,7 +95,7 @@ namespace alpaka
         {
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY AccGpuCudaRt(
+            __device__ AccGpuCudaRt(
                 vec::Vec<TDim, TIdx> const & threadElemExtent) :
                     workdiv::WorkDivCudaBuiltIn<TDim, TIdx>(threadElemExtent),
                     idx::gb::IdxGbCudaBuiltIn<TDim, TIdx>(),
@@ -115,13 +115,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY AccGpuCudaRt(AccGpuCudaRt const &) = delete;
+            __device__ AccGpuCudaRt(AccGpuCudaRt const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY AccGpuCudaRt(AccGpuCudaRt &&) = delete;
+            __device__ AccGpuCudaRt(AccGpuCudaRt &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(AccGpuCudaRt const &) -> AccGpuCudaRt & = delete;
+            __device__ auto operator=(AccGpuCudaRt const &) -> AccGpuCudaRt & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(AccGpuCudaRt &&) -> AccGpuCudaRt & = delete;
+            __device__ auto operator=(AccGpuCudaRt &&) -> AccGpuCudaRt & = delete;
             //-----------------------------------------------------------------------------
             ~AccGpuCudaRt() = default;
         };

--- a/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
+++ b/include/alpaka/atomic/AtomicCudaBuiltIn.hpp
@@ -48,13 +48,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             AtomicCudaBuiltIn() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY AtomicCudaBuiltIn(AtomicCudaBuiltIn const &) = delete;
+            __device__ AtomicCudaBuiltIn(AtomicCudaBuiltIn const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY AtomicCudaBuiltIn(AtomicCudaBuiltIn &&) = delete;
+            __device__ AtomicCudaBuiltIn(AtomicCudaBuiltIn &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(AtomicCudaBuiltIn const &) -> AtomicCudaBuiltIn & = delete;
+            __device__ auto operator=(AtomicCudaBuiltIn const &) -> AtomicCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(AtomicCudaBuiltIn &&) -> AtomicCudaBuiltIn & = delete;
+            __device__ auto operator=(AtomicCudaBuiltIn &&) -> AtomicCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AtomicCudaBuiltIn() = default;
         };
@@ -79,7 +79,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -99,7 +99,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -120,7 +120,7 @@ namespace alpaka
             {
                 //-----------------------------------------------------------------------------
                 //
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -141,7 +141,7 @@ namespace alpaka
             {
                 //-----------------------------------------------------------------------------
                 //
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     float * const addr,
                     float const & value)
@@ -161,7 +161,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     double * const addr,
                     double const & value)
@@ -204,7 +204,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -224,7 +224,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -248,7 +248,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -268,7 +268,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -289,7 +289,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -314,7 +314,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -333,7 +333,7 @@ namespace alpaka
                 unsigned int,
                 THierarchy>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -354,7 +354,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -379,7 +379,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -399,7 +399,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -419,7 +419,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -439,7 +439,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     float * const addr,
                     float const & value)
@@ -463,7 +463,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -487,7 +487,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -511,7 +511,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -531,7 +531,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -552,7 +552,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -577,7 +577,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -597,7 +597,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -618,7 +618,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -643,7 +643,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & value)
@@ -663,7 +663,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & value)
@@ -684,7 +684,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & value)
@@ -709,7 +709,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     int * const addr,
                     int const & compare,
@@ -730,7 +730,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned int * const addr,
                     unsigned int const & compare,
@@ -751,7 +751,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atomicOp(
+                __device__ static auto atomicOp(
                     atomic::AtomicCudaBuiltIn const &,
                     unsigned long long int * const addr,
                     unsigned long long int const & compare,

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynCudaBuiltIn.hpp
@@ -51,13 +51,13 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     BlockSharedMemDynCudaBuiltIn() = default;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY BlockSharedMemDynCudaBuiltIn(BlockSharedMemDynCudaBuiltIn const &) = delete;
+                    __device__ BlockSharedMemDynCudaBuiltIn(BlockSharedMemDynCudaBuiltIn const &) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY BlockSharedMemDynCudaBuiltIn(BlockSharedMemDynCudaBuiltIn &&) = delete;
+                    __device__ BlockSharedMemDynCudaBuiltIn(BlockSharedMemDynCudaBuiltIn &&) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSharedMemDynCudaBuiltIn const &) -> BlockSharedMemDynCudaBuiltIn & = delete;
+                    __device__ auto operator=(BlockSharedMemDynCudaBuiltIn const &) -> BlockSharedMemDynCudaBuiltIn & = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSharedMemDynCudaBuiltIn &&) -> BlockSharedMemDynCudaBuiltIn & = delete;
+                    __device__ auto operator=(BlockSharedMemDynCudaBuiltIn &&) -> BlockSharedMemDynCudaBuiltIn & = delete;
                     //-----------------------------------------------------------------------------
                     /*virtual*/ ~BlockSharedMemDynCudaBuiltIn() = default;
                 };
@@ -72,7 +72,7 @@ namespace alpaka
                         BlockSharedMemDynCudaBuiltIn>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_CUDA_ONLY static auto getMem(
+                        __device__ static auto getMem(
                             block::shared::dyn::BlockSharedMemDynCudaBuiltIn const &)
                         -> T *
                         {

--- a/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStCudaBuiltIn.hpp
@@ -52,13 +52,13 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     BlockSharedMemStCudaBuiltIn() = default;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY BlockSharedMemStCudaBuiltIn(BlockSharedMemStCudaBuiltIn const &) = delete;
+                    __device__ BlockSharedMemStCudaBuiltIn(BlockSharedMemStCudaBuiltIn const &) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY BlockSharedMemStCudaBuiltIn(BlockSharedMemStCudaBuiltIn &&) = delete;
+                    __device__ BlockSharedMemStCudaBuiltIn(BlockSharedMemStCudaBuiltIn &&) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSharedMemStCudaBuiltIn const &) -> BlockSharedMemStCudaBuiltIn & = delete;
+                    __device__ auto operator=(BlockSharedMemStCudaBuiltIn const &) -> BlockSharedMemStCudaBuiltIn & = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSharedMemStCudaBuiltIn &&) -> BlockSharedMemStCudaBuiltIn & = delete;
+                    __device__ auto operator=(BlockSharedMemStCudaBuiltIn &&) -> BlockSharedMemStCudaBuiltIn & = delete;
                     //-----------------------------------------------------------------------------
                     /*virtual*/ ~BlockSharedMemStCudaBuiltIn() = default;
                 };
@@ -75,7 +75,7 @@ namespace alpaka
                         BlockSharedMemStCudaBuiltIn>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_CUDA_ONLY static auto allocVar(
+                        __device__ static auto allocVar(
                             block::shared::st::BlockSharedMemStCudaBuiltIn const &)
                         -> T &
                         {
@@ -90,7 +90,7 @@ namespace alpaka
                         BlockSharedMemStCudaBuiltIn>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_CUDA_ONLY static auto freeMem(
+                        __device__ static auto freeMem(
                             block::shared::st::BlockSharedMemStCudaBuiltIn const &)
                         -> void
                         {

--- a/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
+++ b/include/alpaka/block/sync/BlockSyncCudaBuiltIn.hpp
@@ -47,13 +47,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 BlockSyncCudaBuiltIn() = default;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY BlockSyncCudaBuiltIn(BlockSyncCudaBuiltIn const &) = delete;
+                __device__ BlockSyncCudaBuiltIn(BlockSyncCudaBuiltIn const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY BlockSyncCudaBuiltIn(BlockSyncCudaBuiltIn &&) = delete;
+                __device__ BlockSyncCudaBuiltIn(BlockSyncCudaBuiltIn &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSyncCudaBuiltIn const &) -> BlockSyncCudaBuiltIn & = delete;
+                __device__ auto operator=(BlockSyncCudaBuiltIn const &) -> BlockSyncCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(BlockSyncCudaBuiltIn &&) -> BlockSyncCudaBuiltIn & = delete;
+                __device__ auto operator=(BlockSyncCudaBuiltIn &&) -> BlockSyncCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~BlockSyncCudaBuiltIn() = default;
             };
@@ -66,7 +66,7 @@ namespace alpaka
                     BlockSyncCudaBuiltIn>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreads(
+                    __device__ static auto syncBlockThreads(
                         block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/)
                     -> void
                     {
@@ -81,7 +81,7 @@ namespace alpaka
                     BlockSyncCudaBuiltIn>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                    __device__ static auto syncBlockThreadsPredicate(
                         block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
                         int predicate)
                     -> int
@@ -97,7 +97,7 @@ namespace alpaka
                     BlockSyncCudaBuiltIn>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                    __device__ static auto syncBlockThreadsPredicate(
                         block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
                         int predicate)
                     -> int
@@ -113,7 +113,7 @@ namespace alpaka
                     BlockSyncCudaBuiltIn>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto syncBlockThreadsPredicate(
+                    __device__ static auto syncBlockThreadsPredicate(
                         block::sync::BlockSyncCudaBuiltIn const & /*blockSync*/,
                         int predicate)
                     -> int

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -109,14 +109,13 @@
 #endif
 
 //-----------------------------------------------------------------------------
-//! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC_CUDA_ONLY or ALPAKA_FN_ACC.
+//! All functions that can be used on an accelerator have to be attributed with ALPAKA_FN_ACC or ALPAKA_FN_HOST_ACC.
 //!
 //! Usage:
 //! ALPAKA_FN_ACC
 //! auto add(std::int32_t a, std::int32_t b)
 //! -> std::int32_t;
 #if BOOST_LANG_CUDA
-    #define ALPAKA_FN_ACC_CUDA_ONLY __device__
     #define ALPAKA_FN_ACC_NO_CUDA __host__
     #if defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE)
         #define ALPAKA_FN_ACC __device__
@@ -126,9 +125,6 @@
     #define ALPAKA_FN_HOST_ACC __device__ __host__
     #define ALPAKA_FN_HOST __host__
 #else
-    // NOTE: ALPAKA_FN_ACC_CUDA_ONLY should not be defined to cause build failures when CUDA only functions are used and CUDA is disabled.
-    // However, this also destroys syntax highlighting.
-    #define ALPAKA_FN_ACC_CUDA_ONLY
     #define ALPAKA_FN_ACC_NO_CUDA
     #define ALPAKA_FN_ACC
     #define ALPAKA_FN_HOST_ACC

--- a/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
+++ b/include/alpaka/idx/bt/IdxBtCudaBuiltIn.hpp
@@ -55,13 +55,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 IdxBtCudaBuiltIn() = default;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY IdxBtCudaBuiltIn(IdxBtCudaBuiltIn const &) = delete;
+                __device__ IdxBtCudaBuiltIn(IdxBtCudaBuiltIn const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY IdxBtCudaBuiltIn(IdxBtCudaBuiltIn &&) = delete;
+                __device__ IdxBtCudaBuiltIn(IdxBtCudaBuiltIn &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(IdxBtCudaBuiltIn const & ) -> IdxBtCudaBuiltIn & = delete;
+                __device__ auto operator=(IdxBtCudaBuiltIn const & ) -> IdxBtCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(IdxBtCudaBuiltIn &&) -> IdxBtCudaBuiltIn & = delete;
+                __device__ auto operator=(IdxBtCudaBuiltIn &&) -> IdxBtCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxBtCudaBuiltIn() = default;
             };
@@ -102,7 +102,7 @@ namespace alpaka
                 //! \return The index of the current thread in the block.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_CUDA_ONLY static auto getIdx(
+                __device__ static auto getIdx(
                     idx::bt::IdxBtCudaBuiltIn<TDim, TIdx> const & idx,
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
+++ b/include/alpaka/idx/gb/IdxGbCudaBuiltIn.hpp
@@ -55,13 +55,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 IdxGbCudaBuiltIn() = default;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY IdxGbCudaBuiltIn(IdxGbCudaBuiltIn const &) = delete;
+                __device__ IdxGbCudaBuiltIn(IdxGbCudaBuiltIn const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY IdxGbCudaBuiltIn(IdxGbCudaBuiltIn &&) = delete;
+                __device__ IdxGbCudaBuiltIn(IdxGbCudaBuiltIn &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(IdxGbCudaBuiltIn const & ) -> IdxGbCudaBuiltIn & = delete;
+                __device__ auto operator=(IdxGbCudaBuiltIn const & ) -> IdxGbCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY auto operator=(IdxGbCudaBuiltIn &&) -> IdxGbCudaBuiltIn & = delete;
+                __device__ auto operator=(IdxGbCudaBuiltIn &&) -> IdxGbCudaBuiltIn & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxGbCudaBuiltIn() = default;
             };
@@ -102,7 +102,7 @@ namespace alpaka
                 //! \return The index of the current block in the grid.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_CUDA_ONLY static auto getIdx(
+                __device__ static auto getIdx(
                     idx::gb::IdxGbCudaBuiltIn<TDim, TIdx> const & idx,
                     TWorkDiv const &)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto abs(
+                __device__ static auto abs(
                     AbsCudaBuiltIn const & abs,
                     TArg const & arg)
                 -> decltype(::abs(arg))

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -64,7 +64,7 @@ namespace alpaka
                     std::is_floating_point<TArg>::value>::type>
             {
                 ALPAKA_NO_HOST_ACC_WARNING
-                ALPAKA_FN_ACC_CUDA_ONLY static auto acos(
+                __device__ static auto acos(
                     AcosCudaBuiltIn const & acos,
                     TArg const & arg)
                 -> decltype(::acos(arg))

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto asin(
+                __device__ static auto asin(
                     AsinCudaBuiltIn const & asin,
                     TArg const & arg)
                 -> decltype(::asin(arg))

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atan(
+                __device__ static auto atan(
                     AtanCudaBuiltIn const & atan,
                     TArg const & arg)
                 -> decltype(::atan(arg))

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
                     std::is_floating_point<Ty>::value
                     && std::is_floating_point<Tx>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto atan2(
+                __device__ static auto atan2(
                     Atan2CudaBuiltIn const & atan2,
                     Ty const & y,
                     Tx const & x)

--- a/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/cbrt/CbrtCudaBuiltIn.hpp
@@ -59,7 +59,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto cbrt(
+                __device__ static auto cbrt(
                     CbrtCudaBuiltIn const & cbrt,
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto ceil(
+                __device__ static auto ceil(
                     CeilCudaBuiltIn const & ceil,
                     TArg const & arg)
                 -> decltype(::ceil(arg))

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto cos(
+                __device__ static auto cos(
                     CosCudaBuiltIn const & cos,
                     TArg const & arg)
                 -> decltype(::cos(arg))

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto erf(
+                __device__ static auto erf(
                     ErfCudaBuiltIn const & erf,
                     TArg const & arg)
                 -> decltype(::erf(arg))

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto exp(
+                __device__ static auto exp(
                     ExpCudaBuiltIn const & exp,
                     TArg const & arg)
                 -> decltype(::exp(arg))

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto floor(
+                __device__ static auto floor(
                     FloorCudaBuiltIn const & floor,
                     TArg const & arg)
                 -> decltype(::floor(arg))

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
                     std::is_floating_point<Tx>::value
                     && std::is_floating_point<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto fmod(
+                __device__ static auto fmod(
                     FmodCudaBuiltIn const & fmod,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto log(
+                __device__ static auto log(
                     LogCudaBuiltIn const & log,
                     TArg const & arg)
                 -> decltype(::log(arg))

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
                     std::is_integral<Tx>::value
                     && std::is_integral<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto max(
+                __device__ static auto max(
                     MaxCudaBuiltIn const & max,
                     Tx const & x,
                     Ty const & y)
@@ -91,7 +91,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto max(
+                __device__ static auto max(
                     MaxCudaBuiltIn const & max,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                     std::is_integral<Tx>::value
                     && std::is_integral<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto min(
+                __device__ static auto min(
                     MinCudaBuiltIn const & min,
                     Tx const & x,
                     Ty const & y)
@@ -92,7 +92,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto max(
+                __device__ static auto max(
                     MinCudaBuiltIn const & min,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -66,7 +66,7 @@ namespace alpaka
                     std::is_floating_point<TBase>::value
                     && std::is_floating_point<TExp>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto pow(
+                __device__ static auto pow(
                     PowCudaBuiltIn const & pow,
                     TBase const & base,
                     TExp const & exp)

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto remainder(
+                __device__ static auto remainder(
                     RemainderCudaBuiltIn const & remainder,
                     TArg const & arg)
                 -> decltype(::remainder(arg))

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto round(
+                __device__ static auto round(
                     RoundCudaBuiltIn const & round,
                     TArg const & arg)
                 -> decltype(::round(arg))
@@ -82,7 +82,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto lround(
+                __device__ static auto lround(
                     RoundCudaBuiltIn const & lround,
                     TArg const & arg)
                 -> long int
@@ -101,7 +101,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto llround(
+                __device__ static auto llround(
                     RoundCudaBuiltIn const & llround,
                     TArg const & arg)
                 -> long int

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto rsqrt(
+                __device__ static auto rsqrt(
                     RsqrtCudaBuiltIn const & rsqrt,
                     TArg const & arg)
                 -> decltype(::rsqrt(arg))

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto sin(
+                __device__ static auto sin(
                     SinCudaBuiltIn const & sin,
                     TArg const & arg)
                 -> decltype(::sin(arg))

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto sqrt(
+                __device__ static auto sqrt(
                     SqrtCudaBuiltIn const & sqrt,
                     TArg const & arg)
                 -> decltype(::sqrt(arg))

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto tan(
+                __device__ static auto tan(
                     TanCudaBuiltIn const & tan,
                     TArg const & arg)
                 -> decltype(::tan(arg))

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -63,7 +63,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_floating_point<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto trunc(
+                __device__ static auto trunc(
                     TruncCudaBuiltIn const & trunc,
                     TArg const & arg)
                 -> decltype(::trunc(arg))

--- a/include/alpaka/rand/RandCuRand.hpp
+++ b/include/alpaka/rand/RandCuRand.hpp
@@ -67,7 +67,7 @@ namespace alpaka
                     Xor() = default;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY Xor(
+                    __device__ Xor(
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence = 0,
                         std::uint32_t const & offset = 0)
@@ -107,7 +107,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator()(
+                    __device__ auto operator()(
                         TGenerator & generator)
                     -> float
                     {
@@ -127,7 +127,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator()(
+                    __device__ auto operator()(
                         TGenerator & generator)
                     -> double
                     {
@@ -154,7 +154,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator()(
+                    __device__ auto operator()(
                         TGenerator & generator)
                     -> float
                     {
@@ -178,7 +178,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator()(
+                    __device__ auto operator()(
                         TGenerator & generator)
                     -> double
                     {
@@ -209,7 +209,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_CUDA_ONLY auto operator()(
+                    __device__ auto operator()(
                         TGenerator & generator)
                     -> unsigned int
                     {
@@ -234,7 +234,7 @@ namespace alpaka
                         std::is_floating_point<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto createNormalReal(
+                    __device__ static auto createNormalReal(
                         RandCuRand const & /*rand*/)
                     -> rand::distribution::cuda::NormalReal<T>
                     {
@@ -252,7 +252,7 @@ namespace alpaka
                         std::is_floating_point<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto createUniformReal(
+                    __device__ static auto createUniformReal(
                         RandCuRand const & /*rand*/)
                     -> rand::distribution::cuda::UniformReal<T>
                     {
@@ -270,7 +270,7 @@ namespace alpaka
                         std::is_integral<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto createUniformUint(
+                    __device__ static auto createUniformUint(
                         RandCuRand const & /*rand*/)
                     -> rand::distribution::cuda::UniformUint<T>
                     {
@@ -290,7 +290,7 @@ namespace alpaka
                     RandCuRand>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_CUDA_ONLY static auto createDefault(
+                    __device__ static auto createDefault(
                         RandCuRand const & /*rand*/,
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence)

--- a/include/alpaka/time/TimeCudaBuiltIn.hpp
+++ b/include/alpaka/time/TimeCudaBuiltIn.hpp
@@ -45,13 +45,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             TimeCudaBuiltIn() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY TimeCudaBuiltIn(TimeCudaBuiltIn const &) = delete;
+            __device__ TimeCudaBuiltIn(TimeCudaBuiltIn const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY TimeCudaBuiltIn(TimeCudaBuiltIn &&) = delete;
+            __device__ TimeCudaBuiltIn(TimeCudaBuiltIn &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(TimeCudaBuiltIn const &) -> TimeCudaBuiltIn & = delete;
+            __device__ auto operator=(TimeCudaBuiltIn const &) -> TimeCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(TimeCudaBuiltIn &&) -> TimeCudaBuiltIn & = delete;
+            __device__ auto operator=(TimeCudaBuiltIn &&) -> TimeCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~TimeCudaBuiltIn() = default;
         };
@@ -65,7 +65,7 @@ namespace alpaka
                 time::TimeCudaBuiltIn>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_CUDA_ONLY static auto clock(
+                __device__ static auto clock(
                     time::TimeCudaBuiltIn const &)
                 -> std::uint64_t
                 {

--- a/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
+++ b/include/alpaka/workdiv/WorkDivCudaBuiltIn.hpp
@@ -51,18 +51,18 @@ namespace alpaka
             using WorkDivBase = WorkDivCudaBuiltIn;
 
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY WorkDivCudaBuiltIn(
+            __device__ WorkDivCudaBuiltIn(
                 vec::Vec<TDim, TIdx> const & threadElemExtent) :
                     m_threadElemExtent(threadElemExtent)
             {}
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY WorkDivCudaBuiltIn(WorkDivCudaBuiltIn const &) = delete;
+            __device__ WorkDivCudaBuiltIn(WorkDivCudaBuiltIn const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY WorkDivCudaBuiltIn(WorkDivCudaBuiltIn &&) = delete;
+            __device__ WorkDivCudaBuiltIn(WorkDivCudaBuiltIn &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(WorkDivCudaBuiltIn const &) -> WorkDivCudaBuiltIn & = delete;
+            __device__ auto operator=(WorkDivCudaBuiltIn const &) -> WorkDivCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_CUDA_ONLY auto operator=(WorkDivCudaBuiltIn &&) -> WorkDivCudaBuiltIn & = delete;
+            __device__ auto operator=(WorkDivCudaBuiltIn &&) -> WorkDivCudaBuiltIn & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~WorkDivCudaBuiltIn() = default;
 
@@ -121,7 +121,7 @@ namespace alpaka
             {
                 //-----------------------------------------------------------------------------
                 //! \return The number of blocks in each dimension of the grid.
-                ALPAKA_FN_ACC_CUDA_ONLY static auto getWorkDiv(
+                __device__ static auto getWorkDiv(
                     WorkDivCudaBuiltIn<TDim, TIdx> const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
@@ -142,7 +142,7 @@ namespace alpaka
             {
                 //-----------------------------------------------------------------------------
                 //! \return The number of threads in each dimension of a block.
-                ALPAKA_FN_ACC_CUDA_ONLY static auto getWorkDiv(
+                __device__ static auto getWorkDiv(
                     WorkDivCudaBuiltIn<TDim, TIdx> const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {
@@ -163,7 +163,7 @@ namespace alpaka
             {
                 //-----------------------------------------------------------------------------
                 //! \return The number of blocks in each dimension of the grid.
-                ALPAKA_FN_ACC_CUDA_ONLY static auto getWorkDiv(
+                __device__ static auto getWorkDiv(
                     WorkDivCudaBuiltIn<TDim, TIdx> const & workDiv)
                 -> vec::Vec<TDim, TIdx>
                 {

--- a/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
+++ b/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_SUITE(kernel)
 //! /alpaka/include/alpaka/workdiv/Traits.hpp(...): error: calling a __device__ function("getWorkDiv") from a __host__ __device__ function("getWorkDiv") is not allowed
 //! The kernel function objects function call operator is attributed with ALPAKA_FN_ACC which is identical to __host__ __device__.
 //! The 'alpaka::workdiv::getWorkDiv<...>(acc)' function that is called has the ALPAKA_FN_HOST_ACC attribute (also equal to __host__ __device__).
-//! The underlying trait calls the CUDA specialized method which has the ALPAKA_FN_ACC_CUDA_ONLY attribute (equal to __device__).
+//! The underlying trait calls the CUDA specialized method which has the __device__ attribute.
 //! Because this call chain does not contain any templates and therefore no calls depending on input types,
 //! everything can be resolved at the first time the template is parsed which results in the given error.
 //!


### PR DESCRIPTION
As written in #585, `ALPAKA_FN_ACC_CUDA_ONLY` is only ever used in code that is guarded with `BOOST_LANG_CUDA`. It always resolves to `__device__`. To remove the confusion and reduce the number of macros (you know, macros are evil), the simple replacement should be enough.