### PR TITLE
Replace ALPAKA_FN_ACC_NO_CUDA with ALPAKA_FN_HOST

### DIFF
--- a/include/alpaka/acc/AccCpuFibers.hpp
+++ b/include/alpaka/acc/AccCpuFibers.hpp
@@ -106,7 +106,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuFibers(
+            ALPAKA_FN_HOST AccCpuFibers(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -131,13 +131,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuFibers(AccCpuFibers const &) = delete;
+            ALPAKA_FN_HOST AccCpuFibers(AccCpuFibers const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuFibers(AccCpuFibers &&) = delete;
+            ALPAKA_FN_HOST AccCpuFibers(AccCpuFibers &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuFibers const &) -> AccCpuFibers & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuFibers const &) -> AccCpuFibers & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuFibers &&) -> AccCpuFibers & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuFibers &&) -> AccCpuFibers & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuFibers() = default;
 

--- a/include/alpaka/acc/AccCpuOmp2Blocks.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Blocks.hpp
@@ -107,7 +107,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Blocks(
+            ALPAKA_FN_HOST AccCpuOmp2Blocks(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -129,13 +129,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Blocks(AccCpuOmp2Blocks const &) = delete;
+            ALPAKA_FN_HOST AccCpuOmp2Blocks(AccCpuOmp2Blocks const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Blocks(AccCpuOmp2Blocks &&) = delete;
+            ALPAKA_FN_HOST AccCpuOmp2Blocks(AccCpuOmp2Blocks &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp2Blocks const &) -> AccCpuOmp2Blocks & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp2Blocks const &) -> AccCpuOmp2Blocks & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp2Blocks &&) -> AccCpuOmp2Blocks & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp2Blocks &&) -> AccCpuOmp2Blocks & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuOmp2Blocks() = default;
 

--- a/include/alpaka/acc/AccCpuOmp2Threads.hpp
+++ b/include/alpaka/acc/AccCpuOmp2Threads.hpp
@@ -107,7 +107,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Threads(
+            ALPAKA_FN_HOST AccCpuOmp2Threads(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -131,13 +131,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Threads(AccCpuOmp2Threads const &) = delete;
+            ALPAKA_FN_HOST AccCpuOmp2Threads(AccCpuOmp2Threads const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp2Threads(AccCpuOmp2Threads &&) = delete;
+            ALPAKA_FN_HOST AccCpuOmp2Threads(AccCpuOmp2Threads &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp2Threads const &) -> AccCpuOmp2Threads & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp2Threads const &) -> AccCpuOmp2Threads & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp2Threads &&) -> AccCpuOmp2Threads & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp2Threads &&) -> AccCpuOmp2Threads & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuOmp2Threads() = default;
 

--- a/include/alpaka/acc/AccCpuOmp4.hpp
+++ b/include/alpaka/acc/AccCpuOmp4.hpp
@@ -107,7 +107,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp4(
+            ALPAKA_FN_HOST AccCpuOmp4(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -131,13 +131,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp4(AccCpuOmp4 const &) = delete;
+            ALPAKA_FN_HOST AccCpuOmp4(AccCpuOmp4 const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuOmp4(AccCpuOmp4 &&) = delete;
+            ALPAKA_FN_HOST AccCpuOmp4(AccCpuOmp4 &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp4 const &) -> AccCpuOmp4 & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp4 const &) -> AccCpuOmp4 & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuOmp4 &&) -> AccCpuOmp4 & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuOmp4 &&) -> AccCpuOmp4 & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuOmp4() = default;
 

--- a/include/alpaka/acc/AccCpuSerial.hpp
+++ b/include/alpaka/acc/AccCpuSerial.hpp
@@ -101,7 +101,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuSerial(
+            ALPAKA_FN_HOST AccCpuSerial(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -123,13 +123,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuSerial(AccCpuSerial const &) = delete;
+            ALPAKA_FN_HOST AccCpuSerial(AccCpuSerial const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuSerial(AccCpuSerial &&) = delete;
+            ALPAKA_FN_HOST AccCpuSerial(AccCpuSerial &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuSerial const &) -> AccCpuSerial & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuSerial const &) -> AccCpuSerial & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuSerial &&) -> AccCpuSerial & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuSerial &&) -> AccCpuSerial & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuSerial() = default;
 

--- a/include/alpaka/acc/AccCpuTbbBlocks.hpp
+++ b/include/alpaka/acc/AccCpuTbbBlocks.hpp
@@ -99,7 +99,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuTbbBlocks(
+            ALPAKA_FN_HOST AccCpuTbbBlocks(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -121,13 +121,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuTbbBlocks(AccCpuTbbBlocks const &) = delete;
+            ALPAKA_FN_HOST AccCpuTbbBlocks(AccCpuTbbBlocks const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuTbbBlocks(AccCpuTbbBlocks &&) = delete;
+            ALPAKA_FN_HOST AccCpuTbbBlocks(AccCpuTbbBlocks &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuTbbBlocks const &) -> AccCpuTbbBlocks & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuTbbBlocks const &) -> AccCpuTbbBlocks & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuTbbBlocks &&) -> AccCpuTbbBlocks & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuTbbBlocks &&) -> AccCpuTbbBlocks & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuTbbBlocks() = default;
 

--- a/include/alpaka/acc/AccCpuThreads.hpp
+++ b/include/alpaka/acc/AccCpuThreads.hpp
@@ -103,7 +103,7 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             template<
                 typename TWorkDiv>
-            ALPAKA_FN_ACC_NO_CUDA AccCpuThreads(
+            ALPAKA_FN_HOST AccCpuThreads(
                 TWorkDiv const & workDiv,
                 TIdx const & blockSharedMemDynSizeBytes) :
                     workdiv::WorkDivMembers<TDim, TIdx>(workDiv),
@@ -128,13 +128,13 @@ namespace alpaka
 
         public:
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuThreads(AccCpuThreads const &) = delete;
+            ALPAKA_FN_HOST AccCpuThreads(AccCpuThreads const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AccCpuThreads(AccCpuThreads &&) = delete;
+            ALPAKA_FN_HOST AccCpuThreads(AccCpuThreads &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuThreads const &) -> AccCpuThreads & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuThreads const &) -> AccCpuThreads & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AccCpuThreads &&) -> AccCpuThreads & = delete;
+            ALPAKA_FN_HOST auto operator=(AccCpuThreads &&) -> AccCpuThreads & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AccCpuThreads() = default;
 

--- a/include/alpaka/atomic/AtomicNoOp.hpp
+++ b/include/alpaka/atomic/AtomicNoOp.hpp
@@ -38,13 +38,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             AtomicNoOp() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicNoOp(AtomicNoOp const &) = delete;
+            ALPAKA_FN_HOST AtomicNoOp(AtomicNoOp const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicNoOp(AtomicNoOp &&) = delete;
+            ALPAKA_FN_HOST AtomicNoOp(AtomicNoOp &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicNoOp const &) -> AtomicNoOp & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicNoOp const &) -> AtomicNoOp & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicNoOp &&) -> AtomicNoOp & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicNoOp &&) -> AtomicNoOp & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AtomicNoOp() = default;
         };
@@ -64,7 +64,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicNoOp const & atomic,
                     T * const addr,
                     T const & value)
@@ -74,7 +74,7 @@ namespace alpaka
                     return TOp()(addr, value);
                 }
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicNoOp const & atomic,
                     T * const addr,
                     T const & compare,

--- a/include/alpaka/atomic/AtomicOmpCritSec.hpp
+++ b/include/alpaka/atomic/AtomicOmpCritSec.hpp
@@ -44,13 +44,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             AtomicOmpCritSec() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicOmpCritSec(AtomicOmpCritSec const &) = delete;
+            ALPAKA_FN_HOST AtomicOmpCritSec(AtomicOmpCritSec const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicOmpCritSec(AtomicOmpCritSec &&) = delete;
+            ALPAKA_FN_HOST AtomicOmpCritSec(AtomicOmpCritSec &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicOmpCritSec const &) -> AtomicOmpCritSec & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicOmpCritSec const &) -> AtomicOmpCritSec & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicOmpCritSec &&) -> AtomicOmpCritSec & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicOmpCritSec &&) -> AtomicOmpCritSec & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AtomicOmpCritSec() = default;
         };
@@ -73,7 +73,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicOmpCritSec const & atomic,
                     T * const addr,
                     T const & value)
@@ -89,7 +89,7 @@ namespace alpaka
                     return old;
                 }
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicOmpCritSec const & atomic,
                     T * const addr,
                     T const & compare,

--- a/include/alpaka/atomic/AtomicStlLock.hpp
+++ b/include/alpaka/atomic/AtomicStlLock.hpp
@@ -74,13 +74,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             AtomicStlLock() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicStlLock(AtomicStlLock const &) = delete;
+            ALPAKA_FN_HOST AtomicStlLock(AtomicStlLock const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA AtomicStlLock(AtomicStlLock &&) = delete;
+            ALPAKA_FN_HOST AtomicStlLock(AtomicStlLock &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicStlLock const &) -> AtomicStlLock & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicStlLock const &) -> AtomicStlLock & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(AtomicStlLock &&) -> AtomicStlLock & = delete;
+            ALPAKA_FN_HOST auto operator=(AtomicStlLock &&) -> AtomicStlLock & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~AtomicStlLock() = default;
 
@@ -117,7 +117,7 @@ namespace alpaka
                 THierarchy>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicStlLock<THashTableSize> const & atomic,
                     T * const addr,
                     T const & value)
@@ -127,7 +127,7 @@ namespace alpaka
                     return TOp()(addr, value);
                 }
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto atomicOp(
+                ALPAKA_FN_HOST static auto atomicOp(
                     atomic::AtomicStlLock<THashTableSize> const & atomic,
                     T * const addr,
                     T const & compare,

--- a/include/alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp
+++ b/include/alpaka/block/shared/dyn/BlockSharedMemDynBoostAlignedAlloc.hpp
@@ -47,7 +47,7 @@ namespace alpaka
                     using BlockSharedMemDynBase = BlockSharedMemDynBoostAlignedAlloc;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemDynBoostAlignedAlloc(
+                    ALPAKA_FN_HOST BlockSharedMemDynBoostAlignedAlloc(
                         std::size_t const & blockSharedMemDynSizeBytes)
                     {
                         if(blockSharedMemDynSizeBytes > 0u)
@@ -58,13 +58,13 @@ namespace alpaka
                         }
                     }
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc const &) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc const &) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc &&) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemDynBoostAlignedAlloc(BlockSharedMemDynBoostAlignedAlloc &&) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemDynBoostAlignedAlloc const &) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemDynBoostAlignedAlloc const &) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemDynBoostAlignedAlloc &&) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemDynBoostAlignedAlloc &&) -> BlockSharedMemDynBoostAlignedAlloc & = delete;
                     //-----------------------------------------------------------------------------
                     /*virtual*/ ~BlockSharedMemDynBoostAlignedAlloc() = default;
 
@@ -89,7 +89,7 @@ namespace alpaka
                         BlockSharedMemDynBoostAlignedAlloc>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto getMem(
+                        ALPAKA_FN_HOST static auto getMem(
                             block::shared::dyn::BlockSharedMemDynBoostAlignedAlloc const & blockSharedMemDyn)
                         -> T *
                         {

--- a/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStMasterSync.hpp
@@ -48,20 +48,20 @@ namespace alpaka
                     using BlockSharedMemStBase = BlockSharedMemStMasterSync;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemStMasterSync(
+                    ALPAKA_FN_HOST BlockSharedMemStMasterSync(
                         std::function<void()> fnSync,
                         std::function<bool()> fnIsMasterThread) :
                             m_syncFn(fnSync),
                             m_isMasterThreadFn(fnIsMasterThread)
                     {}
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemStMasterSync(BlockSharedMemStMasterSync const &) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemStMasterSync(BlockSharedMemStMasterSync &&) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemStMasterSync const &) -> BlockSharedMemStMasterSync & = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemStMasterSync &&) -> BlockSharedMemStMasterSync & = delete;
                     //-----------------------------------------------------------------------------
                     /*virtual*/ ~BlockSharedMemStMasterSync() = default;
 
@@ -94,7 +94,7 @@ namespace alpaka
                         BlockSharedMemStMasterSync>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto allocVar(
+                        ALPAKA_FN_HOST static auto allocVar(
                             block::shared::st::BlockSharedMemStMasterSync const & blockSharedMemSt)
                         -> T &
                         {
@@ -128,7 +128,7 @@ namespace alpaka
                         BlockSharedMemStMasterSync>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto freeMem(
+                        ALPAKA_FN_HOST static auto freeMem(
                             block::shared::st::BlockSharedMemStMasterSync const & blockSharedMemSt)
                         -> void
                         {

--- a/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
+++ b/include/alpaka/block/shared/st/BlockSharedMemStNoSync.hpp
@@ -49,13 +49,13 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     BlockSharedMemStNoSync() = default;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemStNoSync(BlockSharedMemStNoSync const &) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemStNoSync(BlockSharedMemStNoSync const &) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA BlockSharedMemStNoSync(BlockSharedMemStNoSync &&) = delete;
+                    ALPAKA_FN_HOST BlockSharedMemStNoSync(BlockSharedMemStNoSync &&) = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemStNoSync const &) -> BlockSharedMemStNoSync & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemStNoSync const &) -> BlockSharedMemStNoSync & = delete;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSharedMemStNoSync &&) -> BlockSharedMemStNoSync & = delete;
+                    ALPAKA_FN_HOST auto operator=(BlockSharedMemStNoSync &&) -> BlockSharedMemStNoSync & = delete;
                     //-----------------------------------------------------------------------------
                     /*virtual*/ ~BlockSharedMemStNoSync() = default;
 
@@ -85,7 +85,7 @@ namespace alpaka
                         BlockSharedMemStNoSync>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto allocVar(
+                        ALPAKA_FN_HOST static auto allocVar(
                             block::shared::st::BlockSharedMemStNoSync const & blockSharedMemSt)
                         -> T &
                         {
@@ -111,7 +111,7 @@ namespace alpaka
                         BlockSharedMemStNoSync>
                     {
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_ACC_NO_CUDA static auto freeMem(
+                        ALPAKA_FN_HOST static auto freeMem(
                             block::shared::st::BlockSharedMemStNoSync const & blockSharedMemSt)
                         -> void
                         {

--- a/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierFiber.hpp
@@ -48,7 +48,7 @@ namespace alpaka
                 using BlockSyncBase = BlockSyncBarrierFiber;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierFiber(
+                ALPAKA_FN_HOST BlockSyncBarrierFiber(
                     TIdx const & blockThreadCount) :
                         m_barrier(static_cast<std::size_t>(blockThreadCount)),
                         m_threadCount(blockThreadCount),
@@ -56,13 +56,13 @@ namespace alpaka
                         m_generation(static_cast<TIdx>(0u))
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierFiber(BlockSyncBarrierFiber const &) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierFiber(BlockSyncBarrierFiber &&) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierFiber(BlockSyncBarrierFiber &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierFiber const &) -> BlockSyncBarrierFiber & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber const &) -> BlockSyncBarrierFiber & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierFiber &&) -> BlockSyncBarrierFiber & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierFiber &&) -> BlockSyncBarrierFiber & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~BlockSyncBarrierFiber() = default;
 
@@ -83,7 +83,7 @@ namespace alpaka
                     BlockSyncBarrierFiber<TIdx>>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto syncBlockThreads(
+                    ALPAKA_FN_HOST static auto syncBlockThreads(
                         block::sync::BlockSyncBarrierFiber<TIdx> const & blockSync)
                     -> void
                     {

--- a/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierOmp.hpp
@@ -42,17 +42,17 @@ namespace alpaka
                 using BlockSyncBase = BlockSyncBarrierOmp;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierOmp() :
+                ALPAKA_FN_HOST BlockSyncBarrierOmp() :
                     m_generation(0u)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierOmp(BlockSyncBarrierOmp const &) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierOmp(BlockSyncBarrierOmp &&) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierOmp(BlockSyncBarrierOmp &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierOmp const &) -> BlockSyncBarrierOmp & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp const &) -> BlockSyncBarrierOmp & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierOmp &&) -> BlockSyncBarrierOmp & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierOmp &&) -> BlockSyncBarrierOmp & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~BlockSyncBarrierOmp() = default;
 
@@ -68,7 +68,7 @@ namespace alpaka
                     BlockSyncBarrierOmp>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto syncBlockThreads(
+                    ALPAKA_FN_HOST static auto syncBlockThreads(
                         block::sync::BlockSyncBarrierOmp const & blockSync)
                     -> void
                     {

--- a/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
+++ b/include/alpaka/block/sync/BlockSyncBarrierThread.hpp
@@ -52,19 +52,19 @@ namespace alpaka
                 using BarrierWithPredicate = core::threads::BarrierThreadWithPredicate<TIdx>;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierThread(
+                ALPAKA_FN_HOST BlockSyncBarrierThread(
                     TIdx const & blockThreadCount) :
                         m_barrier(blockThreadCount),
                         m_barrierWithPredicate(blockThreadCount)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierThread(BlockSyncBarrierThread const &) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BlockSyncBarrierThread(BlockSyncBarrierThread &&) = delete;
+                ALPAKA_FN_HOST BlockSyncBarrierThread(BlockSyncBarrierThread &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierThread const &) -> BlockSyncBarrierThread & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread const &) -> BlockSyncBarrierThread & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BlockSyncBarrierThread &&) -> BlockSyncBarrierThread & = delete;
+                ALPAKA_FN_HOST auto operator=(BlockSyncBarrierThread &&) -> BlockSyncBarrierThread & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~BlockSyncBarrierThread() = default;
 
@@ -81,7 +81,7 @@ namespace alpaka
                     BlockSyncBarrierThread<TIdx>>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto syncBlockThreads(
+                    ALPAKA_FN_HOST static auto syncBlockThreads(
                         block::sync::BlockSyncBarrierThread<TIdx> const & blockSync)
                     -> void
                     {

--- a/include/alpaka/core/BarrierThread.hpp
+++ b/include/alpaka/core/BarrierThread.hpp
@@ -48,26 +48,26 @@ namespace alpaka
             {
             public:
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA explicit BarrierThread(
+                ALPAKA_FN_HOST explicit BarrierThread(
                     TIdx const & threadCount) :
                     m_threadCount(threadCount),
                     m_curThreadCount(threadCount),
                     m_generation(0)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BarrierThread(BarrierThread const &) = delete;
+                ALPAKA_FN_HOST BarrierThread(BarrierThread const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BarrierThread(BarrierThread &&) = delete;
+                ALPAKA_FN_HOST BarrierThread(BarrierThread &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BarrierThread const &) -> BarrierThread & = delete;
+                ALPAKA_FN_HOST auto operator=(BarrierThread const &) -> BarrierThread & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BarrierThread &&) -> BarrierThread & = delete;
+                ALPAKA_FN_HOST auto operator=(BarrierThread &&) -> BarrierThread & = delete;
                 //-----------------------------------------------------------------------------
                 ~BarrierThread() = default;
 
                 //-----------------------------------------------------------------------------
                 //! Waits for all the other threads to reach the barrier.
-                ALPAKA_FN_ACC_NO_CUDA auto wait()
+                ALPAKA_FN_HOST auto wait()
                 -> void
                 {
                     TIdx const generationWhenEnteredTheWait = m_generation;
@@ -156,20 +156,20 @@ namespace alpaka
             {
             public:
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA explicit BarrierThreadWithPredicate(
+                ALPAKA_FN_HOST explicit BarrierThreadWithPredicate(
                     TIdx const & threadCount) :
                     m_threadCount(threadCount),
                     m_curThreadCount(threadCount),
                     m_generation(0)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BarrierThreadWithPredicate(BarrierThreadWithPredicate const & other) = delete;
+                ALPAKA_FN_HOST BarrierThreadWithPredicate(BarrierThreadWithPredicate const & other) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA BarrierThreadWithPredicate(BarrierThreadWithPredicate &&) = delete;
+                ALPAKA_FN_HOST BarrierThreadWithPredicate(BarrierThreadWithPredicate &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BarrierThreadWithPredicate const &) -> BarrierThreadWithPredicate & = delete;
+                ALPAKA_FN_HOST auto operator=(BarrierThreadWithPredicate const &) -> BarrierThreadWithPredicate & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(BarrierThreadWithPredicate &&) -> BarrierThreadWithPredicate & = delete;
+                ALPAKA_FN_HOST auto operator=(BarrierThreadWithPredicate &&) -> BarrierThreadWithPredicate & = delete;
                 //-----------------------------------------------------------------------------
                 ~BarrierThreadWithPredicate() = default;
 
@@ -177,7 +177,7 @@ namespace alpaka
                 //! Waits for all the other threads to reach the barrier.
                 template<
                     typename TOp>
-                ALPAKA_FN_ACC_NO_CUDA auto wait(int predicate)
+                ALPAKA_FN_HOST auto wait(int predicate)
                 -> int
                 {
                     TIdx const generationWhenEnteredTheWait = m_generation;

--- a/include/alpaka/core/Common.hpp
+++ b/include/alpaka/core/Common.hpp
@@ -116,7 +116,6 @@
 //! auto add(std::int32_t a, std::int32_t b)
 //! -> std::int32_t;
 #if BOOST_LANG_CUDA
-    #define ALPAKA_FN_ACC_NO_CUDA __host__
     #if defined(ALPAKA_ACC_GPU_CUDA_ONLY_MODE)
         #define ALPAKA_FN_ACC __device__
     #else
@@ -125,7 +124,6 @@
     #define ALPAKA_FN_HOST_ACC __device__ __host__
     #define ALPAKA_FN_HOST __host__
 #else
-    #define ALPAKA_FN_ACC_NO_CUDA
     #define ALPAKA_FN_ACC
     #define ALPAKA_FN_HOST_ACC
     #define ALPAKA_FN_HOST

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -53,13 +53,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 IdxBtOmp() = default;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtOmp(IdxBtOmp const &) = delete;
+                ALPAKA_FN_HOST IdxBtOmp(IdxBtOmp const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtOmp(IdxBtOmp &&) = delete;
+                ALPAKA_FN_HOST IdxBtOmp(IdxBtOmp &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtOmp const &) -> IdxBtOmp & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtOmp const &) -> IdxBtOmp & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtOmp &&) -> IdxBtOmp & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtOmp &&) -> IdxBtOmp & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxBtOmp() = default;
             };
@@ -100,7 +100,7 @@ namespace alpaka
                 //! \return The index of the current thread in the block.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_NO_CUDA static auto getIdx(
+                ALPAKA_FN_HOST static auto getIdx(
                     idx::bt::IdxBtOmp<TDim, TIdx> const & idx,
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -52,18 +52,18 @@ namespace alpaka
                 using FiberIdToIdxMap = std::map<boost::fibers::fiber::id, vec::Vec<TDim, TIdx>>;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefFiberIdMap(
+                ALPAKA_FN_HOST IdxBtRefFiberIdMap(
                     FiberIdToIdxMap const & mFibersToIndices) :
                     m_fibersToIndices(mFibersToIndices)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefFiberIdMap(IdxBtRefFiberIdMap const &) = delete;
+                ALPAKA_FN_HOST IdxBtRefFiberIdMap(IdxBtRefFiberIdMap const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefFiberIdMap(IdxBtRefFiberIdMap &&) = delete;
+                ALPAKA_FN_HOST IdxBtRefFiberIdMap(IdxBtRefFiberIdMap &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtRefFiberIdMap const &) -> IdxBtRefFiberIdMap & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtRefFiberIdMap const &) -> IdxBtRefFiberIdMap & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtRefFiberIdMap &&) -> IdxBtRefFiberIdMap & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtRefFiberIdMap &&) -> IdxBtRefFiberIdMap & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxBtRefFiberIdMap() = default;
 
@@ -107,7 +107,7 @@ namespace alpaka
                 //! \return The index of the current thread in the block.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_NO_CUDA static auto getIdx(
+                ALPAKA_FN_HOST static auto getIdx(
                     idx::bt::IdxBtRefFiberIdMap<TDim, TIdx> const & idx,
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -52,18 +52,18 @@ namespace alpaka
                 using ThreadIdToIdxMap = std::map<std::thread::id, vec::Vec<TDim, TIdx>>;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefThreadIdMap(
+                ALPAKA_FN_HOST IdxBtRefThreadIdMap(
                     ThreadIdToIdxMap const & mThreadToIndices) :
                     m_threadToIndexMap(mThreadToIndices)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefThreadIdMap(IdxBtRefThreadIdMap const &) = delete;
+                ALPAKA_FN_HOST IdxBtRefThreadIdMap(IdxBtRefThreadIdMap const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtRefThreadIdMap(IdxBtRefThreadIdMap &&) = delete;
+                ALPAKA_FN_HOST IdxBtRefThreadIdMap(IdxBtRefThreadIdMap &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtRefThreadIdMap const &) -> IdxBtRefThreadIdMap & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtRefThreadIdMap const &) -> IdxBtRefThreadIdMap & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtRefThreadIdMap &&) -> IdxBtRefThreadIdMap & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtRefThreadIdMap &&) -> IdxBtRefThreadIdMap & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxBtRefThreadIdMap() = default;
 
@@ -107,7 +107,7 @@ namespace alpaka
                 //! \return The index of the current thread in the block.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_NO_CUDA static auto getIdx(
+                ALPAKA_FN_HOST static auto getIdx(
                     idx::bt::IdxBtRefThreadIdMap<TDim, TIdx> const & idx,
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/idx/bt/IdxBtZero.hpp
+++ b/include/alpaka/idx/bt/IdxBtZero.hpp
@@ -46,13 +46,13 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 IdxBtZero() = default;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtZero(IdxBtZero const &) = delete;
+                ALPAKA_FN_HOST IdxBtZero(IdxBtZero const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxBtZero(IdxBtZero &&) = delete;
+                ALPAKA_FN_HOST IdxBtZero(IdxBtZero &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtZero const &) -> IdxBtZero & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtZero const &) -> IdxBtZero & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxBtZero &&) -> IdxBtZero & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxBtZero &&) -> IdxBtZero & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxBtZero() = default;
             };
@@ -93,7 +93,7 @@ namespace alpaka
                 //! \return The index of the current thread in the block.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_NO_CUDA static auto getIdx(
+                ALPAKA_FN_HOST static auto getIdx(
                     idx::bt::IdxBtZero<TDim, TIdx> const & idx,
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/idx/gb/IdxGbRef.hpp
+++ b/include/alpaka/idx/gb/IdxGbRef.hpp
@@ -45,18 +45,18 @@ namespace alpaka
                 using IdxGbBase = IdxGbRef;
 
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxGbRef(
+                ALPAKA_FN_HOST IdxGbRef(
                     vec::Vec<TDim, TIdx> const & gridBlockIdx) :
                         m_gridBlockIdx(gridBlockIdx)
                 {}
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxGbRef(IdxGbRef const &) = delete;
+                ALPAKA_FN_HOST IdxGbRef(IdxGbRef const &) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA IdxGbRef(IdxGbRef &&) = delete;
+                ALPAKA_FN_HOST IdxGbRef(IdxGbRef &&) = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxGbRef const &) -> IdxGbRef & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxGbRef const &) -> IdxGbRef & = delete;
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA auto operator=(IdxGbRef &&) -> IdxGbRef & = delete;
+                ALPAKA_FN_HOST auto operator=(IdxGbRef &&) -> IdxGbRef & = delete;
                 //-----------------------------------------------------------------------------
                 /*virtual*/ ~IdxGbRef() = default;
 
@@ -100,7 +100,7 @@ namespace alpaka
                 //! \return The index of the current block in the grid.
                 template<
                     typename TWorkDiv>
-                ALPAKA_FN_ACC_NO_CUDA static auto getIdx(
+                ALPAKA_FN_HOST static auto getIdx(
                     idx::gb::IdxGbRef<TDim, TIdx> const & idx,
                     TWorkDiv const & workDiv)
                 -> vec::Vec<TDim, TIdx>

--- a/include/alpaka/math/abs/AbsStl.hpp
+++ b/include/alpaka/math/abs/AbsStl.hpp
@@ -54,7 +54,7 @@ namespace alpaka
                     std::is_arithmetic<TArg>::value
                     && std::is_signed<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto abs(
+                ALPAKA_FN_HOST static auto abs(
                     AbsStl const & abs,
                     TArg const & arg)
                 -> decltype(std::abs(arg))

--- a/include/alpaka/math/acos/AcosStl.hpp
+++ b/include/alpaka/math/acos/AcosStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto acos(
+                ALPAKA_FN_HOST static auto acos(
                     AcosStl const & acos,
                     TArg const & arg)
                 -> decltype(std::acos(arg))

--- a/include/alpaka/math/asin/AsinStl.hpp
+++ b/include/alpaka/math/asin/AsinStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto asin(
+                ALPAKA_FN_HOST static auto asin(
                     AsinStl const & asin,
                     TArg const & arg)
                 -> decltype(std::asin(arg))

--- a/include/alpaka/math/atan/AtanStl.hpp
+++ b/include/alpaka/math/atan/AtanStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto atan(
+                ALPAKA_FN_HOST static auto atan(
                     AtanStl const & atan,
                     TArg const & arg)
                 -> decltype(std::atan(arg))

--- a/include/alpaka/math/atan2/Atan2Stl.hpp
+++ b/include/alpaka/math/atan2/Atan2Stl.hpp
@@ -55,7 +55,7 @@ namespace alpaka
                     std::is_arithmetic<Ty>::value
                     && std::is_arithmetic<Tx>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto atan2(
+                ALPAKA_FN_HOST static auto atan2(
                     Atan2Stl const & abs,
                     Ty const & y,
                     Tx const & x)

--- a/include/alpaka/math/cbrt/CbrtStl.hpp
+++ b/include/alpaka/math/cbrt/CbrtStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto cbrt(
+                ALPAKA_FN_HOST static auto cbrt(
                     CbrtStl const & cbrt,
                     TArg const & arg)
                 -> decltype(std::cbrt(arg))

--- a/include/alpaka/math/ceil/CeilStl.hpp
+++ b/include/alpaka/math/ceil/CeilStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto ceil(
+                ALPAKA_FN_HOST static auto ceil(
                     CeilStl const & ceil,
                     TArg const & arg)
                 -> decltype(std::ceil(arg))

--- a/include/alpaka/math/cos/CosStl.hpp
+++ b/include/alpaka/math/cos/CosStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto cos(
+                ALPAKA_FN_HOST static auto cos(
                     CosStl const & cos,
                     TArg const & arg)
                 -> decltype(std::cos(arg))

--- a/include/alpaka/math/erf/ErfStl.hpp
+++ b/include/alpaka/math/erf/ErfStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto erf(
+                ALPAKA_FN_HOST static auto erf(
                     ErfStl const & erf,
                     TArg const & arg)
                 -> decltype(std::erf(arg))

--- a/include/alpaka/math/exp/ExpStl.hpp
+++ b/include/alpaka/math/exp/ExpStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto exp(
+                ALPAKA_FN_HOST static auto exp(
                     ExpStl const & exp,
                     TArg const & arg)
                 -> decltype(std::exp(arg))

--- a/include/alpaka/math/floor/FloorStl.hpp
+++ b/include/alpaka/math/floor/FloorStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto floor(
+                ALPAKA_FN_HOST static auto floor(
                     FloorStl const & floor,
                     TArg const & arg)
                 -> decltype(std::floor(arg))

--- a/include/alpaka/math/fmod/FmodStl.hpp
+++ b/include/alpaka/math/fmod/FmodStl.hpp
@@ -55,7 +55,7 @@ namespace alpaka
                     std::is_arithmetic<Tx>::value
                     && std::is_arithmetic<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto fmod(
+                ALPAKA_FN_HOST static auto fmod(
                     FmodStl const & fmod,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/log/LogStl.hpp
+++ b/include/alpaka/math/log/LogStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto log(
+                ALPAKA_FN_HOST static auto log(
                     LogStl const & log,
                     TArg const & arg)
                 -> decltype(std::log(arg))

--- a/include/alpaka/math/max/MaxStl.hpp
+++ b/include/alpaka/math/max/MaxStl.hpp
@@ -56,7 +56,7 @@ namespace alpaka
                     std::is_integral<Tx>::value
                     && std::is_integral<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto max(
+                ALPAKA_FN_HOST static auto max(
                     MaxStl const & max,
                     Tx const & x,
                     Ty const & y)
@@ -81,7 +81,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto max(
+                ALPAKA_FN_HOST static auto max(
                     MaxStl const & max,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/min/MinStl.hpp
+++ b/include/alpaka/math/min/MinStl.hpp
@@ -56,7 +56,7 @@ namespace alpaka
                     std::is_integral<Tx>::value
                     && std::is_integral<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto min(
+                ALPAKA_FN_HOST static auto min(
                     MinStl const & min,
                     Tx const & x,
                     Ty const & y)
@@ -81,7 +81,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto max(
+                ALPAKA_FN_HOST static auto max(
                     MinStl const & min,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/pow/PowStl.hpp
+++ b/include/alpaka/math/pow/PowStl.hpp
@@ -55,7 +55,7 @@ namespace alpaka
                     std::is_arithmetic<TBase>::value
                     && std::is_arithmetic<TExp>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto pow(
+                ALPAKA_FN_HOST static auto pow(
                     PowStl const & pow,
                     TBase const & base,
                     TExp const & exp)

--- a/include/alpaka/math/remainder/RemainderStl.hpp
+++ b/include/alpaka/math/remainder/RemainderStl.hpp
@@ -55,7 +55,7 @@ namespace alpaka
                     std::is_integral<Tx>::value
                     && std::is_integral<Ty>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto remainder(
+                ALPAKA_FN_HOST static auto remainder(
                     RemainderStl const & remainder,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/round/RoundStl.hpp
+++ b/include/alpaka/math/round/RoundStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto round(
+                ALPAKA_FN_HOST static auto round(
                     RoundStl const & round,
                     TArg const & arg)
                 -> decltype(std::round(arg))
@@ -71,7 +71,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto lround(
+                ALPAKA_FN_HOST static auto lround(
                     RoundStl const & lround,
                     TArg const & arg)
                 -> long int
@@ -90,7 +90,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto llround(
+                ALPAKA_FN_HOST static auto llround(
                     RoundStl const & llround,
                     TArg const & arg)
                 -> long int

--- a/include/alpaka/math/rsqrt/RsqrtStl.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto rsqrt(
+                ALPAKA_FN_HOST static auto rsqrt(
                     RsqrtStl const & rsqrt,
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))

--- a/include/alpaka/math/sin/SinStl.hpp
+++ b/include/alpaka/math/sin/SinStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto sin(
+                ALPAKA_FN_HOST static auto sin(
                     SinStl const & sin,
                     TArg const & arg)
                 -> decltype(std::sin(arg))

--- a/include/alpaka/math/sqrt/SqrtStl.hpp
+++ b/include/alpaka/math/sqrt/SqrtStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto sqrt(
+                ALPAKA_FN_HOST static auto sqrt(
                     SqrtStl const & sqrt,
                     TArg const & arg)
                 -> decltype(std::sqrt(arg))

--- a/include/alpaka/math/tan/TanStl.hpp
+++ b/include/alpaka/math/tan/TanStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto tan(
+                ALPAKA_FN_HOST static auto tan(
                     TanStl const & tan,
                     TArg const & arg)
                 -> decltype(std::tan(arg))

--- a/include/alpaka/math/trunc/TruncStl.hpp
+++ b/include/alpaka/math/trunc/TruncStl.hpp
@@ -52,7 +52,7 @@ namespace alpaka
                 typename std::enable_if<
                     std::is_arithmetic<TArg>::value>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto trunc(
+                ALPAKA_FN_HOST static auto trunc(
                     TruncStl const & trunc,
                     TArg const & arg)
                 -> decltype(std::trunc(arg))

--- a/include/alpaka/rand/RandStl.hpp
+++ b/include/alpaka/rand/RandStl.hpp
@@ -76,7 +76,7 @@ namespace alpaka
                     MersenneTwister() = default;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA MersenneTwister(
+                    ALPAKA_FN_HOST MersenneTwister(
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence = 0,
                         std::uint32_t const & offset = 0) :
@@ -107,7 +107,7 @@ namespace alpaka
                     TinyMersenneTwister() = default;
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA TinyMersenneTwister(
+                    ALPAKA_FN_HOST TinyMersenneTwister(
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence = 0,
                         std::uint32_t const & offset = 0) :
@@ -138,7 +138,7 @@ namespace alpaka
                     }
 
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA RandomDevice(
+                    ALPAKA_FN_HOST RandomDevice(
                         std::uint32_t const &,
                         std::uint32_t const & = 0,
                         std::uint32_t const & = 0) :
@@ -169,7 +169,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_NO_CUDA auto operator()(
+                    ALPAKA_FN_HOST auto operator()(
                         TGenerator & generator)
                     -> T
                     {
@@ -191,7 +191,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_NO_CUDA auto operator()(
+                    ALPAKA_FN_HOST auto operator()(
                         TGenerator & generator)
                     -> T
                     {
@@ -217,7 +217,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     template<
                         typename TGenerator>
-                    ALPAKA_FN_ACC_NO_CUDA auto operator()(
+                    ALPAKA_FN_HOST auto operator()(
                         TGenerator & generator)
                     -> T
                     {
@@ -243,7 +243,7 @@ namespace alpaka
                         std::is_floating_point<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createNormalReal(
+                    ALPAKA_FN_HOST static auto createNormalReal(
                         RandStl const & rand)
                     -> rand::distribution::cpu::NormalReal<T>
                     {
@@ -262,7 +262,7 @@ namespace alpaka
                         std::is_floating_point<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createUniformReal(
+                    ALPAKA_FN_HOST static auto createUniformReal(
                         RandStl const & rand)
                     -> rand::distribution::cpu::UniformReal<T>
                     {
@@ -281,7 +281,7 @@ namespace alpaka
                         std::is_integral<T>::value>::type>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createUniformUint(
+                    ALPAKA_FN_HOST static auto createUniformUint(
                         RandStl const & rand)
                     -> rand::distribution::cpu::UniformUint<T>
                     {
@@ -302,7 +302,7 @@ namespace alpaka
                     TinyMersenneTwister>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createDefault(
+                    ALPAKA_FN_HOST static auto createDefault(
                         TinyMersenneTwister const & rand,
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence)
@@ -320,7 +320,7 @@ namespace alpaka
                     MersenneTwister>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createDefault(
+                    ALPAKA_FN_HOST static auto createDefault(
                         MersenneTwister const & rand,
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence)
@@ -338,7 +338,7 @@ namespace alpaka
                     RandomDevice>
                 {
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_ACC_NO_CUDA static auto createDefault(
+                    ALPAKA_FN_HOST static auto createDefault(
                         RandomDevice const & rand,
                         std::uint32_t const & seed,
                         std::uint32_t const & subsequence)

--- a/include/alpaka/time/TimeOmp.hpp
+++ b/include/alpaka/time/TimeOmp.hpp
@@ -44,13 +44,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             TimeOmp() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA TimeOmp(TimeOmp const &) = delete;
+            ALPAKA_FN_HOST TimeOmp(TimeOmp const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA TimeOmp(TimeOmp &&) = delete;
+            ALPAKA_FN_HOST TimeOmp(TimeOmp &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeOmp const &) -> TimeOmp & = delete;
+            ALPAKA_FN_HOST auto operator=(TimeOmp const &) -> TimeOmp & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeOmp &&) -> TimeOmp & = delete;
+            ALPAKA_FN_HOST auto operator=(TimeOmp &&) -> TimeOmp & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~TimeOmp() = default;
         };
@@ -64,7 +64,7 @@ namespace alpaka
                 time::TimeOmp>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto clock(
+                ALPAKA_FN_HOST static auto clock(
                     time::TimeOmp const & time)
                 -> std::uint64_t
                 {

--- a/include/alpaka/time/TimeStl.hpp
+++ b/include/alpaka/time/TimeStl.hpp
@@ -43,13 +43,13 @@ namespace alpaka
             //-----------------------------------------------------------------------------
             TimeStl() = default;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA TimeStl(TimeStl const &) = delete;
+            ALPAKA_FN_HOST TimeStl(TimeStl const &) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA TimeStl(TimeStl &&) = delete;
+            ALPAKA_FN_HOST TimeStl(TimeStl &&) = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeStl const &) -> TimeStl & = delete;
+            ALPAKA_FN_HOST auto operator=(TimeStl const &) -> TimeStl & = delete;
             //-----------------------------------------------------------------------------
-            ALPAKA_FN_ACC_NO_CUDA auto operator=(TimeStl &&) -> TimeStl & = delete;
+            ALPAKA_FN_HOST auto operator=(TimeStl &&) -> TimeStl & = delete;
             //-----------------------------------------------------------------------------
             /*virtual*/ ~TimeStl() = default;
         };
@@ -63,7 +63,7 @@ namespace alpaka
                 TimeStl>
             {
                 //-----------------------------------------------------------------------------
-                ALPAKA_FN_ACC_NO_CUDA static auto clock(
+                ALPAKA_FN_HOST static auto clock(
                     time::TimeStl const & time)
                 -> std::uint64_t
                 {


### PR DESCRIPTION
`ALPAKA_FN_ACC_NO_CUDA` is not used consistently and always ever resolves to `__host__`. This has lead to confusion which can be reduced by replacing it directly with `ALPAKA_FN_HOST`.

This is only a first step. We could simply remove `ALPAKA_FN_HOST` in a seperate PR.