### PR TITLE
Adds missing ALPAKA_NO_HOST_ACC_WARNING to DevCpu

### DIFF
--- a/include/alpaka/dev/DevCpu.hpp
+++ b/include/alpaka/dev/DevCpu.hpp
@@ -168,12 +168,16 @@ namespace alpaka
             {}
         public:
             //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
             DevCpu(DevCpu const &) = default;
             //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
             DevCpu(DevCpu &&) = default;
             //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
             auto operator=(DevCpu const &) -> DevCpu & = default;
             //-----------------------------------------------------------------------------
+            ALPAKA_NO_HOST_ACC_WARNING
             auto operator=(DevCpu &&) -> DevCpu & = default;
             //-----------------------------------------------------------------------------
             ALPAKA_FN_HOST auto operator==(DevCpu const &) const


### PR DESCRIPTION
There were still several CUDA warnings like:
```
/alpaka/include/alpaka/block/shared/st/Traits.hpp(162): warning: calling a __host__ function("std::__shared_count<( ::__gnu_cxx::_Lock_policy)2> ::__shared_count") from a __host__ __device__ function("alpaka::dev::DevCpu::DevCpu") is not allowed
```

This PR fixes DevCpu by adding `ALPAKA_NO_HOST_ACC_WARNING` to the used constructors to silent the annoying warnings completely.

Relates to #505, where I first tried to fix the mentioned files instead of DevCpu directly.