### PR TITLE
Remove explicit queue deregistration from device because this could throw in destructors

### DIFF
--- a/include/alpaka/queue/QueueCpuAsync.hpp
+++ b/include/alpaka/queue/QueueCpuAsync.hpp
@@ -82,10 +82,8 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     auto operator=(QueueCpuAsyncImpl &&) -> QueueCpuAsyncImpl & = default;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST ~QueueCpuAsyncImpl() noexcept(false)
-                    {
-                        m_dev.m_spDevCpuImpl->UnregisterAsyncQueue(this);
-                    }
+                    ~QueueCpuAsyncImpl() = default;
+
                 public:
                     dev::DevCpu const m_dev;            //!< The device this queue is bound to.
 


### PR DESCRIPTION
Fixes #659

I am thinking about removing the support for waiting for a complete device completely (`alpaka::wait::wait(dev);`). It is broken and not tested and there is no easy way to fix.
The current implementation requires all CPU queues to register themselves in the CPU device which breaks the abstraction. Furhermore the waiting is implemented by waiting for each queue sequentially. So the result is not really a wait for the complete device.
Is anybody using this feature and what is the use-case for this?