### PR TITLE
Fixed broken `alpaka::math::min` for non-integral types

### DIFF
--- a/include/alpaka/math/min/MinCudaBuiltIn.hpp
+++ b/include/alpaka/math/min/MinCudaBuiltIn.hpp
@@ -89,7 +89,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                __device__ static auto max(
+                __device__ static auto min(
                     MinCudaBuiltIn const & min,
                     Tx const & x,
                     Ty const & y)

--- a/include/alpaka/math/min/MinStdLib.hpp
+++ b/include/alpaka/math/min/MinStdLib.hpp
@@ -81,7 +81,7 @@ namespace alpaka
                     && !(std::is_integral<Tx>::value
                         && std::is_integral<Ty>::value)>::type>
             {
-                ALPAKA_FN_HOST static auto max(
+                ALPAKA_FN_HOST static auto min(
                     MinStdLib const & min,
                     Tx const & x,
                     Ty const & y)


### PR DESCRIPTION
See issue https://github.com/ComputationalRadiationPhysics/alpaka/issues/680.