### PR TITLE
backport to 0.3.4 chunk 3

### DIFF
--- a/include/alpaka/exec/ExecCpuOmp2Threads.hpp
+++ b/include/alpaka/exec/ExecCpuOmp2Threads.hpp
@@ -151,6 +151,12 @@ namespace alpaka
                 TSize const blockThreadCount(blockThreadExtent.prod());
                 int const iBlockThreadCount(static_cast<int>(blockThreadCount));
                 boost::ignore_unused(iBlockThreadCount);
+
+                if(::omp_in_parallel() != 0)
+                {
+                    throw std::runtime_error("The OpenMP 2.0 thread backend can not be used within an existing parallel region!");
+                }
+
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());
                 ::omp_set_dynamic(0);

--- a/include/alpaka/exec/ExecCpuOmp4.hpp
+++ b/include/alpaka/exec/ExecCpuOmp4.hpp
@@ -151,6 +151,11 @@ namespace alpaka
                 auto const maxTeamCount(maxOmpThreadCount/static_cast<int>(blockThreadCount));
                 auto const teamCount(std::min(maxTeamCount, static_cast<int>(gridBlockCount)));
 
+                if(::omp_in_parallel() != 0)
+                {
+                    throw std::runtime_error("The OpenMP 4.0 backend can not be used within an existing parallel region!");
+                }
+
                 // Force the environment to use the given number of threads.
                 int const ompIsDynamic(::omp_get_dynamic());
                 ::omp_set_dynamic(0);

--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -89,7 +89,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_CUDA_ONLY static auto max(
+                ALPAKA_FN_ACC_CUDA_ONLY static auto min(
                     MinCudaBuiltIn const & /*min*/,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/min/MinStl.hpp
+++ b/include/alpaka/math/min/MinStl.hpp
@@ -81,7 +81,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_ACC_NO_CUDA static auto max(
+                ALPAKA_FN_HOST static auto min(
                     MinStl const & min,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/mem/buf/BufCpu.hpp
+++ b/include/alpaka/mem/buf/BufCpu.hpp
@@ -105,7 +105,7 @@ namespace alpaka
                         //-----------------------------------------------------------------------------
                         auto operator=(BufCpuImpl &&) -> BufCpuImpl & = default;
                         //-----------------------------------------------------------------------------
-                        ALPAKA_FN_HOST ~BufCpuImpl() noexcept(false)
+                        ALPAKA_FN_HOST ~BufCpuImpl()
                         {
                             ALPAKA_DEBUG_MINIMAL_LOG_SCOPE;
 

--- a/include/alpaka/stream/StreamCpuAsync.hpp
+++ b/include/alpaka/stream/StreamCpuAsync.hpp
@@ -82,10 +82,8 @@ namespace alpaka
                     //-----------------------------------------------------------------------------
                     auto operator=(StreamCpuAsyncImpl &&) -> StreamCpuAsyncImpl & = default;
                     //-----------------------------------------------------------------------------
-                    ALPAKA_FN_HOST ~StreamCpuAsyncImpl() noexcept(false)
-                    {
-                        m_dev.m_spDevCpuImpl->UnregisterAsyncStream(this);
-                    }
+                    ~StreamCpuAsyncImpl() = default;
+
                 public:
                     dev::DevCpu const m_dev;            //!< The device this stream is bound to.
 


### PR DESCRIPTION
containing backports:
- Remove explicit queue deregistration from device because this could throw in destructors #665
- Remove noexcept(false) from destructor #677
- Allow to run OpenMP 2 block backend within parallel region #666
- Fixed broken `alpaka::math::min` for non-integral types #681
- reduce the `acc` test to reduce compile time in CI: https://github.com/ComputationalRadiationPhysics/alpaka/commit/a00b128bb28f4ba92b51a50a2a836ae0768b9f81 https://github.com/ComputationalRadiationPhysics/alpaka/commit/dd5da1a3c61f307e439f193ea3d6bad52c8b1383