### PR TITLE
Mem Tests: Boost Predef

### DIFF
--- a/test/unit/mem/p2p/src/P2P.cpp
+++ b/test/unit/mem/p2p/src/P2P.cpp
@@ -32,7 +32,7 @@
 #include <alpaka/test/queue/Queue.hpp>
 #include <alpaka/test/mem/view/ViewTest.hpp>
 
-#include <boost/predef.h>
+#include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wunused-parameter"

--- a/test/unit/mem/p2p/src/main.cpp
+++ b/test/unit/mem/p2p/src/main.cpp
@@ -21,7 +21,7 @@
 
 #define BOOST_TEST_MODULE memP2P
 
-#include <boost/predef.h>
+#include <alpaka/core/BoostPredef.hpp>
 #if BOOST_COMP_CLANG
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wunused-parameter"


### PR DESCRIPTION
Apply our boost predef work-around to two tests where it was missing.

Follow-up to #606