### PR TITLE
Allow to copy and move construct ViewPlainPtr

### DIFF
--- a/include/alpaka/mem/view/ViewPlainPtr.hpp
+++ b/include/alpaka/mem/view/ViewPlainPtr.hpp
@@ -82,13 +82,19 @@ namespace alpaka
                 {}
 
                 //-----------------------------------------------------------------------------
-                ViewPlainPtr(ViewPlainPtr const &) = delete;
+                ViewPlainPtr(ViewPlainPtr const &) = default;
                 //-----------------------------------------------------------------------------
-                ViewPlainPtr(ViewPlainPtr &&) = default;
+                ViewPlainPtr(ViewPlainPtr && other) :
+                        m_pMem(other.m_pMem),
+                        m_dev(other.m_dev),
+                        m_extentElements(other.m_extentElements),
+                        m_pitchBytes(other.m_pitchBytes)
+                {
+                }
                 //-----------------------------------------------------------------------------
                 auto operator=(ViewPlainPtr const &) -> ViewPlainPtr & = delete;
                 //-----------------------------------------------------------------------------
-                auto operator=(ViewPlainPtr &&) -> ViewPlainPtr & = default;
+                auto operator=(ViewPlainPtr &&) -> ViewPlainPtr & = delete;
                 //-----------------------------------------------------------------------------
                 ~ViewPlainPtr() = default;
 

--- a/test/unit/mem/view/src/ViewPlainPtrTest.cpp
+++ b/test/unit/mem/view/src/ViewPlainPtrTest.cpp
@@ -173,6 +173,38 @@ namespace view
 
         alpaka::test::mem::view::testViewPlainPtrImmutable<TAcc>(view, dev, extentView, offsetView);
     }
+
+    //-----------------------------------------------------------------------------
+    template<
+        typename TAcc,
+        typename TElem>
+    auto testViewPlainPtrOperators()
+    -> void
+    {
+        using Dev = alpaka::dev::Dev<TAcc>;
+        using Pltf = alpaka::pltf::Pltf<Dev>;
+
+        using Dim = alpaka::dim::Dim<TAcc>;
+        using Idx = alpaka::idx::Idx<TAcc>;
+        using View = alpaka::mem::view::ViewPlainPtr<Dev, TElem, Dim, Idx>;
+
+        Dev const dev(alpaka::pltf::getDevByIdx<Pltf>(0u));
+
+        auto const extentBuf(alpaka::vec::createVecFromIndexedFnWorkaround<Dim, Idx, alpaka::test::CreateExtentBufVal>(Idx()));
+        auto buf(alpaka::mem::buf::alloc<TElem, Idx>(dev, extentBuf));
+
+        View view(
+            alpaka::mem::view::getPtrNative(buf),
+            alpaka::dev::getDev(buf),
+            alpaka::extent::getExtentVec(buf),
+            alpaka::mem::view::getPitchBytesVec(buf));
+
+        // copy-constructor
+        View viewCopy(view);
+
+        // move-constructor
+        View viewMove(std::move(viewCopy));
+    }
 }
 }
 }
@@ -199,6 +231,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
     alpaka::test::acc::TestAccs)
 {
     alpaka::test::mem::view::testViewPlainPtrConst<TAcc, float>();
+}
+
+//-----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE_TEMPLATE(
+    viewPlainPtrOperatorTest,
+    TAcc,
+    alpaka::test::acc::TestAccs)
+{
+    alpaka::test::mem::view::testViewPlainPtrOperators<TAcc, float>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a part of #655. I will think about the assignment operators separately.


[edit from psychocoder]
PR adds a test for copy and move constructor