### PR TITLE
Replace assert with ALPAKA_ASSERT

### DIFF
--- a/example/bufferCopy/src/bufferCopy.cpp
+++ b/example/bufferCopy/src/bufferCopy.cpp
@@ -24,7 +24,6 @@
 
 #include <iostream>
 #include <cstdint>
-#include <cassert>
 
 //-----------------------------------------------------------------------------
 template <size_t width>
@@ -100,7 +99,7 @@ struct TestBufferKernel
 
         for(size_t i(linearizedGlobalThreadIdx[0]); i < extents.prod(); i += globalThreadExtent.prod())
         {
-            assert(data[linIdxToPitchedIdx<2>(i,pitch)] == i);
+            ALPAKA_ASSERT(data[linIdxToPitchedIdx<2>(i,pitch)] == i);
         }
     }
 };

--- a/include/alpaka/core/Assert.hpp
+++ b/include/alpaka/core/Assert.hpp
@@ -27,6 +27,8 @@
 #include <cassert>
 #include <type_traits>
 
+#define ALPAKA_ASSERT(EXPRESSION) assert(EXPRESSION)
+
 namespace alpaka
 {
     namespace core
@@ -53,7 +55,7 @@ namespace alpaka
 #ifdef NDEBUG
                     alpaka::ignore_unused(arg);
 #else
-                    assert(arg >= 0);
+                    ALPAKA_ASSERT(arg >= 0);
 #endif
                 }
             };
@@ -115,7 +117,7 @@ namespace alpaka
 #ifdef NDEBUG
                     alpaka::ignore_unused(lhs);
 #else
-                    assert(TLhs::value > lhs);
+                    ALPAKA_ASSERT(TLhs::value > lhs);
 #endif
                 }
             };

--- a/include/alpaka/event/EventCpu.hpp
+++ b/include/alpaka/event/EventCpu.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/dev/DevCpu.hpp>
 #include <alpaka/queue/QueueCpuAsync.hpp>
@@ -31,7 +32,6 @@
 #include <alpaka/wait/Traits.hpp>
 #include <alpaka/dev/Traits.hpp>
 
-#include <cassert>
 #include <mutex>
 #include <condition_variable>
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
@@ -79,7 +79,7 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     auto wait(std::size_t const & enqueueCount, std::unique_lock<std::mutex>& lk) noexcept -> void
                     {
-                        assert(enqueueCount <= m_enqueueCount);
+                        ALPAKA_ASSERT(enqueueCount <= m_enqueueCount);
 
                         while(enqueueCount > m_LastReadyEnqueueCount)
                         {

--- a/include/alpaka/idx/bt/IdxBtOmp.hpp
+++ b/include/alpaka/idx/bt/IdxBtOmp.hpp
@@ -26,13 +26,13 @@
 #include <alpaka/idx/Traits.hpp>
 #include <alpaka/workdiv/Traits.hpp>
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/idx/MapIdx.hpp>
 
 #include <omp.h>
 
-#include <cassert>
 
 namespace alpaka
 {
@@ -107,7 +107,7 @@ namespace alpaka
                 {
                     alpaka::ignore_unused(idx);
                     // We assume that the thread id is positive.
-                    assert(::omp_get_thread_num()>=0);
+                    ALPAKA_ASSERT(::omp_get_thread_num()>=0);
                     // \TODO: Would it be faster to precompute the index and cache it inside an array?
                     return idx::mapIdx<TDim::value>(
                         vec::Vec<dim::DimInt<1u>, TIdx>(static_cast<TIdx>(::omp_get_thread_num())),

--- a/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefFiberIdMap.hpp
@@ -25,13 +25,13 @@
 
 #include <alpaka/idx/Traits.hpp>
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Fibers.hpp>
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/vec/Vec.hpp>
 
 #include <map>
-#include <cassert>
 
 namespace alpaka
 {
@@ -115,7 +115,7 @@ namespace alpaka
                     alpaka::ignore_unused(workDiv);
                     auto const fiberId(boost::this_fiber::get_id());
                     auto const fiberEntry(idx.m_fibersToIndices.find(fiberId));
-                    assert(fiberEntry != idx.m_fibersToIndices.end());
+                    ALPAKA_ASSERT(fiberEntry != idx.m_fibersToIndices.end());
                     return fiberEntry->second;
                 }
             };

--- a/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
+++ b/include/alpaka/idx/bt/IdxBtRefThreadIdMap.hpp
@@ -25,13 +25,13 @@
 
 #include <alpaka/idx/Traits.hpp>
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Positioning.hpp>
 #include <alpaka/core/Unused.hpp>
 #include <alpaka/vec/Vec.hpp>
 
 #include <thread>
 #include <map>
-#include <cassert>
 
 namespace alpaka
 {
@@ -115,7 +115,7 @@ namespace alpaka
                     alpaka::ignore_unused(workDiv);
                     auto const threadId(std::this_thread::get_id());
                     auto const threadEntry(idx.m_threadToIndexMap.find(threadId));
-                    assert(threadEntry != idx.m_threadToIndexMap.end());
+                    ALPAKA_ASSERT(threadEntry != idx.m_threadToIndexMap.end());
                     return threadEntry->second;
                 }
             };

--- a/include/alpaka/mem/buf/BufCudaRt.hpp
+++ b/include/alpaka/mem/buf/BufCudaRt.hpp
@@ -29,16 +29,16 @@
     #error If ALPAKA_ACC_GPU_CUDA_ENABLED is set, the compiler has to support CUDA!
 #endif
 
+#include <alpaka/core/Assert.hpp>
+#include <alpaka/core/Cuda.hpp>
 #include <alpaka/dev/DevCudaRt.hpp>
 #include <alpaka/vec/Vec.hpp>
-#include <alpaka/core/Cuda.hpp>
 
 #include <alpaka/dev/Traits.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/mem/buf/Traits.hpp>
 
 #include <memory>
-#include <cassert>
 
 namespace alpaka
 {
@@ -412,7 +412,7 @@ namespace alpaka
                                 &pitchBytes,
                                 static_cast<std::size_t>(widthBytes),
                                 static_cast<std::size_t>(height)));
-                        assert(pitchBytes >= static_cast<std::size_t>(widthBytes) || (width * height) == 0);
+                        ALPAKA_ASSERT(pitchBytes >= static_cast<std::size_t>(widthBytes) || (width * height) == 0);
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
                         std::cout << BOOST_CURRENT_FUNCTION

--- a/include/alpaka/mem/buf/cpu/Copy.hpp
+++ b/include/alpaka/mem/buf/cpu/Copy.hpp
@@ -21,13 +21,13 @@
 
 #pragma once
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/extent/Traits.hpp>
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/Integral.hpp>
 
-#include <cassert>
 #include <cstring>
 
 namespace alpaka
@@ -106,10 +106,10 @@ namespace alpaka
                                 m_dstMemNative(reinterpret_cast<std::uint8_t *>(mem::view::getPtrNative(viewDst))),
                                 m_srcMemNative(reinterpret_cast<std::uint8_t const *>(mem::view::getPtrNative(viewSrc)))
                         {
-                            assert((vec::cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                            assert((vec::cast<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
-                            assert(static_cast<DstSize>(m_extentWidthBytes) <= m_dstPitchBytes[TDim::value - 1u]);
-                            assert(static_cast<SrcSize>(m_extentWidthBytes) <= m_srcPitchBytes[TDim::value - 1u]);
+                            ALPAKA_ASSERT((vec::cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                            ALPAKA_ASSERT((vec::cast<SrcSize>(m_extent) <= m_srcExtent).foldrAll(std::logical_or<bool>()));
+                            ALPAKA_ASSERT(static_cast<DstSize>(m_extentWidthBytes) <= m_dstPitchBytes[TDim::value - 1u]);
+                            ALPAKA_ASSERT(static_cast<SrcSize>(m_extentWidthBytes) <= m_srcPitchBytes[TDim::value - 1u]);
                         }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/mem/buf/cpu/Set.hpp
+++ b/include/alpaka/mem/buf/cpu/Set.hpp
@@ -21,13 +21,13 @@
 
 #pragma once
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/dim/DimIntegralConst.hpp>
 #include <alpaka/extent/Traits.hpp>
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/meta/NdLoop.hpp>
 #include <alpaka/meta/Integral.hpp>
 
-#include <cassert>
 #include <cstring>
 
 namespace alpaka
@@ -89,8 +89,8 @@ namespace alpaka
                                 m_dstPitchBytes(mem::view::getPitchBytesVec(view)),
                                 m_dstMemNative(reinterpret_cast<std::uint8_t *>(mem::view::getPtrNative(view)))
                         {
-                            assert((vec::cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
-                            assert(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
+                            ALPAKA_ASSERT((vec::cast<DstSize>(m_extent) <= m_dstExtent).foldrAll(std::logical_or<bool>()));
+                            ALPAKA_ASSERT(m_extentWidthBytes <= m_dstPitchBytes[TDim::value - 1u]);
                         }
 
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL

--- a/include/alpaka/mem/buf/cuda/Copy.hpp
+++ b/include/alpaka/mem/buf/cuda/Copy.hpp
@@ -40,12 +40,12 @@
 #include <alpaka/queue/QueueCudaRtAsync.hpp>
 #include <alpaka/queue/QueueCudaRtSync.hpp>
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Cuda.hpp>
 
 #include <set>
 #include <tuple>
 
-#include <cassert>
 
 namespace alpaka
 {
@@ -116,8 +116,8 @@ namespace alpaka
                                 m_srcMemNative(reinterpret_cast<void const *>(mem::view::getPtrNative(viewSrc)))
                         {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                            assert(m_extentWidth <= m_dstWidth);
-                            assert(m_extentWidth <= m_srcWidth);
+                            ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                            ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
 #endif
                         }
 
@@ -210,12 +210,12 @@ namespace alpaka
                                 m_srcMemNative(reinterpret_cast<void const *>(mem::view::getPtrNative(viewSrc)))
                         {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                            assert(m_extentWidth <= m_dstWidth);
-                            assert(m_extentHeight <= m_dstHeight);
-                            assert(m_extentWidth <= m_srcWidth);
-                            assert(m_extentHeight <= m_srcHeight);
-                            assert(m_extentWidthBytes <= m_dstpitchBytesX);
-                            assert(m_extentWidthBytes <= m_srcpitchBytesX);
+                            ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                            ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
+                            ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+                            ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
+                            ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
+                            ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
 #endif
                         }
 
@@ -331,14 +331,14 @@ namespace alpaka
                                 m_srcMemNative(reinterpret_cast<void const *>(mem::view::getPtrNative(viewSrc)))
                         {
 #if ALPAKA_DEBUG >= ALPAKA_DEBUG_FULL
-                            assert(m_extentWidth <= m_dstWidth);
-                            assert(m_extentHeight <= m_dstHeight);
-                            assert(m_extentDepth <= m_dstDepth);
-                            assert(m_extentWidth <= m_srcWidth);
-                            assert(m_extentHeight <= m_srcHeight);
-                            assert(m_extentDepth <= m_srcDepth);
-                            assert(m_extentWidthBytes <= m_dstpitchBytesX);
-                            assert(m_extentWidthBytes <= m_srcpitchBytesX);
+                            ALPAKA_ASSERT(m_extentWidth <= m_dstWidth);
+                            ALPAKA_ASSERT(m_extentHeight <= m_dstHeight);
+                            ALPAKA_ASSERT(m_extentDepth <= m_dstDepth);
+                            ALPAKA_ASSERT(m_extentWidth <= m_srcWidth);
+                            ALPAKA_ASSERT(m_extentHeight <= m_srcHeight);
+                            ALPAKA_ASSERT(m_extentDepth <= m_srcDepth);
+                            ALPAKA_ASSERT(m_extentWidthBytes <= m_dstpitchBytesX);
+                            ALPAKA_ASSERT(m_extentWidthBytes <= m_srcpitchBytesX);
 #endif
                         }
 
@@ -403,7 +403,7 @@ namespace alpaka
                         const int & devDst)
                     -> void
                     {
-                        assert(devSrc != devDst);
+                        ALPAKA_ASSERT(devSrc != devDst);
 
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push

--- a/include/alpaka/mem/buf/cuda/Set.hpp
+++ b/include/alpaka/mem/buf/cuda/Set.hpp
@@ -38,9 +38,9 @@
 #include <alpaka/mem/view/Traits.hpp>
 #include <alpaka/queue/Traits.hpp>
 
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Cuda.hpp>
 
-#include <cassert>
 
 namespace alpaka
 {
@@ -177,7 +177,7 @@ namespace alpaka
                     auto const dstWidth(extent::getWidth(view));
 #endif
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
 
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
@@ -235,7 +235,7 @@ namespace alpaka
                     auto const dstWidth(extent::getWidth(view));
 #endif
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
 
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
@@ -296,8 +296,8 @@ namespace alpaka
 #endif
                     auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
-                    assert(extentHeight <= dstHeight);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentHeight <= dstHeight);
 
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
@@ -361,8 +361,8 @@ namespace alpaka
 #endif
                     auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
-                    assert(extentHeight <= dstHeight);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentHeight <= dstHeight);
 
                     // Set the current device.
                     ALPAKA_CUDA_RT_CHECK(
@@ -429,9 +429,9 @@ namespace alpaka
                     auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
                     auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(view));
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
-                    assert(extentHeight <= dstHeight);
-                    assert(extentDepth <= dstDepth);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentHeight <= dstHeight);
+                    ALPAKA_ASSERT(extentDepth <= dstDepth);
 
                     // Fill CUDA parameter structures.
                     cudaPitchedPtr const cudaPitchedPtrVal(
@@ -510,9 +510,9 @@ namespace alpaka
                     auto const dstPitchBytesX(mem::view::getPitchBytes<dim::Dim<TView>::value - 1u>(view));
                     auto const dstPitchBytesY(mem::view::getPitchBytes<dim::Dim<TView>::value - (2u % dim::Dim<TView>::value)>(view));
                     auto const dstNativePtr(reinterpret_cast<void *>(mem::view::getPtrNative(view)));
-                    assert(extentWidth <= dstWidth);
-                    assert(extentHeight <= dstHeight);
-                    assert(extentDepth <= dstDepth);
+                    ALPAKA_ASSERT(extentWidth <= dstWidth);
+                    ALPAKA_ASSERT(extentHeight <= dstHeight);
+                    ALPAKA_ASSERT(extentDepth <= dstDepth);
 
                     // Fill CUDA parameter structures.
                     cudaPitchedPtr const cudaPitchedPtrVal(

--- a/include/alpaka/mem/view/ViewSubView.hpp
+++ b/include/alpaka/mem/view/ViewSubView.hpp
@@ -30,10 +30,11 @@
 
 #include <alpaka/mem/view/ViewPlainPtr.hpp>
 #include <alpaka/vec/Vec.hpp>
+
+#include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Common.hpp>
 
 #include <type_traits>
-#include <cassert>
 
 namespace alpaka
 {
@@ -101,7 +102,7 @@ namespace alpaka
                         std::is_same<TDim, dim::Dim<TOffsets>>::value,
                         "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                    assert(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
+                    ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
                 }
                 //-----------------------------------------------------------------------------
                 //! Constructor.
@@ -150,7 +151,7 @@ namespace alpaka
                         std::is_same<TDim, dim::Dim<TOffsets>>::value,
                         "The dim type of TOffsets and the TDim template parameter have to be identical!");
 
-                    assert(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
+                    ALPAKA_ASSERT(((m_offsetsElements + m_extentElements) <= extent::getExtentVec(view)).foldrAll(std::logical_and<bool>()));
                 }
 
                 //-----------------------------------------------------------------------------

--- a/include/alpaka/workdiv/WorkDivHelpers.hpp
+++ b/include/alpaka/workdiv/WorkDivHelpers.hpp
@@ -31,7 +31,6 @@
 #include <alpaka/core/Assert.hpp>
 #include <alpaka/core/Common.hpp>
 
-#include <cassert>
 #include <cmath>
 #include <algorithm>
 #include <functional>
@@ -73,7 +72,7 @@ namespace alpaka
 
                 core::assertValueUnsigned(dividend);
                 core::assertValueUnsigned(maxDivisor);
-                assert(dividend <= maxDivisor);
+                ALPAKA_ASSERT(dividend <= maxDivisor);
 
                 while((dividend%divisor) != 0)
                 {
@@ -98,7 +97,7 @@ namespace alpaka
 
                 core::assertValueUnsigned(val);
                 core::assertValueUnsigned(maxDivisor);
-                assert(maxDivisor <= val);
+                ALPAKA_ASSERT(maxDivisor <= val);
 
                 for(T i(1); i <= std::min(val, maxDivisor); ++i)
                 {
@@ -184,12 +183,12 @@ namespace alpaka
             // Check that the input data is valid.
             for(typename TDim::value_type i(0); i<TDim::value; ++i)
             {
-                assert(gridElemExtent[i] >= 1);
-                assert(threadElemExtent[i] >= 1);
-                assert(threadElemExtent[i] <= accDevProps.m_threadElemExtentMax[i]);
+                ALPAKA_ASSERT(gridElemExtent[i] >= 1);
+                ALPAKA_ASSERT(threadElemExtent[i] >= 1);
+                ALPAKA_ASSERT(threadElemExtent[i] <= accDevProps.m_threadElemExtentMax[i]);
             }
-            assert(threadElemExtent.prod() <= accDevProps.m_threadElemCountMax);
-            assert(isValidAccDevProps(accDevProps));
+            ALPAKA_ASSERT(threadElemExtent.prod() <= accDevProps.m_threadElemCountMax);
+            ALPAKA_ASSERT(isValidAccDevProps(accDevProps));
 
             ///////////////////////////////////////////////////////////////////
             // Handle the given threadElemExtent. After this only the blockThreadExtent has to be optimized.

--- a/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
+++ b/test/common/include/alpaka/test/event/EventHostManualTrigger.hpp
@@ -304,7 +304,7 @@ namespace alpaka
                     std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
                     // The event should not yet be enqueued.
-                    assert(spEventImpl->m_bIsReady);
+                    ALPAKA_ASSERT(spEventImpl->m_bIsReady);
 
                     // Set its state to enqueued.
                     spEventImpl->m_bIsReady = false;
@@ -356,7 +356,7 @@ namespace alpaka
                     std::unique_lock<std::mutex> lk(spEventImpl->m_mutex);
 
                     // The event should not yet be enqueued.
-                    assert(spEventImpl->m_bIsReady);
+                    ALPAKA_ASSERT(spEventImpl->m_bIsReady);
 
                     // Set its state to enqueued.
                     spEventImpl->m_bIsReady = false;
@@ -631,7 +631,7 @@ namespace alpaka
                     std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
                     // The event should not yet be enqueued.
-                    assert(spEventImpl->m_bIsReady);
+                    ALPAKA_ASSERT(spEventImpl->m_bIsReady);
 
                     // Set its state to enqueued.
                     spEventImpl->m_bIsReady = false;
@@ -671,7 +671,7 @@ namespace alpaka
                     std::lock_guard<std::mutex> lk(spEventImpl->m_mutex);
 
                     // The event should not yet be enqueued.
-                    assert(spEventImpl->m_bIsReady);
+                    ALPAKA_ASSERT(spEventImpl->m_bIsReady);
 
                     // Set its state to enqueued.
                     spEventImpl->m_bIsReady = false;

--- a/test/integ/mandelbrot/src/main.cpp
+++ b/test/integ/mandelbrot/src/main.cpp
@@ -46,7 +46,6 @@
 
 #include <iostream>
 #include <typeinfo>
-#include <cassert>
 #include <fstream>
 #include <algorithm>
 
@@ -273,14 +272,14 @@ auto writeTgaColorImage(
     auto const bufWidthElems(alpaka::extent::getWidth(bufRgba));
     auto const bufWidthBytes(bufWidthElems * sizeof(alpaka::elem::Elem<TBuf>));
     // The row width in bytes has to be dividable by 4 Bytes (RGBA).
-    assert(bufWidthBytes % sizeof(std::uint32_t) == 0);
+    ALPAKA_ASSERT(bufWidthBytes % sizeof(std::uint32_t) == 0);
     // The number of colors in a row.
     auto const bufWidthColors(bufWidthBytes / sizeof(std::uint32_t));
-    assert(bufWidthColors >= 1);
+    ALPAKA_ASSERT(bufWidthColors >= 1);
     auto const bufHeightColors(alpaka::extent::getHeight(bufRgba));
-    assert(bufHeightColors >= 1);
+    ALPAKA_ASSERT(bufHeightColors >= 1);
     auto const bufPitchBytes(alpaka::mem::view::getPitchBytes<alpaka::dim::Dim<TBuf>::value - 1u>(bufRgba));
-    assert(bufPitchBytes >= bufWidthBytes);
+    ALPAKA_ASSERT(bufPitchBytes >= bufWidthBytes);
 
     std::ofstream ofs(
         fileName,

--- a/test/integ/matMul/src/main.cpp
+++ b/test/integ/matMul/src/main.cpp
@@ -106,7 +106,7 @@ public:
         auto const blockThreadExtent(alpaka::workdiv::getWorkDiv<alpaka::Block, alpaka::Threads>(acc));
         auto const & blockThreadExtentX(blockThreadExtent[1u]);
         auto const & blockThreadExtentY(blockThreadExtent[0u]);
-        //assert(blockThreadExtentX == blockThreadExtentY);
+        //ALPAKA_ASSERT(blockThreadExtentX == blockThreadExtentY);
         auto const & blockThreadExtentVal(blockThreadExtentX);
 
         // Shared memory used to store the current blocks of A and B.


### PR DESCRIPTION
- these changes came from HIP(HCC) testing branch
- there, an error occurred, when `__assert_fail` does not have the
right host-device signature, which is included with cassert
- in general, we rely on `core/Assert.hpp` anyways
- there, specific assert handling can be done safely for e.g. HIP,
and does not get interfered afterwards by a cassert

Edit after first review process:
**Replaces assert() with ALPAKA_ASSERT().**

- use ALPAKA_ASSERT() macro instead of assert()
- now, specific assert handling can be done in core/Assert.hpp
- it is disallowed to include cassert somewhere else,
because it can interfere the specified behavior
- at the moment this is only required by the future HIP(HCC) back-end