### PR TITLE
Initialize result vector (vectorAdd). cout -> cerr.

### DIFF
--- a/example/reduce/src/reduce.cpp
+++ b/example/reduce/src/reduce.cpp
@@ -165,7 +165,7 @@ int main()
     T expectedResult = static_cast<T>(n / 2 * (n + 1));
     if (result != expectedResult)
     {
-        std::cout << "Results don't match: " << result << " != " << expectedResult
+        std::cerr << "Results don't match: " << result << " != " << expectedResult
                   << "\n";
         return EXIT_FAILURE;
     }

--- a/example/vectorAdd/src/main.cpp
+++ b/example/vectorAdd/src/main.cpp
@@ -127,8 +127,8 @@ auto main()
     BufHost bufHostC(alpaka::mem::buf::alloc<Data, Idx>(devHost, extent));
 
     // Initialize the host input vectors A and B
-    Data * const pBufHostA = alpaka::mem::view::getPtrNative(bufHostA);
-    Data * const pBufHostB = alpaka::mem::view::getPtrNative(bufHostB);
+    Data * const pBufHostA(alpaka::mem::view::getPtrNative(bufHostA));
+    Data * const pBufHostB(alpaka::mem::view::getPtrNative(bufHostB));
     Data * const pBufHostC(alpaka::mem::view::getPtrNative(bufHostC));
 
     // C++11 random generator for uniformly distributed numbers in {1,..,42}
@@ -140,6 +140,7 @@ auto main()
     {
         pBufHostA[i] = dist(eng);
         pBufHostB[i] = dist(eng);
+        pBufHostC[i] = 0;
     }
 
     // Allocate 3 buffers on the accelerator
@@ -151,6 +152,7 @@ auto main()
     // Copy Host -> Acc
     alpaka::mem::view::copy(queue, bufAccA, bufHostA, extent);
     alpaka::mem::view::copy(queue, bufAccB, bufHostB, extent);
+    alpaka::mem::view::copy(queue, bufAccC, bufHostC, extent);
 
     // Instantiate the kernel function object
     VectorAddKernel kernel;
@@ -179,7 +181,7 @@ auto main()
         Data const correctResult(pBufHostA[i] + pBufHostB[i]);
         if(val != correctResult)
         {
-            std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
+            std::cerr << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
             resultCorrect = false;
         }
     }

--- a/test/integ/axpy/src/main.cpp
+++ b/test/integ/axpy/src/main.cpp
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         auto const correctResult(alpha * pBufHostX[i] + pBufHostOrigY[i]);
         if( boost::math::relative_difference(val, correctResult) > std::numeric_limits<Val>::epsilon() )
         {
-            std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
+            std::cerr << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
             resultCorrect = false;
         }
     }

--- a/test/integ/mandelbrot/src/main.cpp
+++ b/test/integ/mandelbrot/src/main.cpp
@@ -338,7 +338,7 @@ using TestAccs = alpaka::test::acc::EnabledAccs<
     std::uint32_t>;
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(
-    calculateAxpy,
+    calculateMandelbrot,
     TAcc,
     TestAccs)
 {

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         auto const & val(pHostData[i]);
         if(val != correctResult)
         {
-            std::cout << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
+            std::cerr << "C[" << i << "] == " << val << " != " << correctResult << std::endl;
             resultCorrect = false;
         }
     }

--- a/test/integ/sharedMem/src/main.cpp
+++ b/test/integ/sharedMem/src/main.cpp
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         auto const val(blockRetVals[static_cast<std::size_t>(i)]);
         if(val != correctResult)
         {
-            std::cout << "blockRetVals[" << i << "] == " << val << " != " << correctResult << std::endl;
+            std::cerr << "blockRetVals[" << i << "] == " << val << " != " << correctResult << std::endl;
             resultCorrect = false;
         }
     }


### PR DESCRIPTION
- uses cerr instead of cout for results error in examples and tests
- ~~P2P test invokes BOOST_CHECK(true) as long as there was no error~~