### PR TITLE
Allow to run OpenMP 2 block backend within parallel region

### DIFF
--- a/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Blocks.hpp
@@ -148,56 +148,72 @@ namespace alpaka
                     throw std::runtime_error("Only one thread per block allowed in the OpenMP 2.0 block accelerator!");
                 }
 
-                // Force the environment to use the given number of threads.
-                int const ompIsDynamic(::omp_get_dynamic());
-                ::omp_set_dynamic(0);
-
-                // Execute the blocks in parallel.
-                // NOTE: Setting num_threads(number_of_cores) instead of the default thread number does not improve performance.
-                #pragma omp parallel
+                if(::omp_in_parallel() != 0)
                 {
-#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
-                    // The first thread does some debug logging.
-                    if(::omp_get_thread_num() == 0)
-                    {
-                        int const numThreads(::omp_get_num_threads());
-                        std::cout << BOOST_CURRENT_FUNCTION << " omp_get_num_threads: " << numThreads << std::endl;
-                    }
-#endif
-                    acc::AccCpuOmp2Blocks<TDim, TIdx> acc(
-                        *static_cast<workdiv::WorkDivMembers<TDim, TIdx> const *>(this),
-                        blockSharedMemDynSizeBytes);
-
-                    // NOTE: schedule(static) does not improve performance.
-#if _OPENMP < 200805    // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop header.
-                    std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numBlocksInGrid));
-                    std::intmax_t i;
-                    #pragma omp for nowait schedule(guided)
-                    for(i = 0; i < iNumBlocksInGrid; ++i)
-#else
-                    #pragma omp for nowait schedule(guided)
-                    for(TIdx i = 0; i < numBlocksInGrid; ++i)
-#endif
-                    {
-                        acc.m_gridBlockIdx =
-                            idx::mapIdx<TDim::value>(
-#if _OPENMP < 200805
-                                vec::Vec<dim::DimInt<1u>, TIdx>(static_cast<TIdx>(i)),
-#else
-                                vec::Vec<dim::DimInt<1u>, TIdx>(i),
-#endif
-                                gridBlockExtent);
-
-                        boundKernelFnObj(
-                            acc);
-
-                        // After a block has been processed, the shared memory has to be deleted.
-                        block::shared::st::freeMem(acc);
-                    }
+                    parallelFn(
+                        boundKernelFnObj,
+                        blockSharedMemDynSizeBytes,
+                        numBlocksInGrid,
+                        gridBlockExtent);
                 }
+                else
+                {
+                    #pragma omp parallel
+                    parallelFn(
+                        boundKernelFnObj,
+                        blockSharedMemDynSizeBytes,
+                        numBlocksInGrid,
+                        gridBlockExtent);
+                }
+            }
 
-                // Reset the dynamic thread number setting.
-                ::omp_set_dynamic(ompIsDynamic);
+            template<
+                typename FnObj>
+            ALPAKA_FN_HOST auto parallelFn(
+                FnObj const & boundKernelFnObj,
+                TIdx const & blockSharedMemDynSizeBytes,
+                TIdx const & numBlocksInGrid,
+                vec::Vec<TDim, TIdx> const & gridBlockExtent) const
+            -> void
+            {
+#if ALPAKA_DEBUG >= ALPAKA_DEBUG_MINIMAL
+                // The first thread does some debug logging.
+                if(::omp_get_thread_num() == 0)
+                {
+                    int const numThreads(::omp_get_num_threads());
+                    std::cout << BOOST_CURRENT_FUNCTION << " omp_get_num_threads: " << numThreads << std::endl;
+                }
+#endif
+                acc::AccCpuOmp2Blocks<TDim, TIdx> acc(
+                    *static_cast<workdiv::WorkDivMembers<TDim, TIdx> const *>(this),
+                    blockSharedMemDynSizeBytes);
+
+                // NOTE: schedule(static) does not improve performance.
+#if _OPENMP < 200805    // For OpenMP < 3.0 you have to declare the loop index (a signed integer) outside of the loop header.
+                std::intmax_t iNumBlocksInGrid(static_cast<std::intmax_t>(numBlocksInGrid));
+                std::intmax_t i;
+                #pragma omp for nowait schedule(guided)
+                for(i = 0; i < iNumBlocksInGrid; ++i)
+#else
+                #pragma omp for nowait schedule(guided)
+                for(TIdx i = 0; i < numBlocksInGrid; ++i)
+#endif
+                {
+                    acc.m_gridBlockIdx =
+                        idx::mapIdx<TDim::value>(
+#if _OPENMP < 200805
+                            vec::Vec<dim::DimInt<1u>, TIdx>(static_cast<TIdx>(i)),
+#else
+                            vec::Vec<dim::DimInt<1u>, TIdx>(i),
+#endif
+                            gridBlockExtent);
+
+                    boundKernelFnObj(
+                        acc);
+
+                    // After a block has been processed, the shared memory has to be deleted.
+                    block::shared::st::freeMem(acc);
+                }
             }
 
             TKernelFnObj m_kernelFnObj;

--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -148,6 +148,12 @@ namespace alpaka
                 TIdx const blockThreadCount(blockThreadExtent.prod());
                 int const iBlockThreadCount(static_cast<int>(blockThreadCount));
                 alpaka::ignore_unused(iBlockThreadCount);
+
+                if(::omp_in_parallel() != 0)
+                {
+                    throw std::runtime_error("The OpenMP 2.0 thread backend can not be used within an existing parallel region!");
+                }
+
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());
                 ::omp_set_dynamic(0);

--- a/include/alpaka/exec/ExecCpuOmp4.hpp
+++ b/include/alpaka/exec/ExecCpuOmp4.hpp
@@ -150,6 +150,11 @@ namespace alpaka
                 auto const maxTeamCount(maxOmpThreadCount/static_cast<int>(blockThreadCount));
                 auto const teamCount(std::min(maxTeamCount, static_cast<int>(gridBlockCount)));
 
+                if(::omp_in_parallel() != 0)
+                {
+                    throw std::runtime_error("The OpenMP 4.0 backend can not be used within an existing parallel region!");
+                }
+
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());
                 ::omp_set_dynamic(0);


### PR DESCRIPTION
Proposal for #651

This does not change anything for the standard case (except one extra function call per thread).

I do not yet have a full understanding of the requirements. How is the kernel enqued? Is the enqueue already in a parallel region (are there multiple enqueues)? Is it in a single-threaded region? Should we add some single-threaded regions for the setup before the parallel part?