### PR TITLE
Fix tests using std::int16_t overflowing

### DIFF
--- a/test/unit/mem/buf/src/BufTest.cpp
+++ b/test/unit/mem/buf/src/BufTest.cpp
@@ -63,7 +63,7 @@ struct CreateExtentBufVal
         TIdx)
     -> TIdx
     {
-        return sizeof(TIdx) * (5u - Tidx);
+        return static_cast<TIdx>(5u - Tidx);
     }
 };
 

--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -65,7 +65,7 @@ struct CreateExtentBufVal
         TIdx)
     -> TIdx
     {
-        return sizeof(TIdx) * (5u - Tidx);
+        return static_cast<TIdx>(5u - Tidx);
     }
 };
 

--- a/test/unit/mem/view/src/ViewSubViewTest.cpp
+++ b/test/unit/mem/view/src/ViewSubViewTest.cpp
@@ -80,7 +80,7 @@ namespace view
             TIdx)
         -> TIdx
         {
-            return sizeof(TIdx) * (5u - Tidx);
+            return static_cast<TIdx>(5u - Tidx);
         }
     };
 
@@ -100,7 +100,7 @@ namespace view
             TIdx)
         -> TIdx
         {
-            return sizeof(TIdx) * (4u - Tidx);
+            return static_cast<TIdx>(4u - Tidx);
         }
     };
 
@@ -242,7 +242,7 @@ namespace view
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         auto const extentView(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentViewVal>(Idx()));
-        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(sizeof(Idx)));
+        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(1)));
         View view(buf, extentView, offsetView);
 
         alpaka::test::mem::view::testViewSubViewMutable<TAcc>(view, buf, dev, extentView, offsetView);
@@ -268,7 +268,7 @@ namespace view
         auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
 
         auto const extentView(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, CreateExtentViewVal>(Idx()));
-        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(sizeof(Idx)));
+        auto const offsetView(alpaka::vec::Vec<Dim, Idx>::all(static_cast<Idx>(1)));
         View const view(buf, extentView, offsetView);
 
         alpaka::test::mem::view::testViewSubViewImmutable<TAcc>(view, buf, dev, extentView, offsetView);


### PR DESCRIPTION
Fixes #644

This does not fail on CPU backends because there we do not add additional stride.