### PR TITLE
Add a check for OpenMP version

### DIFF
--- a/alpakaConfig.cmake
+++ b/alpakaConfig.cmake
@@ -315,6 +315,12 @@ IF(ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLE OR ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE OR A
         SET(ALPAKA_ACC_CPU_BT_OMP4_ENABLE OFF CACHE BOOL "Enable the OpenMP 4.0 CPU block and thread back-end" FORCE)
 
     ELSE()
+
+        # Check whether OpenMP 4 is supported
+        IF(OpenMP_CXX_VERSION VERSION_LESS 4.0)
+            SET(ALPAKA_ACC_CPU_BT_OMP4_ENABLE OFF CACHE BOOL "Enable the OpenMP 4.0 CPU block and thread back-end" FORCE)
+        ENDIF()
+
         # CUDA requires some special handling
         IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
             SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")


### PR DESCRIPTION
Fixes #628. For my system (Win 10, VS 2017) with default options it disables the OpenMP 4 accelerator which has been a problem originally.
[Original cmake output](https://github.com/ComputationalRadiationPhysics/alpaka/files/2349459/output_original.txt), and here is [output after fix](https://github.com/ComputationalRadiationPhysics/alpaka/files/2349460/output_new.txt) ( `ALPAKA_ACC_CPU_BT_OMP4_ENABLED `is no longer set).
