### PR TITLE
Change ALPAKA_ADD_EXECUTABLE|LIBRARY to CMake macros.

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -22,7 +22,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 
 #------------------------------------------------------------------------------
 # Calls CUDA_ADD_EXECUTABLE or ADD_EXECUTABLE depending on the enabled alpaka accelerators.
-FUNCTION(ALPAKA_ADD_EXECUTABLE In_Name)
+# Using a macro to stay in the scope (fixes lost assignment of linker command in FindHIP.cmake)
+# https://github.com/ROCm-Developer-Tools/HIP/issues/631
+MACRO(ALPAKA_ADD_EXECUTABLE In_Name)
     IF(ALPAKA_ACC_GPU_CUDA_ENABLE)
         IF(ALPAKA_CUDA_COMPILER MATCHES "clang")
             FOREACH(_file ${ARGN})
@@ -53,4 +55,4 @@ FUNCTION(ALPAKA_ADD_EXECUTABLE In_Name)
             ${In_Name}
             ${ARGN})
     ENDIF()
-ENDFUNCTION()
+ENDMACRO()

--- a/cmake/addLibrary.cmake
+++ b/cmake/addLibrary.cmake
@@ -36,7 +36,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.7.0)
 # code filenames!
 # OPTIONS and the arguments thereafter are ignored if not using CUDA, they
 # won't throw an error in that case.
-FUNCTION(ALPAKA_ADD_LIBRARY libraryName)
+MACRO(ALPAKA_ADD_LIBRARY libraryName)
     # CUDA_ADD_LIBRARY( cuda_target file0 file1 ...
     #                   [STATIC | SHARED | MODULE]
     #                   [EXCLUDE_FROM_ALL] [OPTIONS <nvcc-flags> ... ] )
@@ -145,4 +145,4 @@ FUNCTION(ALPAKA_ADD_LIBRARY libraryName)
     UNSET( sourceFileNames )
     UNSET( excludeFromAll )
     UNSET( optionArguments )
-ENDFUNCTION()
+ENDMACRO()


### PR DESCRIPTION
This is a requirement for future HIP back-end, as long as there is no solution to an HIP issue, see [here](https://github.com/ROCm-Developer-Tools/HIP/issues/631#issuecomment-416243382).

However, maybe it is a better solution to use a macro anyways? 
A macro does not open an extra scope.