### PR TITLE
Replace BOOST_VERIFY by ALPAKA_CHECK and return success from all test kernels

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -141,7 +141,7 @@ before_build:
     - cmd: if not "%ALPAKA_ACC_CPU_B_SEQ_T_FIBERS_ENABLE%"=="OFF" set ALPAKA_BOOST_B2=%ALPAKA_BOOST_B2% --with-fiber --with-context --with-thread --with-system --with-atomic --with-chrono --with-date_time
 
     - cmd: if "%APPVEYOR_BUILD_WORKER_IMAGE%"=="Visual Studio 2017" set ALPAKA_BOOST_TOOLSET=msvc-14.1
-    - cmd: b2 -j2 --toolset=%ALPAKA_BOOST_TOOLSET% --layout=versioned %ALPAKA_BOOST_B2% architecture=x86 address-model=%ALPAKA_BOOST_ADDRESS_MODEL% variant=%ALPAKA_BOOST_VARIANT% link=static threading=multi runtime-link=shared define=_CRT_NONSTDC_NO_DEPRECATE define=_CRT_SECURE_NO_DEPRECATE define=_SCL_SECURE_NO_DEPRECAT define=BOOST_USE_WINFIBERS --stagedir="%ALPAKA_B2_STAGE_DIR%"
+    - cmd: b2 -j2 --toolset=%ALPAKA_BOOST_TOOLSET% --layout=versioned %ALPAKA_BOOST_B2% architecture=x86 address-model=%ALPAKA_BOOST_ADDRESS_MODEL% variant=%ALPAKA_BOOST_VARIANT% link=static threading=multi runtime-link=shared define=_CRT_NONSTDC_NO_DEPRECATE define=_CRT_SECURE_NO_DEPRECATE define=_SCL_SECURE_NO_DEPRECAT define=BOOST_USE_WINFIBERS define=_ENABLE_EXTENDED_ALIGNED_STORAGE --stagedir="%ALPAKA_B2_STAGE_DIR%"
 
     #-------------------------------------------------------------------------------
     # Install TBB

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,9 +89,9 @@ matrix:
     # gcc 6 ASan is triggered within libtbb.so
     # gcc 7 ASan introduced 'stack-use-after-scope' which is triggered by GOMP_parallel
     - name: gcc-4.9 Debug
-      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=4.9     CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.66.0 ALPAKA_CI_CMAKE_VER=3.7.2  ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=4
+      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=4.9     CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.62.0 ALPAKA_CI_CMAKE_VER=3.7.2  ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=4
     - name: gcc-5 Release
-      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=5       CMAKE_BUILD_TYPE=Release ALPAKA_CI_BOOST_BRANCH=boost-1.62.0 ALPAKA_CI_CMAKE_VER=3.10.3 ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=3
+      env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=5       CMAKE_BUILD_TYPE=Release ALPAKA_CI_BOOST_BRANCH=boost-1.66.0 ALPAKA_CI_CMAKE_VER=3.10.3 ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=3
     - name: gcc-6 Debug
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:17.10 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=6       CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.67.0 ALPAKA_CI_CMAKE_VER=3.9.6  ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=2
     - name: gcc-7 Release
@@ -100,11 +100,11 @@ matrix:
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=g++     CC=gcc   ALPAKA_CI_GCC_VER=8       CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.68.0 ALPAKA_CI_CMAKE_VER=3.12.0 ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=4
 
     # clang++
-    - name: clang-4 Debug
+    - name: clang-4 Debug UBSan
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:14.04 CXX=clang++ CC=clang ALPAKA_CI_CLANG_VER=4.0.0 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.64.0 ALPAKA_CI_CMAKE_VER=3.7.2  ALPAKA_CI_SANITIZERS=UBSan OMP_NUM_THREADS=4
     - name: clang-5 Debug
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=clang++ CC=clang ALPAKA_CI_CLANG_VER=5.0.2 CMAKE_BUILD_TYPE=Debug   ALPAKA_CI_BOOST_BRANCH=boost-1.67.0 ALPAKA_CI_CMAKE_VER=3.11.4 ALPAKA_CI_SANITIZERS=      OMP_NUM_THREADS=3
-    - name: clang-6 Release
+    - name: clang-6 Release ASan
       env: ALPAKA_CI_DOCKER_BASE_IMAGE_NAME=ubuntu:16.04 CXX=clang++ CC=clang ALPAKA_CI_CLANG_VER=6.0.1 CMAKE_BUILD_TYPE=Release ALPAKA_CI_BOOST_BRANCH=boost-1.63.0 ALPAKA_CI_CMAKE_VER=3.8.2  ALPAKA_CI_SANITIZERS=ASan  OMP_NUM_THREADS=2
 
     ## CUDA 8.0
@@ -162,6 +162,10 @@ cache:
         - $ALPAKA_CI_DOCKER_CACHE_DIR
 
 script:
+    - sudo apt-get -y --quiet --allow-unauthenticated --no-install-recommends install smem
+    - sudo smem
+    - sudo free -m -t
+
     - ./script/travis/print_travisEnv.sh
 
     - sudo apt-get -y --quiet install moreutils
@@ -169,6 +173,12 @@ script:
     - source ./script/travis/before_install.sh
     - ./script/travis/docker_install.sh | ts
     - ./script/travis/docker_run.sh | ts
+
+after_failure:
+    - sudo smem
+    - sudo free -m -t
+    # show actions of the OOM killer
+    - sudo dmesg
 
 notifications:
     email: false

--- a/example/helloWorldLambda/src/helloWorldLambda.cpp
+++ b/example/helloWorldLambda/src/helloWorldLambda.cpp
@@ -47,7 +47,7 @@ void ALPAKA_FN_ACC hiWorldFunction(
     Vec const globalThreadExtent = alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc);
     Vec1 const linearizedGlobalThreadIdx = alpaka::idx::mapIdx<1u>(globalThreadIdx,
                                                               globalThreadExtent);
-                                                          
+
     printf("[z:%u, y:%u, x:%u][linear:%u] Hi world from a function",
            static_cast<unsigned>(globalThreadIdx[0]),
            static_cast<unsigned>(globalThreadIdx[1]),

--- a/script/travis/print_travisEnv.sh
+++ b/script/travis/print_travisEnv.sh
@@ -39,3 +39,15 @@ echo TRAVIS_SECURE_ENV_VARS: "${TRAVIS_SECURE_ENV_VARS}"
 echo TRAVIS_REPO_SLUG: "${TRAVIS_REPO_SLUG}"
 echo TRAVIS_OS_NAME: "${TRAVIS_OS_NAME}"
 echo TRAVIS_TAG: "${TRAVIS_TAG}"
+
+# Show all running services
+sudo service --status-all
+
+# Stop some unnecessary services to save memory
+sudo /etc/init.d/mysql stop
+sudo /etc/init.d/postgresql stop
+sudo /etc/init.d/redis-server stop
+
+# Show memory stats
+sudo smem
+sudo free -m -t

--- a/test/common/include/alpaka/test/Check.hpp
+++ b/test/common/include/alpaka/test/Check.hpp
@@ -1,6 +1,6 @@
 /**
  * \file
- * Copyright 2017 Benjamin Worpitz
+ * Copyright 2018 Benjamin Worpitz
  *
  * This file is part of alpaka.
  *
@@ -21,32 +21,11 @@
 
 #pragma once
 
-namespace alpaka
-{
-    namespace test
-    {
-        //#############################################################################
-        template<
-            typename TType,
-            size_t TSize>
-        struct Array {
-            TType m_data[TSize];
+#include <cstdio>
 
-            template<
-                typename T_Idx>
-            ALPAKA_FN_HOST_ACC const TType &operator[](
-                const T_Idx idx) const
-            {
-                return m_data[idx];
-            }
-
-            template<
-                typename TIdx>
-            ALPAKA_FN_HOST_ACC TType & operator[](
-                const TIdx idx)
-            {
-                return m_data[idx];
-            }
-        };
+#define ALPAKA_CHECK(success, expression) \
+    if(!(expression)) \
+    { \
+        printf("ALPAKA_CHECK failed because '!(%s)'\n", #expression); \
+        success = false; \
     }
-}

--- a/test/common/include/alpaka/test/acc/Acc.hpp
+++ b/test/common/include/alpaka/test/acc/Acc.hpp
@@ -202,45 +202,16 @@ namespace alpaka
                 os << std::endl;
             }
 
-#if defined(ALPAKA_CUDA_CI)
             //#############################################################################
             //! A std::tuple holding dimensions.
             using TestDims =
                 std::tuple<
                     alpaka::dim::DimInt<1u>,
-                    //alpaka::dim::DimInt<2u>,
-                    alpaka::dim::DimInt<3u>
-            // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
-#if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
-                    /*,alpaka::dim::DimInt<4u>*/
-#endif
-                >;
-
-            //#############################################################################
-            //! A std::tuple holding idx types.
-            using TestIdxs =
-                std::tuple<
-                    std::size_t,
-                    //std::int64_t,
-                    std::uint64_t,
-                    std::int32_t,
-                    //std::uint32_t,
-                    //std::int16_t,
-                    std::uint16_t/*,
-                    // When Idx is a 8 bit integer, extents within the tests would be extremely limited
-                    // (especially when Dim is 4). Therefore, we do not test it.
-                    std::int8_t,
-                    std::uint8_t*/>;
-#else
-
-            //#############################################################################
-            //! A std::tuple holding dimensions.
-            using TestDims =
-                std::tuple<
-                    alpaka::dim::DimInt<1u>,
+#if !defined(ALPAKA_CUDA_CI)
                     alpaka::dim::DimInt<2u>,
+#endif
                     alpaka::dim::DimInt<3u>
-            // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
+                    // The CUDA acceleator does not currently support 4D buffers and 4D acceleration.
 #if !(defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA)
                     ,alpaka::dim::DimInt<4u>
 #endif
@@ -253,17 +224,20 @@ namespace alpaka
                     // size_t is most probably identical to either std::uint64_t or std::uint32_t.
                     // This would lead to duplicate tests (especially test names) which is not allowed.
                     //std::size_t,
+#if !defined(ALPAKA_CI)
                     std::int64_t,
+#endif
                     std::uint64_t,
                     std::int32_t,
+#if !defined(ALPAKA_CI)
                     std::uint32_t,
-                    //std::int16_t,
+                    std::int16_t,
+#endif
                     std::uint16_t/*,
                     // When Idx is a 8 bit integer, extents within the tests would be extremely limited
                     // (especially when Dim is 4). Therefore, we do not test it.
                     std::int8_t,
                     std::uint8_t*/>;
-#endif
 
             namespace detail
             {

--- a/test/common/include/alpaka/test/mem/view/Iterator.hpp
+++ b/test/common/include/alpaka/test/mem/view/Iterator.hpp
@@ -229,7 +229,7 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 template<
                     typename TView>
-                ALPAKA_FN_HOST static auto begin(
+                ALPAKA_FN_HOST auto begin(
                     TView & view)
                 -> Iterator<TView>
                 {
@@ -239,7 +239,7 @@ namespace alpaka
                 //-----------------------------------------------------------------------------
                 template<
                     typename TView>
-                ALPAKA_FN_HOST static auto end(
+                ALPAKA_FN_HOST auto end(
                     TView & view)
                 -> Iterator<TView>
                 {

--- a/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
+++ b/test/integ/cudaOnly/src/cudaNativeFunctions.cpp
@@ -57,13 +57,18 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const &) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
+        alpaka::ignore_unused(acc);
+
         // We should be able to call some native CUDA functions when ALPAKA_ACC_GPU_CUDA_ONLY_MODE is enabled.
         __threadfence_block();
         userDefinedThreadFence();
         __threadfence_system();
+
+        *success = true;
     }
 };
 

--- a/test/unit/atomic/src/AtomicTest.cpp
+++ b/test/unit/atomic/src/AtomicTest.cpp
@@ -31,7 +31,6 @@
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -53,6 +52,7 @@ public:
         typename T>
     ALPAKA_FN_ACC auto operator()(
         TAcc const & acc,
+        bool * success,
         T operandOrig) const
     -> void
     {
@@ -69,9 +69,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig + value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -85,9 +85,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig - value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -101,9 +101,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = (operandOrig < value) ? operandOrig : value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -117,9 +117,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = (operandOrig > value) ? operandOrig : value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -133,9 +133,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -150,9 +150,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig + 1;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -167,9 +167,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig - 1;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -183,9 +183,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig & value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -199,9 +199,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig | value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -215,9 +215,9 @@ public:
                         acc,
                         &operand,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig ^ value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -233,9 +233,9 @@ public:
                         &operand,
                         compare,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = value;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
 
         //-----------------------------------------------------------------------------
@@ -251,9 +251,9 @@ public:
                         &operand,
                         compare,
                         value);
-            BOOST_VERIFY(operandOrig == ret);
+            ALPAKA_CHECK(*success, operandOrig == ret);
             T const reference = operandOrig;
-            BOOST_VERIFY(operand == reference);
+            ALPAKA_CHECK(*success, operand == reference);
         }
     }
 };

--- a/test/unit/block/shared/src/BlockSharedMemDyn.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemDyn.cpp
@@ -32,7 +32,6 @@
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -52,20 +51,21 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
         // Assure that the pointer is non null.
         auto && a = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
-        BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != a);
+        ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != a);
 
         // Each call should return the same pointer ...
         auto && b = alpaka::block::shared::dyn::getMem<std::uint32_t>(acc);
-        BOOST_VERIFY(a == b);
+        ALPAKA_CHECK(*success, a == b);
 
         // ... even for different types.
         auto && c = alpaka::block::shared::dyn::getMem<float>(acc);
-        BOOST_VERIFY(a == reinterpret_cast<std::uint32_t *>(c));
+        ALPAKA_CHECK(*success, a == reinterpret_cast<std::uint32_t *>(c));
     }
 };
 
@@ -90,10 +90,12 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
                     BlockSharedMemDynTestKernel const & blockSharedMemDyn,
                     TVec const & blockThreadExtent,
-                    TVec const & threadElemExtent)
+                    TVec const & threadElemExtent,
+                    bool * success)
                 -> idx::Idx<TAcc>
                 {
                     alpaka::ignore_unused(blockSharedMemDyn);
+                    alpaka::ignore_unused(success);
                     return
                         static_cast<idx::Idx<TAcc>>(sizeof(std::uint32_t)) * blockThreadExtent.prod() * threadElemExtent.prod();
                 }

--- a/test/unit/block/shared/src/BlockSharedMemSt.cpp
+++ b/test/unit/block/shared/src/BlockSharedMemSt.cpp
@@ -33,7 +33,6 @@
 #include <alpaka/test/Array.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -55,7 +54,8 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
@@ -66,29 +66,29 @@ public:
         for(std::size_t i=0u; i<10; ++i)
         {
             auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &a);
+            ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &a);
 
             auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &b);
+            ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &b);
 
             auto && c = alpaka::block::shared::st::allocVar<float, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<float *>(nullptr) != &c);
+            ALPAKA_CHECK(*success, static_cast<float *>(nullptr) != &c);
 
             auto && d = alpaka::block::shared::st::allocVar<double, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<double *>(nullptr) != &d);
+            ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &d);
 
             auto && e = alpaka::block::shared::st::allocVar<std::uint64_t, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<std::uint64_t *>(nullptr) != &e);
+            ALPAKA_CHECK(*success, static_cast<std::uint64_t *>(nullptr) != &e);
 
 
             auto && f = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &f[0]);
+            ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &f[0]);
 
             auto && g = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<std::uint32_t *>(nullptr) != &g[0]);
+            ALPAKA_CHECK(*success, static_cast<std::uint32_t *>(nullptr) != &g[0]);
 
             auto && h = alpaka::block::shared::st::allocVar<alpaka::test::Array<double, 16>, __COUNTER__>(acc);
-            BOOST_VERIFY(static_cast<double *>(nullptr) != &h[0]);
+            ALPAKA_CHECK(*success, static_cast<double *>(nullptr) != &h[0]);
         }
 #if BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(6, 0, 0)
     #pragma GCC diagnostic pop
@@ -126,7 +126,8 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
         // Multiple runs to make sure it really works.
@@ -134,21 +135,21 @@ public:
         {
             auto && a = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
             auto && b = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            BOOST_VERIFY(&a != &b);
+            ALPAKA_CHECK(*success, &a != &b);
             auto && c = alpaka::block::shared::st::allocVar<std::uint32_t, __COUNTER__>(acc);
-            BOOST_VERIFY(&b != &c);
-            BOOST_VERIFY(&a != &c);
-            BOOST_VERIFY(&b != &c);
+            ALPAKA_CHECK(*success, &b != &c);
+            ALPAKA_CHECK(*success, &a != &c);
+            ALPAKA_CHECK(*success, &b != &c);
 
             auto && d = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-            BOOST_VERIFY(&a != &d[0]);
-            BOOST_VERIFY(&b != &d[0]);
-            BOOST_VERIFY(&c != &d[0]);
+            ALPAKA_CHECK(*success, &a != &d[0]);
+            ALPAKA_CHECK(*success, &b != &d[0]);
+            ALPAKA_CHECK(*success, &c != &d[0]);
             auto && e = alpaka::block::shared::st::allocVar<alpaka::test::Array<std::uint32_t, 32>, __COUNTER__>(acc);
-            BOOST_VERIFY(&a != &e[0]);
-            BOOST_VERIFY(&b != &e[0]);
-            BOOST_VERIFY(&c != &e[0]);
-            BOOST_VERIFY(&d[0] != &e[0]);
+            ALPAKA_CHECK(*success, &a != &e[0]);
+            ALPAKA_CHECK(*success, &b != &e[0]);
+            ALPAKA_CHECK(*success, &c != &e[0]);
+            ALPAKA_CHECK(*success, &d[0] != &e[0]);
         }
     }
 };

--- a/test/unit/block/sync/src/BlockSync.cpp
+++ b/test/unit/block/sync/src/BlockSync.cpp
@@ -31,7 +31,6 @@
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -53,7 +52,8 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
         using Idx = alpaka::idx::Idx<TAcc>;
@@ -76,7 +76,7 @@ public:
         // All other threads within the block should now have written their index into the shared memory.
         for(auto i(static_cast<Idx>(0u)); i < blockThreadExtent1D; ++i)
         {
-            BOOST_VERIFY(pBlockSharedArray[i] == i);
+            ALPAKA_CHECK(*success, pBlockSharedArray[i] == i);
         }
     }
 };
@@ -102,13 +102,15 @@ namespace alpaka
                 ALPAKA_FN_HOST static auto getBlockSharedMemDynSizeBytes(
                     BlockSyncTestKernel const & blockSharedMemDyn,
                     TVec const & blockThreadExtent,
-                    TVec const & threadElemExtent)
+                    TVec const & threadElemExtent,
+                    bool * success)
                 -> idx::Idx<TAcc>
                 {
                     using Idx = alpaka::idx::Idx<TAcc>;
 
                     alpaka::ignore_unused(blockSharedMemDyn);
                     alpaka::ignore_unused(threadElemExtent);
+                    alpaka::ignore_unused(success);
                     return
                         static_cast<idx::Idx<TAcc>>(sizeof(Idx)) * blockThreadExtent.prod();
                 }

--- a/test/unit/block/sync/src/BlockSyncPredicate.cpp
+++ b/test/unit/block/sync/src/BlockSyncPredicate.cpp
@@ -31,7 +31,6 @@
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -51,7 +50,8 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
         using Idx = alpaka::idx::Idx<TAcc>;
@@ -68,48 +68,48 @@ public:
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D / modulus));
-            BOOST_VERIFY(expectedResult == result);
+            ALPAKA_CHECK(*success, expectedResult == result);
         }
         {
             Idx const modulus(3u);
             int const predicate(static_cast<int>(blockThreadIdx1D % modulus));
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::Count>(acc, predicate));
             auto const expectedResult(static_cast<int>(blockThreadExtent1D - ((blockThreadExtent1D + modulus - static_cast<Idx>(1u)) / modulus)));
-            BOOST_VERIFY(expectedResult == result);
+            ALPAKA_CHECK(*success, expectedResult == result);
         }
 
         // syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>
         {
             int const predicate(1);
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
-            BOOST_VERIFY(result == 1);
+            ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
-            BOOST_VERIFY(result == 0);
+            ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(blockThreadIdx1D != 0);
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalAnd>(acc, predicate));
-            BOOST_VERIFY(result == 0);
+            ALPAKA_CHECK(*success, result == 0);
         }
 
         // syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>
         {
             int const predicate(1);
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
-            BOOST_VERIFY(result == 1);
+            ALPAKA_CHECK(*success, result == 1);
         }
         {
             int const predicate(0);
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
-            BOOST_VERIFY(result == 0);
+            ALPAKA_CHECK(*success, result == 0);
         }
         {
             int const predicate(static_cast<int>(blockThreadIdx1D != 1));
             auto const result(alpaka::block::sync::syncBlockThreadsPredicate<alpaka::block::sync::op::LogicalOr>(acc, predicate));
-            BOOST_VERIFY(result == 1);
+            ALPAKA_CHECK(*success, result == 1);
         }
     }
 };

--- a/test/unit/kernel/src/KernelWithAdditionalParam.cpp
+++ b/test/unit/kernel/src/KernelWithAdditionalParam.cpp
@@ -54,14 +54,13 @@ public:
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
         TAcc const & acc,
+        bool * success,
         std::int32_t const & val) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        alpaka::ignore_unused(acc);
 
-        (void)val;
-        BOOST_VERIFY(42 == val);
+        ALPAKA_CHECK(*success, 42 == val);
     }
 };
 

--- a/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
+++ b/test/unit/kernel/src/KernelWithConstructorAndMember.cpp
@@ -59,13 +59,13 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        alpaka::ignore_unused(acc);
 
-        BOOST_VERIFY(42 == m_val);
+        ALPAKA_CHECK(*success, 42 == m_val);
     }
 
 private:

--- a/test/unit/kernel/src/KernelWithHostConstexpr.cpp
+++ b/test/unit/kernel/src/KernelWithHostConstexpr.cpp
@@ -57,21 +57,22 @@ public:
     ALPAKA_NO_HOST_ACC_WARNING
     template<typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool* success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
-        
-        constexpr double epsilon = std::numeric_limits< double >::epsilon();
-        this->ignoreUnused(epsilon);
+        alpaka::ignore_unused(acc);
+
+#if BOOST_COMP_MSVC
+    #pragma warning(push)
+    #pragma warning(disable: 4127)  // warning C4127: conditional expression is constant
+#endif
+        constexpr auto max = std::numeric_limits< std::uint32_t >::max();
+        ALPAKA_CHECK(*success, 0 != max);
+#if BOOST_COMP_MSVC
+    #pragma warning(pop)
+#endif
     }
-private:
-    //! ignore unused variables
-    template<typename T>
-    ALPAKA_FN_ACC auto ignoreUnused(T const &) const
-    -> void
-    {}
 };
 
 //-----------------------------------------------------------------------------

--- a/test/unit/kernel/src/KernelWithTemplate.cpp
+++ b/test/unit/kernel/src/KernelWithTemplate.cpp
@@ -56,13 +56,17 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<TAcc>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
-        BOOST_VERIFY((std::is_same<std::int32_t, T>::value));
+        static_assert(
+            std::is_same<std::int32_t, T>::value,
+            "Incorrect additional kernel template parameter type!");
     }
 };
 
@@ -97,13 +101,17 @@ public:
         typename T>
     ALPAKA_FN_ACC auto operator()(
         TAcc const & acc,
+        bool * success,
         T const &) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<TAcc>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
 
-        BOOST_VERIFY((std::is_same<std::int32_t, T>::value));
+        static_assert(
+            std::is_same<std::int32_t, T>::value,
+            "Incorrect additional kernel template parameter type!");
     }
 };
 

--- a/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
+++ b/test/unit/kernel/src/KernelWithoutTemplatedAccParam.cpp
@@ -66,11 +66,13 @@ struct KernelNoTemplateCpu
     //-----------------------------------------------------------------------------
     ALPAKA_FN_ACC
     auto operator()(
-        AccCpu const & acc) const
+        AccCpu const & acc,
+        bool* success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<AccCpu>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
     }
 };
 
@@ -97,11 +99,13 @@ struct KernelNoTemplateGpu
     //-----------------------------------------------------------------------------
     ALPAKA_FN_ACC
     auto operator()(
-        AccGpu const & acc) const
+        AccGpu const & acc,
+        bool* success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<AccGpu>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
     }
 };
 
@@ -129,11 +133,13 @@ struct KernelWithoutTemplateParamCpu
         typename TNotUsed = void>
     ALPAKA_FN_ACC
     auto operator()(
-        AccCpu const & acc) const
+        AccCpu const & acc,
+        bool* success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<AccCpu>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
     }
 };
 
@@ -161,11 +167,13 @@ struct KernelWithoutTemplateParamGpu
         typename TNotUsed = void>
     ALPAKA_FN_ACC
     auto operator()(
-        AccGpu const & acc) const
+        AccGpu const & acc,
+        bool* success) const
     -> void
     {
-        // Do something useless on the accelerator.
-        alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Blocks>(acc);
+        ALPAKA_CHECK(
+            *success,
+            static_cast<alpaka::idx::Idx<AccGpu>>(1) == (alpaka::workdiv::getWorkDiv<alpaka::Grid, alpaka::Threads>(acc)).prod());
     }
 };
 

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -92,7 +92,6 @@ static auto testP2P(
     Dev const dev0(alpaka::pltf::getDevByIdx<Pltf>(0u));
     Dev const dev1(alpaka::pltf::getDevByIdx<Pltf>(1u));
     Queue queue0(dev0);
-    Queue queue1(dev1);
 
     //-----------------------------------------------------------------------------
     auto buf0(alpaka::mem::buf::alloc<Elem, Idx>(dev0, extent));
@@ -105,10 +104,7 @@ static auto testP2P(
     //-----------------------------------------------------------------------------
     alpaka::mem::view::copy(queue0, buf1, buf0, extent);
     alpaka::wait::wait(queue0);
-    alpaka::test::mem::view::verifyBytesSet<TAcc>(queue1, buf1, byte);
-
-    // This should be removed when verifyBytesSet uses boost test macros internally.
-    BOOST_CHECK(true);
+    alpaka::test::mem::view::verifyBytesSet<TAcc>(buf1, byte);
 }
 
 //-----------------------------------------------------------------------------

--- a/test/unit/mem/view/CMakeLists.txt
+++ b/test/unit/mem/view/CMakeLists.txt
@@ -24,7 +24,7 @@ append_recursive_files_add_to_src_group("src/" "src/" "cpp" _FILES_SOURCE)
 
 # FIXME: The appveyor CI builds crash with out of memory when building this file.
 IF(ALPAKA_CI MATCHES "APPVEYOR")
-    SET_SOURCE_FILES_PROPERTIES("${_SOURCE_DIR}/ViewSubViewTest.cpp" PROPERTIES HEADER_FILE_ONLY TRUE)
+    SET_SOURCE_FILES_PROPERTIES("src/ViewSubVieTest.cpp" PROPERTIES HEADER_FILE_ONLY TRUE)
 ENDIF()
 
 ALPAKA_ADD_EXECUTABLE(

--- a/test/unit/mem/view/src/ViewStaticAccMem.cpp
+++ b/test/unit/mem/view/src/ViewStaticAccMem.cpp
@@ -65,7 +65,7 @@ ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DInitialized[3][2] =
 ALPAKA_STATIC_ACC_MEM_CONSTANT Elem g_constantMemory2DUninitialized[3][2];
 
 //#############################################################################
-//! Uses static device memory on the defined globally for the whole compilation unit.
+//! Uses static device memory on the accelerator defined globally for the whole compilation unit.
 struct StaticDeviceMemoryTestKernel
 {
     ALPAKA_NO_HOST_ACC_WARNING
@@ -74,6 +74,7 @@ struct StaticDeviceMemoryTestKernel
         typename TElem>
     ALPAKA_FN_ACC void operator()(
         TAcc const & acc,
+        bool * success,
         TElem const * const pConstantMem) const
     {
         auto const gridThreadExtent =
@@ -84,7 +85,7 @@ struct StaticDeviceMemoryTestKernel
         auto const offset = gridThreadExtent[1u] * gridThreadIdx[0u] + gridThreadIdx[1u];
         auto const val = offset;
 
-        BOOST_VERIFY(val == *(pConstantMem + offset));
+        ALPAKA_CHECK(*success, val == *(pConstantMem + offset));
     }
 };
 

--- a/test/unit/time/src/ClockTest.cpp
+++ b/test/unit/time/src/ClockTest.cpp
@@ -31,7 +31,6 @@
 #include <alpaka/test/acc/Acc.hpp>
 #include <alpaka/test/KernelExecutionFixture.hpp>
 
-#include <boost/assert.hpp>
 #include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
@@ -51,20 +50,21 @@ public:
     template<
         typename TAcc>
     ALPAKA_FN_ACC auto operator()(
-        TAcc const & acc) const
+        TAcc const & acc,
+        bool * success) const
     -> void
     {
         std::uint64_t const start(
             alpaka::time::clock(acc));
-        BOOST_VERIFY(0u != start);
+        ALPAKA_CHECK(*success, 0u != start);
 
         std::uint64_t const end(
             alpaka::time::clock(acc));
-        BOOST_VERIFY(0u != end);
+        ALPAKA_CHECK(*success, 0u != end);
 
         // 'end' has to be greater equal 'start'.
         // CUDA clock will never be equal for two calls, but the clock implementations for CPUs can be.
-        BOOST_VERIFY(end >= start);
+        ALPAKA_CHECK(*success, end >= start);
     }
 };
 


### PR DESCRIPTION
Fixes #617

[edit by @psychocoder]
This PR also added 
  - an overview of the free memory of travis test instance
  - a new unit test to test generic lamdas