### PR TITLE
CUDA: Math & Public Headers

### DIFF
--- a/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
+++ b/include/alpaka/math/abs/AbsCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/abs/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
+++ b/include/alpaka/math/acos/AcosCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/acos/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
+++ b/include/alpaka/math/asin/AsinCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/asin/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
+++ b/include/alpaka/math/atan/AtanCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/atan/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
+++ b/include/alpaka/math/atan2/Atan2CudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/atan2/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
+++ b/include/alpaka/math/ceil/CeilCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/ceil/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/cos/CosCudaBuiltIn.hpp
+++ b/include/alpaka/math/cos/CosCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/cos/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
+++ b/include/alpaka/math/erf/ErfCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/erf/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
+++ b/include/alpaka/math/exp/ExpCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/exp/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
+++ b/include/alpaka/math/floor/FloorCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/floor/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
+++ b/include/alpaka/math/fmod/FmodCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/fmod/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/log/LogCudaBuiltIn.hpp
+++ b/include/alpaka/math/log/LogCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/log/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/max/MaxCudaBuiltIn.hpp
+++ b/include/alpaka/math/max/MaxCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/max/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/min/Traits.hpp>
 
+#include <cuda_runtime.h>
+
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
 #include <algorithm>
 
 namespace alpaka

--- a/include/alpaka/math/pow/PowCudaBuiltIn.hpp
+++ b/include/alpaka/math/pow/PowCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/pow/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
+++ b/include/alpaka/math/remainder/RemainderCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/remainder/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/round/RoundCudaBuiltIn.hpp
+++ b/include/alpaka/math/round/RoundCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/round/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/rsqrt/RsqrtCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/rsqrt/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/sin/SinCudaBuiltIn.hpp
+++ b/include/alpaka/math/sin/SinCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/sin/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
+++ b/include/alpaka/math/sqrt/SqrtCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/sqrt/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/tan/TanCudaBuiltIn.hpp
+++ b/include/alpaka/math/tan/TanCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/tan/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {

--- a/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
+++ b/include/alpaka/math/trunc/TruncCudaBuiltIn.hpp
@@ -32,12 +32,9 @@
 
 #include <alpaka/math/trunc/Traits.hpp>
 
+#include <cuda_runtime.h>
 #include <type_traits>
-#if BOOST_LANG_CUDA >= BOOST_VERSION_NUMBER(9, 0, 0)
-    #include <crt/math_functions.hpp>
-#else
-    #include <math_functions.hpp>
-#endif
+
 
 namespace alpaka
 {


### PR DESCRIPTION
Regression to previous fixes to CUDA headers #455.
The math functions of the CUDA API should be taken from the public "facade" header `<cuda_runtime.h>`

Fix #647