### PR TITLE
Fix empty(QueueCpuAsync) returning true even though the last task is still executing

### DIFF
--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -391,7 +391,7 @@ namespace alpaka
 #endif
                 {
                     auto boundTask([=](){return task(args...);});
-                    auto decrementNumActiveTasks = [this](){--m_numActiveTasks;};
+                    auto decrementNumActiveTasks([this](){--m_numActiveTasks;});
 
                     auto extendedTask(
                         [boundTask, decrementNumActiveTasks]()
@@ -599,7 +599,7 @@ namespace alpaka
 #endif
                 {
                     auto boundTask([=](){return task(args...);});
-                    auto decrementNumActiveTasks = [this](){--m_numActiveTasks;};
+                    auto decrementNumActiveTasks([this](){--m_numActiveTasks;});
 
                     auto extendedTask(
                         [boundTask, decrementNumActiveTasks]()

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -150,6 +150,13 @@ namespace alpaka
 #endif
 
             //#############################################################################
+            template<
+                template<typename TFnObjReturn> class TPromise,
+                typename TFnObj,
+                typename TFnObjReturn = decltype(std::declval<TFnObj>()())>
+            class TaskPkg;
+
+            //#############################################################################
             //! TaskPkg with return type.
             //!
             //! \tparam TPromise The promise type returned by the task.
@@ -352,11 +359,7 @@ namespace alpaka
 #else
                     auto boundTask([=](){return task(args...);});
 #endif
-
-                    // Return type of the function object, can be void via specialization of TaskPkg.
-                    using FnObjReturn = decltype(task(args...));
-                    using TaskPackage = TaskPkg<TPromise, decltype(boundTask), FnObjReturn>;
-
+                    using TaskPackage = TaskPkg<TPromise, decltype(boundTask)>;
                     auto pTaskPackage(new TaskPackage(std::move(boundTask)));
                     std::shared_ptr<ITaskPkg> upTaskPackage(pTaskPackage);
 
@@ -553,11 +556,7 @@ namespace alpaka
 #else
                     auto boundTask([=](){return task(args...);});
 #endif
-
-                    // Return type of the function object, can be void via specialization of TaskPkg.
-                    using FnObjReturn = decltype(task(args...));
-                    using TaskPackage = TaskPkg<TPromise, decltype(boundTask), FnObjReturn>;
-
+                    using TaskPackage = TaskPkg<TPromise, decltype(boundTask)>;
                     auto pTaskPackage(new TaskPackage(std::move(boundTask)));
                     std::shared_ptr<ITaskPkg> upTaskPackage(pTaskPackage);
 

--- a/include/alpaka/core/ConcurrentExecPool.hpp
+++ b/include/alpaka/core/ConcurrentExecPool.hpp
@@ -350,7 +350,7 @@ namespace alpaka
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0))
                     auto boundTask(std::bind(task, args...));
 #else
-                    auto boundTask([=](){task(args...);});
+                    auto boundTask([=](){return task(args...);});
 #endif
 
                     // Return type of the function object, can be void via specialization of TaskPkg.
@@ -551,7 +551,7 @@ namespace alpaka
 #if BOOST_COMP_GNUC && (BOOST_COMP_GNUC < BOOST_VERSION_NUMBER(5, 0, 0))
                     auto boundTask(std::bind(task, args...));
 #else
-                    auto boundTask([=](){task(args...);});
+                    auto boundTask([=](){return task(args...);});
 #endif
 
                     // Return type of the function object, can be void via specialization of TaskPkg.

--- a/include/alpaka/queue/QueueCpuAsync.hpp
+++ b/include/alpaka/queue/QueueCpuAsync.hpp
@@ -218,7 +218,7 @@ namespace alpaka
                     queue::QueueCpuAsync const & queue)
                 -> bool
                 {
-                    return queue.m_spQueueImpl->m_workerThread.isQueueEmpty();
+                    return queue.m_spQueueImpl->m_workerThread.isIdle();
                 }
             };
         }

--- a/include/alpaka/queue/QueueCpuSync.hpp
+++ b/include/alpaka/queue/QueueCpuSync.hpp
@@ -53,7 +53,8 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     ALPAKA_FN_HOST QueueCpuSyncImpl(
                         dev::DevCpu const & dev) :
-                            m_dev(dev)
+                            m_dev(dev),
+                            m_bCurrentlyExecutingTask(false)
                     {}
                     //-----------------------------------------------------------------------------
                     QueueCpuSyncImpl(QueueCpuSyncImpl const &) = delete;
@@ -68,6 +69,7 @@ namespace alpaka
 
                 public:
                     dev::DevCpu const m_dev;            //!< The device this queue is bound to.
+                    bool m_bCurrentlyExecutingTask;
                 };
             }
         }
@@ -171,8 +173,9 @@ namespace alpaka
                     TTask const & task)
                 -> void
                 {
-                    alpaka::ignore_unused(queue);
+                    queue.m_spQueueImpl->m_bCurrentlyExecutingTask = true;
                     task();
+                    queue.m_spQueueImpl->m_bCurrentlyExecutingTask = false;
                 }
             };
             //#############################################################################
@@ -186,8 +189,7 @@ namespace alpaka
                     queue::QueueCpuSync const & queue)
                 -> bool
                 {
-                    alpaka::ignore_unused(queue);
-                    return true;
+                    return !queue.m_spQueueImpl->m_bCurrentlyExecutingTask;
                 }
             };
         }

--- a/include/alpaka/queue/QueueCudaRtSync.hpp
+++ b/include/alpaka/queue/QueueCudaRtSync.hpp
@@ -213,24 +213,45 @@ namespace alpaka
                 TTask>
             {
                 //#############################################################################
-                struct CallbackSynchronizationData
+                enum class CallbackState
+                {
+                    enqueued,
+                    notified,
+                    finished,
+                };
+
+                //#############################################################################
+                struct CallbackSynchronizationData : public std::enable_shared_from_this<CallbackSynchronizationData>
                 {
                     std::mutex m_mutex;
                     std::condition_variable m_event;
-                    bool notified = false;
+                    CallbackState state = CallbackState::enqueued;
                 };
 
                 //-----------------------------------------------------------------------------
                 static void CUDART_CB cudaRtCallback(cudaStream_t /*queue*/, cudaError_t /*status*/, void *arg)
                 {
-                    auto& callbackSynchronizationData = *reinterpret_cast<CallbackSynchronizationData*>(arg);
+                    // explicitly copy the shared_ptr so that this method holds the state even when the executing thread has already finished.
+                    const auto pCallbackSynchronizationData = reinterpret_cast<CallbackSynchronizationData*>(arg)->shared_from_this();
 
+                    // Notify the executing thread.
                     {
-                        std::unique_lock<std::mutex> lock(callbackSynchronizationData.m_mutex);
-                        callbackSynchronizationData.notified = true;
+                        std::unique_lock<std::mutex> lock(pCallbackSynchronizationData->m_mutex);
+                        pCallbackSynchronizationData->state = CallbackState::notified;
                     }
+                    pCallbackSynchronizationData->m_event.notify_one();
 
-                    callbackSynchronizationData.m_event.notify_one();
+                    // Wait for the executing thread to finish the task if it has not already finished.
+                    std::unique_lock<std::mutex> lock(pCallbackSynchronizationData->m_mutex);
+                    if(pCallbackSynchronizationData->state != CallbackState::finished)
+                    {
+                        pCallbackSynchronizationData->m_event.wait(
+                            lock,
+                            [pCallbackSynchronizationData](){
+                                return pCallbackSynchronizationData->state == CallbackState::finished;
+                            }
+                        );
+                    }
                 }
 
                 //-----------------------------------------------------------------------------
@@ -247,19 +268,37 @@ namespace alpaka
                         pCallbackSynchronizationData.get(),
                         0u));
 
-                    // If the callback has not yet been called, we wait for it.
-                    std::unique_lock<std::mutex> lock(pCallbackSynchronizationData->m_mutex);
-                    if(!pCallbackSynchronizationData->notified)
-                    {
-                        pCallbackSynchronizationData->m_event.wait(
-                            lock,
-                            [pCallbackSynchronizationData](){
-                                return pCallbackSynchronizationData->notified;
-                            }
-                        );
-                    }
+                    // We start a new std::thread which stores the task to be executed.
+                    // This circumvents the limitation that it is not possible to call CUDA methods within the CUDA callback thread.
+                    // The CUDA thread signals the std::thread when it is ready to execute the task.
+                    // The CUDA thread is waiting for the std::thread to signal that it is finished executing the task
+                    // before it executes the next task in the queue (CUDA stream).
+                    std::thread t(
+                        [pCallbackSynchronizationData, task](){
 
-                    task();
+                            // If the callback has not yet been called, we wait for it.
+                            {
+                                std::unique_lock<std::mutex> lock(pCallbackSynchronizationData->m_mutex);
+                                if(pCallbackSynchronizationData->state != CallbackState::notified)
+                                {
+                                    pCallbackSynchronizationData->m_event.wait(
+                                        lock,
+                                        [pCallbackSynchronizationData](){
+                                            return pCallbackSynchronizationData->state == CallbackState::notified;
+                                        }
+                                    );
+                                }
+
+                                task();
+
+                                // Notify the waiting CUDA thread.
+                                pCallbackSynchronizationData->state = CallbackState::finished;
+                            }
+                            pCallbackSynchronizationData->m_event.notify_one();
+                        }
+                    );
+
+                    t.join();
                 }
             };
             //#############################################################################

--- a/include/alpaka/queue/QueueCudaRtSync.hpp
+++ b/include/alpaka/queue/QueueCudaRtSync.hpp
@@ -43,6 +43,7 @@
 #include <functional>
 #include <mutex>
 #include <condition_variable>
+#include <thread>
 
 namespace alpaka
 {

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e2));
 
             // re-enqueue should be possible
-            // q1 = [k1, k2, e1]
+            // q1 = [k1, e1-old, k2, e1]
             alpaka::queue::enqueue(q1, e1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));

--- a/test/unit/event/src/EventTest.cpp
+++ b/test/unit/event/src/EventTest.cpp
@@ -76,16 +76,16 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     Fixture f1;
     if(alpaka::test::event::isEventHostManualTriggerSupported(f1.m_dev))
     {
-        auto s1 = f1.m_queue;
+        auto q1 = f1.m_queue;
         alpaka::event::Event<Queue> e1(f1.m_dev);
         alpaka::test::event::EventHostManualTrigger<Dev> k1(f1.m_dev);
 
         if(!alpaka::test::queue::IsSyncQueue<Queue>::value)
         {
-            alpaka::queue::enqueue(s1, k1);
+            alpaka::queue::enqueue(q1, k1);
         }
 
-        alpaka::queue::enqueue(s1, e1);
+        alpaka::queue::enqueue(q1, e1);
 
         if(!alpaka::test::queue::IsSyncQueue<Queue>::value)
         {
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
             k1.trigger();
 
-            alpaka::wait::wait(s1);
+            alpaka::wait::wait(q1);
         }
 
         BOOST_REQUIRE_EQUAL(
@@ -123,40 +123,40 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         Fixture f1;
         if(alpaka::test::event::isEventHostManualTriggerSupported(f1.m_dev))
         {
-            auto s1 = f1.m_queue;
+            auto q1 = f1.m_queue;
             alpaka::event::Event<Queue> e1(f1.m_dev);
             alpaka::test::event::EventHostManualTrigger<Dev> k1(f1.m_dev);
             alpaka::test::event::EventHostManualTrigger<Dev> k2(f1.m_dev);
 
-            // s1 = [k1]
-            alpaka::queue::enqueue(s1, k1);
+            // q1 = [k1]
+            alpaka::queue::enqueue(q1, k1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
 
-            // s1 = [k1, e1]
-            alpaka::queue::enqueue(s1, e1);
+            // q1 = [k1, e1]
+            alpaka::queue::enqueue(q1, e1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
 
-            // s1 = [k1, e1, k2]
-            alpaka::queue::enqueue(s1, k2);
+            // q1 = [k1, e1, k2]
+            alpaka::queue::enqueue(q1, k2);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
 
             // re-enqueue should be possible
-            // s1 = [k1, k2, e1]
-            alpaka::queue::enqueue(s1, e1);
+            // q1 = [k1, k2, e1]
+            alpaka::queue::enqueue(q1, e1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
 
-            // s1 = [k2, e1]
+            // q1 = [k2, e1]
             k1.trigger();
             BOOST_REQUIRE_EQUAL(true, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
 
-            // s1 = [e1]
+            // q1 = [e1]
             k2.trigger();
             BOOST_REQUIRE_EQUAL(true, alpaka::event::test(k2));
             alpaka::wait::wait(e1);
@@ -186,52 +186,52 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         if(alpaka::test::event::isEventHostManualTriggerSupported(f1.m_dev)
             && alpaka::test::event::isEventHostManualTriggerSupported(f2.m_dev))
         {
-            auto s1 = f1.m_queue;
-            auto s2 = f2.m_queue;
+            auto q1 = f1.m_queue;
+            auto q2 = f2.m_queue;
             alpaka::event::Event<Queue> e1(f1.m_dev);
             alpaka::event::Event<Queue> e2(f2.m_dev);
             alpaka::test::event::EventHostManualTrigger<Dev> k1(f1.m_dev);
             alpaka::test::event::EventHostManualTrigger<Dev> k2(f1.m_dev);
 
-            // s1 = [k1]
-            alpaka::queue::enqueue(s1, k1);
+            // q1 = [k1]
+            alpaka::queue::enqueue(q1, k1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
 
-            // s1 = [k1, e1]
-            alpaka::queue::enqueue(s1, e1);
+            // q1 = [k1, e1]
+            alpaka::queue::enqueue(q1, e1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
 
-            // s1 = [k1, e1, k2]
-            alpaka::queue::enqueue(s1, k2);
+            // q1 = [k1, e1, k2]
+            alpaka::queue::enqueue(q1, k2);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
 
             // wait for e1
-            // s2 = [->e1]
-            alpaka::wait::wait(s2, e1);
+            // q2 = [->e1]
+            alpaka::wait::wait(q2, e1);
 
-            // s2 = [->e1, e2]
-            alpaka::queue::enqueue(s2, e2);
+            // q2 = [->e1, e2]
+            alpaka::queue::enqueue(q2, e2);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e2));
 
             // re-enqueue should be possible
-            // s1 = [k1, k2, e1]
-            alpaka::queue::enqueue(s1, e1);
+            // q1 = [k1, k2, e1]
+            alpaka::queue::enqueue(q1, e1);
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e2));
 
-            // s1 = [k2, e1]
+            // q1 = [k2, e1]
             k1.trigger();
             BOOST_REQUIRE_EQUAL(true, alpaka::event::test(k1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(k2));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e1));
             BOOST_REQUIRE_EQUAL(false, alpaka::event::test(e2));
 
-            // s1 = [e1]
+            // q1 = [e1]
             k2.trigger();
             BOOST_REQUIRE_EQUAL(true, alpaka::event::test(k2));
             alpaka::wait::wait(e1);
@@ -264,51 +264,51 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         if(alpaka::test::event::isEventHostManualTriggerSupported(f1.m_dev)
             && alpaka::test::event::isEventHostManualTriggerSupported(f2.m_dev))
         {
-            auto s1 = f1.m_queue;
-            auto s2 = f2.m_queue;
+            auto q1 = f1.m_queue;
+            auto q2 = f2.m_queue;
             alpaka::test::event::EventHostManualTrigger<Dev> k1(f1.m_dev);
             alpaka::test::event::EventHostManualTrigger<Dev> k2(f2.m_dev);
             alpaka::event::Event<Queue> e1(f1.m_dev);
 
-            // 1. kernel k1 is enqueued into queue s1
-            // s1 = [k1]
-            alpaka::queue::enqueue(s1, k1);
-            // 2. kernel k2 is enqueued into queue s2
-            // s2 = [k2]
-            alpaka::queue::enqueue(s2, k2);
+            // 1. kernel k1 is enqueued into queue q1
+            // q1 = [k1]
+            alpaka::queue::enqueue(q1, k1);
+            // 2. kernel k2 is enqueued into queue q2
+            // q2 = [k2]
+            alpaka::queue::enqueue(q2, k2);
 
-            // 3. event e1 is enqueued into queue s1
-            // s1 = [k1, e1]
-            alpaka::queue::enqueue(s1, e1);
+            // 3. event e1 is enqueued into queue q1
+            // q1 = [k1, e1]
+            alpaka::queue::enqueue(q1, e1);
 
-            // 4. s2 waits for e1
-            // s2 = [k2, ->e1]
-            alpaka::wait::wait(s2, e1);
+            // 4. q2 waits for e1
+            // q2 = [k2, ->e1]
+            alpaka::wait::wait(q2, e1);
 
             // 5. kernel k1 finishes
-            // s1 = [e1]
+            // q1 = [e1]
             k1.trigger();
 
             // 6. e1 is finished
-            // s1 = []
+            // q1 = []
             alpaka::wait::wait(e1);
             BOOST_REQUIRE_EQUAL(true, alpaka::event::test(e1));
 
-            // 7. e1 is re-enqueued again but this time into s2
-            // s2 = [k2, ->e1, e1]
-            alpaka::queue::enqueue(s2, e1);
+            // 7. e1 is re-enqueued again but this time into q2
+            // q2 = [k2, ->e1, e1]
+            alpaka::queue::enqueue(q2, e1);
 
             // 8. kernel k2 finishes
-            // s2 = [->e1, e1]
+            // q2 = [->e1, e1]
             k2.trigger();
 
-            // 9. e1 had already been signaled so there should not be waited even though the event is now reused within s2 and its current state is 'unfinished' again.
-            // s2 = [e1]
+            // 9. e1 had already been signaled so there should not be waited even though the event is now reused within q2 and its current state is 'unfinished' again.
+            // q2 = [e1]
 
             // Both queues should successfully finish
-            alpaka::wait::wait(s1);
-            // s2 = []
-            alpaka::wait::wait(s2);
+            alpaka::wait::wait(q1);
+            // q2 = []
+            alpaka::wait::wait(q2);
         }
         else
         {

--- a/test/unit/queue/src/QueueTest.cpp
+++ b/test/unit/queue/src/QueueTest.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     using Fixture = alpaka::test::queue::QueueTestFixture<TDevQueue>;
     Fixture f;
 
-    BOOST_REQUIRE_EQUAL(true, alpaka::queue::empty(f.m_queue));
+    BOOST_CHECK_EQUAL(true, alpaka::queue::empty(f.m_queue));
 }
 
 //-----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         }
     );
 
-    BOOST_REQUIRE_EQUAL(true, promise.get_future().get());
+    BOOST_CHECK_EQUAL(true, promise.get_future().get());
 #endif
 }
 
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         });
 
     alpaka::wait::wait(f.m_queue);
-    BOOST_REQUIRE_EQUAL(true, CallbackFinished);
+    BOOST_CHECK_EQUAL(true, CallbackFinished);
 }
 
 //-----------------------------------------------------------------------------
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         f.m_queue,
         [&f, &CallbackFinished]() noexcept
         {
-            BOOST_REQUIRE_EQUAL(false, alpaka::queue::empty(f.m_queue));
+            BOOST_CHECK_EQUAL(false, alpaka::queue::empty(f.m_queue));
             std::this_thread::sleep_for(std::chrono::milliseconds(100u));
             CallbackFinished = true;
         });
@@ -130,8 +130,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         alpaka::wait::wait(f.m_queue);
     }
 
-    BOOST_REQUIRE_EQUAL(true, alpaka::queue::empty(f.m_queue));
-    BOOST_REQUIRE_EQUAL(true, CallbackFinished);
+    BOOST_CHECK_EQUAL(true, alpaka::queue::empty(f.m_queue));
+    BOOST_CHECK_EQUAL(true, CallbackFinished);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes #621

By the way the test found that this did not work for `QueueCpuSync` and `QueueCudaRtSync` as well (when the last task was a callback).