### PR TITLE
Suppress warning in clang about exit time destructor

### DIFF
--- a/include/alpaka/atomic/AtomicStdLibLock.hpp
+++ b/include/alpaka/atomic/AtomicStdLibLock.hpp
@@ -23,6 +23,8 @@
 
 #include <alpaka/atomic/Traits.hpp>
 
+#include <alpaka/core/BoostPredef.hpp>
+
 #include <mutex>
 #include <array>
 
@@ -94,9 +96,16 @@ namespace alpaka
                 constexpr size_t hashTableSize = THashTableSize == 0u ? 1u : nextPowerOf2(THashTableSize);
 
                 size_t const hashedAddr = hash(ptr) & (hashTableSize - 1u);
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wexit-time-destructors"
+#endif
                 static std::array<
                     std::mutex,
                     hashTableSize> m_mtxAtomic; //!< The mutex protecting access for an atomic operation.
+#if BOOST_COMP_CLANG
+    #pragma clang diagnostic pop
+#endif
                 return m_mtxAtomic[hashedAddr];
             }
         };


### PR DESCRIPTION
Fix exit-time-destructor warning mentioned in #673.