### PR TITLE
Added prepareForAsyncCopy trait and specialization for cpu and cuda memory

### DIFF
--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -599,6 +599,8 @@ namespace alpaka
                         // for exclusive cpu use, no preparing is needed
 #if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
                         pin( buf );
+#else
+                        alpaka::ignore_unused( buf );
 #endif
                     }
                 };

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2018 Benjamin Worpitz, Alexander Matthes
 *
 * This file is part of alpaka.
 *
@@ -577,6 +577,28 @@ namespace alpaka
 #else
                         alpaka::ignore_unused(bufImpl);
                         return false;
+#endif
+                    }
+                };
+                //#############################################################################
+                //! The BufCpu memory prepareForAsyncCopy trait specialization.
+                template<
+                    typename TElem,
+                    typename TDim,
+                    typename TIdx>
+                struct PrepareForAsyncCopy<
+                    mem::buf::BufCpu<TElem, TDim, TIdx>>
+                {
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_HOST static auto prepareForAsyncCopy(
+                        mem::buf::BufCpu<TElem, TDim, TIdx> & buf)
+                    -> void
+                    {
+                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+                        // for use with cuda the cpu buffer has to be pinned,
+                        // for exclusive cpu use, no preparing is needed
+#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED) && BOOST_LANG_CUDA
+                        pin( buf );
 #endif
                     }
                 };

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2018 Benjamin Worpitz, Alexander Matthes
 *
 * This file is part of alpaka.
 *
@@ -596,6 +596,25 @@ namespace alpaka
 
                         // CUDA device memory is always pinned, it can not be swapped out.
                         return true;
+                    }
+                };
+                //#############################################################################
+                //! The BufCudaRt memory prepareForAsyncCopy trait specialization.
+                template<
+                    typename TElem,
+                    typename TDim,
+                    typename TIdx>
+                struct PrepareForAsyncCopy<
+                    mem::buf::BufCudaRt<TElem, TDim, TIdx>>
+                {
+                    //-----------------------------------------------------------------------------
+                    ALPAKA_FN_HOST static auto prepareForAsyncCopy(
+                        mem::buf::BufCudaRt<TElem, TDim, TIdx> &)
+                    -> void
+                    {
+                        ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
+
+                        // CUDA device memory is always ready for async copy
                     }
                 };
             }

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -97,6 +97,13 @@ namespace alpaka
                     typename TBuf,
                     typename TSfinae = void>
                 struct IsPinned;
+
+                //#############################################################################
+                //! The memory prepareForAsyncCopy trait.
+                template<
+                    typename TBuf,
+                    typename TSfinae = void>
+                struct PrepareForAsyncCopy;
             }
 
             //#############################################################################
@@ -242,6 +249,24 @@ namespace alpaka
                     traits::IsPinned<
                         TBuf>
                     ::isPinned(
+                        buf);
+            }
+            //-----------------------------------------------------------------------------
+            //! Prepares the buffer for async copy operations, e.g. pinning if
+            //! async copy between a cpu and a cuda device is wanted
+            //!
+            //! \tparam TBuf The buffer type.
+            //! \param buf The buffer to prepare in the device memory.
+            template<
+                typename TBuf>
+            ALPAKA_FN_HOST auto prepareForAsyncCopy(
+                TBuf & buf)
+            -> void
+            {
+                return
+                    traits::PrepareForAsyncCopy<
+                        TBuf>
+                    ::prepareForAsyncCopy(
                         buf);
             }
         }

--- a/include/alpaka/mem/buf/Traits.hpp
+++ b/include/alpaka/mem/buf/Traits.hpp
@@ -1,6 +1,6 @@
 /**
 * \file
-* Copyright 2014-2015 Benjamin Worpitz
+* Copyright 2014-2018 Benjamin Worpitz, Alexander Matthes
 *
 * This file is part of alpaka.
 *


### PR DESCRIPTION
See https://github.com/ComputationalRadiationPhysics/alpaka/issues/620 for more informations about the "why?".